### PR TITLE
Fixed link to old repository in README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,5 +23,5 @@ The following database systems are directly supported for type-safe queries:
 
 Accessing other database systems is possible, with a reduced feature set.
 
-See <https://github.com/typesafehub/slick/wiki> for more information.
+See <https://github.com/slick/slick/wiki> for more information.
 Licensing conditions (BSD-style) can be found in LICENSE.txt.


### PR DESCRIPTION
README.txt was pointing to typesafehub/slick instead of slick/slick
