### PR TITLE
Support for the java.sql "OTHER" type.

### DIFF
--- a/src/main/scala/org/scalaquery/session/PositionedParameters.scala
+++ b/src/main/scala/org/scalaquery/session/PositionedParameters.scala
@@ -23,6 +23,7 @@ class PositionedParameters(val ps: PreparedStatement) {
   def setString(value: String)       { val npos = pos + 1; ps.setString   (npos, value); pos = npos }
   def setTime(value: Time)           { val npos = pos + 1; ps.setTime     (npos, value); pos = npos }
   def setTimestamp(value: Timestamp) { val npos = pos + 1; ps.setTimestamp(npos, value); pos = npos }
+  def setOther(value: Any)           { val npos = pos + 1; ps.setObject   (npos, value, Types.OTHER); pos = npos }
 
   def setBooleanOption(value: Option[Boolean]) {
     val npos = pos + 1
@@ -92,6 +93,11 @@ class PositionedParameters(val ps: PreparedStatement) {
   def setTimestampOption(value: Option[Timestamp]) {
     val npos = pos + 1
     if(value eq None) ps.setNull(npos, Types.TIMESTAMP) else ps.setTimestamp(npos, value.get)
+    pos = npos
+  }
+  def setOtherOption(value: Option[Any]) {
+    val npos = pos + 1
+    if(value eq None) ps.setNull(npos, Types.OTHER) else ps.setObject(npos, value.get, Types.OTHER)
     pos = npos
   }
 }

--- a/src/main/scala/org/scalaquery/session/PositionedResult.scala
+++ b/src/main/scala/org/scalaquery/session/PositionedResult.scala
@@ -37,6 +37,7 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable {
   final def nextString()    = { val npos = pos + 1; val r = rs getString    npos; pos = npos; r }
   final def nextTime()      = { val npos = pos + 1; val r = rs getTime      npos; pos = npos; r }
   final def nextTimestamp() = { val npos = pos + 1; val r = rs getTimestamp npos; pos = npos; r }
+  final def nextOther()     = { val npos = pos + 1; val r = rs getObject    npos; pos = npos; r }
 
   final def nextBooleanOption()   = { val npos = pos + 1; val r = rs getBoolean   npos; val rr = (if(rs wasNull) None else Some(r)); pos = npos; rr }
   final def nextBlobOption()      = { val npos = pos + 1; val r = rs getBlob      npos; val rr = (if(rs wasNull) None else Some(r)); pos = npos; rr }
@@ -52,6 +53,7 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable {
   final def nextStringOption()    = { val npos = pos + 1; val r = rs getString    npos; val rr = (if(rs wasNull) None else Some(r)); pos = npos; rr }
   final def nextTimeOption()      = { val npos = pos + 1; val r = rs getTime      npos; val rr = (if(rs wasNull) None else Some(r)); pos = npos; rr }
   final def nextTimestampOption() = { val npos = pos + 1; val r = rs getTimestamp npos; val rr = (if(rs wasNull) None else Some(r)); pos = npos; rr }
+  final def nextOtherOption()     = { val npos = pos + 1; val r = rs getObject    npos; val rr = (if(rs wasNull) None else Some(r)); pos = npos; rr }
 
   final def updateBoolean(v: Boolean)     { val npos = pos + 1; rs.updateBoolean  (npos, v); pos = npos }
   final def updateBlob(v: Blob)           { val npos = pos + 1; rs.updateBlob     (npos, v); pos = npos }
@@ -67,6 +69,7 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable {
   final def updateString(v: String)       { val npos = pos + 1; rs.updateString   (npos, v); pos = npos }
   final def updateTime(v: Time)           { val npos = pos + 1; rs.updateTime     (npos, v); pos = npos }
   final def updateTimestamp(v: Timestamp) { val npos = pos + 1; rs.updateTimestamp(npos, v); pos = npos }
+  final def updateOther(v: Any)           { val npos = pos + 1; rs.updateObject   (npos, v); pos = npos }
 
   final def updateBooleanOption(v: Option[Boolean])     { val npos = pos + 1; v match { case Some(s) => rs.updateBoolean  (npos, s); case None => rs.updateNull(npos) }; pos = npos }
   final def updateBlobOption(v: Option[Blob])           { val npos = pos + 1; v match { case Some(s) => rs.updateBlob     (npos, s); case None => rs.updateNull(npos) }; pos = npos }
@@ -82,6 +85,7 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable {
   final def updateStringOption(v: Option[String])       { val npos = pos + 1; v match { case Some(s) => rs.updateString   (npos, s); case None => rs.updateNull(npos) }; pos = npos }
   final def updateTimeOption(v: Option[Time])           { val npos = pos + 1; v match { case Some(s) => rs.updateTime     (npos, s); case None => rs.updateNull(npos) }; pos = npos }
   final def updateTimestampOption(v: Option[Timestamp]) { val npos = pos + 1; v match { case Some(s) => rs.updateTimestamp(npos, s); case None => rs.updateNull(npos) }; pos = npos }
+  final def updateOtherOption(v: Option[Any])           { val npos = pos + 1; v match { case Some(s) => rs.updateObject   (npos, s); case None => rs.updateNull(npos) }; pos = npos }
 
   final def updateNull() { val npos = pos + 1; rs.updateNull(npos); pos = npos }
 

--- a/src/test/scala/org/scalaquery/test/UUIDTest.scala
+++ b/src/test/scala/org/scalaquery/test/UUIDTest.scala
@@ -1,0 +1,99 @@
+package org.scalaquery.test
+
+import javax.sql.rowset.serial.SerialBlob
+import org.junit.Test
+import org.junit.Assert._
+import org.scalaquery.ql._
+import org.scalaquery.ql.basic.{BasicTable => Table, BasicProfile}
+import org.scalaquery.session._
+import org.scalaquery.session.Database.threadLocalSession
+import org.scalaquery.test.util._
+import org.scalaquery.test.util.TestDB._
+import java.util.UUID
+
+object UUIDTest extends DBTestObject(Postgres)
+
+class UUIDTest(tdb: TestDB) extends DBTest(tdb) {
+  import tdb.driver.Implicit._
+
+  implicit object UUIDTypeMapper extends BaseTypeMapper[UUID] with TypeMapperDelegate[UUID] {
+    def apply(p: BasicProfile) = this
+    val zero = new UUID(0, 0)
+    val sqlType = java.sql.Types.OTHER
+    override def sqlTypeName = "uuid"
+    def setValue(v: UUID, p: PositionedParameters) = p.setOther(v)
+    def setOption(v: Option[UUID], p: PositionedParameters) = p.setOtherOption(v)
+    def nextValue(r: PositionedResult) = r.nextOther().asInstanceOf[UUID]
+    def updateValue(v: UUID, r: PositionedResult) = r.updateOther(v)
+    override def valueToSQLLiteral(value: UUID) = "'" + value + "'"
+  }
+
+  object T1 extends Table[(Int, Option[UUID])]("test") {
+    def id = column[Int]("id")
+    def data = column[Option[UUID]]("data")
+    def * = id ~ data
+  }
+
+  object T2 extends Table[(Int, UUID)]("test2") {
+    def id = column[Int]("id", O PrimaryKey)
+    def data = column[UUID]("data")
+    def * = id ~ data
+  }
+
+  val u1 = Some(java.util.UUID.randomUUID())
+  val u2 = None
+  val u3 = java.util.UUID.randomUUID()
+  val u4 = java.util.UUID.randomUUID()
+  val u5 = java.util.UUID.randomUUID()
+
+  @Test def testUUIDOption() {
+    // A Blob result does not survive a commit on all DBMSs so we wrap everything in a transaction
+    db withTransaction {
+      T1.ddl.create;
+      T1 insert (1, u1)
+      T1 insert (2, u2)
+
+      assertEquals(Set((1,u1), (2,u2)),
+        Query(T1).list.toSet)
+    }
+  }
+
+  @Test def testUUID() {
+    db withTransaction {
+      T2.ddl.create;
+      T2.insert (1, u3)
+      T2.insert (2, u4)
+      assertEquals(Set((1,u3), (2,u4)),
+        Query(T2).list.toSet)
+    }
+  }
+
+  @Test def testMutate() {
+    db withTransaction {
+      T2.ddl.create;
+      T2.insert (1, u3)
+      T2.insert (2, u4)
+      val q = for {
+        t <- T2
+      } yield t
+      q.mutate { m => if(m.row._1 == 1) m.row = m.row.copy(_2 = u5) }
+
+      assertEquals(Set((1,u5), (2,u4)),
+        Query(T2).list.toSet)
+    }
+  }
+
+  @Test def testUpdate() {
+    db withTransaction {
+      T2.ddl.create;
+      T2.insert (1, u3)
+      T2.insert (2, u4)
+
+      val q2 = for { t <- T2 if t.id === 1 } yield t.data
+      q2.update(u5)
+
+      assertEquals(Set((1,u5), (2,u4)),
+        Query(T2).list.toSet)
+    }
+  }
+}


### PR DESCRIPTION
I needed to access a UUID column in postgresql, and this seemed to be the way.  There's only a test for postgresql, since I don't know what other databases need the type for.
