### PR TITLE
SymbolNamer: Prioritize child over parent

### DIFF
--- a/src/main/scala/scala/slick/ast/Symbol.scala
+++ b/src/main/scala/scala/slick/ast/Symbol.scala
@@ -91,7 +91,7 @@ class SymbolNamer(symbolPrefix: String, parent: Option[SymbolNamer] = None) {
   }
 
   def get(s: Symbol): Option[String] =
-    parent.flatMap(_.get(s)).orElse(map.get(s))
+    map.get(s) orElse parent.flatMap(_.get(s))
 
   def apply(s: Symbol): String = get(s).getOrElse(s match {
     case a: AnonSymbol =>


### PR DESCRIPTION
This fixed the missing from clause errors I was getting, from sql like:
update customers set name_first = 'xxx' where x3.id = 100
(which I had mentioned on #37)
