### PR TITLE
Add the title and version at the generated API doc

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -99,7 +99,7 @@ object SlickBuild extends Build {
     settings = Project.defaultSettings ++ inConfig(config("macro"))(Defaults.configSettings) ++ sharedSettings ++ fmppSettings ++ site.settings ++ site.sphinxSupport() ++ extTarget("slick", None) ++ Seq(
       name := "Slick",
       description := "Scala Language-Integrated Connection Kit",
-      scalacOptions in doc <++= (version).map(v => Seq("-doc-title", "Slick", "-doc-version", v)),
+      scalacOptions in (Compile, doc) <++= (version).map(v => Seq("-doc-title", "Slick", "-doc-version", v)),
       test := (),
       testOnly <<= inputTask { argTask => (argTask) map { args => }},
       ivyConfigurations += config("macro").hide.extend(Compile),
@@ -112,7 +112,7 @@ object SlickBuild extends Build {
     settings = Project.defaultSettings ++ sharedSettings ++ extTarget("testkit", None) ++ Seq(
       name := "Slick-TestKit",
       description := "Test Kit for Slick (Scala Language-Integrated Connection Kit)",
-      scalacOptions in doc <++= (version).map(v => Seq("-doc-title", "Slick TestKit", "-doc-version", v)),
+      scalacOptions in (Compile, doc) <++= (version).map(v => Seq("-doc-title", "Slick TestKit", "-doc-version", v)),
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),
       //scalacOptions in Compile += "-Yreify-copypaste",
       libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "test"),


### PR DESCRIPTION
[The actual generated API doc](http://slick.typesafe.com/doc/1.0.0/api/) does not show a good HTML title.

By updating the `scalacOptions` not only for the `doc` scope but also for the `Compile` scope solved this issue (at least with my setup which uses sbt 0.12.2). 

With this patch, by using `doc` in the sbt console, the HTML title is correct.

I would really know if anyone has any explanation for this. The only reference I found for this issue is https://groups.google.com/d/msg/simple-build-tool/7jrnGu-zAKo/DutBSGnRY1wJ (but I don't really understand the explanation...)
