### PR TITLE
Expose local scala home as a system property.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,19 +17,25 @@ object SlickBuild extends Build {
     libraryDependencies in config("macro") <+= scalaVersion("org.scala-lang" % "scala-compiler" % _)
   )
 
-  val localScalaSettings: Seq[Setting[_]] = Seq(
+  def localScalaSettings(path: String): Seq[Setting[_]] = Seq(
     scalaVersion := "2.10.0-unknown",
     scalaBinaryVersion := "2.10.0-unknown",
     crossVersion := CrossVersion.Disabled,
-    scalaHome := Some(file("C:/Users/szeiger/code/scala/build/pack")),
+    scalaHome := Some(file(path)),
     autoScalaLibrary := false,
     unmanagedJars <<= scalaInstance.map( _.jars.classpath),
     unmanagedJars in config("test") <<= scalaInstance.map( _.jars.classpath),
     unmanagedJars in config("macro") <<= scalaInstance.map( _.jars.classpath)
   )
 
-  val scalaSettings = publishedScalaSettings
-  //val scalaSettings = localScalaSettings
+  val scalaSettings = {
+    sys.props("scala.home.local") match {
+      case null => publishedScalaSettings
+      case path =>
+        scala.Console.err.println("Using local scala at " + path)
+        localScalaSettings(path)
+    }
+  }
 
   lazy val sharedSettings = Seq(
     version := "0.11.2",


### PR DESCRIPTION
A concession to the outliers among us who don't keep scala at
C:/Users/szeiger/code/scala/build/pack.

Now I can do

  sbt -Dscala.home.local=/scala/inst/3 compile

Or run git-bisect, because I can also do

  sbt -Dscala.home.local=$(find-scala-by-hash <hash>) compile
