### PR TITLE
Remove Filter nodes with a LiteralNode(true) as the filter condition.

### DIFF
--- a/src/main/scala/scala/slick/ast/Dump.scala
+++ b/src/main/scala/scala/slick/ast/Dump.scala
@@ -71,7 +71,7 @@ class DumpContext(val out: PrintWriter, val typed: Boolean = true) {
       case _ =>
         out.println(prefix + name + tree + typeInfo)
         for((chg, n) <- tree.nodeChildren.zip(tree.nodeChildNames))
-          dump(Node(chg), prefix + "  ", n+": ")
+          dump(chg, prefix + "  ", n+": ")
     }
   }
 }

--- a/src/main/scala/scala/slick/ast/Node.scala
+++ b/src/main/scala/scala/slick/ast/Node.scala
@@ -291,10 +291,13 @@ final case class Filter(generator: Symbol, from: Node, where: Node) extends Filt
   def right = where
   override def nodeChildNames = Seq("from "+generator, "where")
   protected[this] def nodeRebuild(left: Node, right: Node) = copy(from = left, where = right)
-  override def nodeDelegate =
-    if(where match { case LiteralNode(true) => true; case _ => false }) left
-    else super.nodeDelegate
   protected[this] def nodeRebuildWithGenerators(gen: IndexedSeq[Symbol]) = copy(generator = gen(0))
+}
+
+object Filter {
+  def ifRefutable(generator: Symbol, from: Node, where: Node): Node =
+    if(where match { case LiteralNode(true) => true; case _ => false }) from
+    else Filter(generator, from, where)
 }
 
 /** A .sortBy call of type

--- a/src/main/scala/scala/slick/direct/SlickBackend.scala
+++ b/src/main/scala/scala/slick/direct/SlickBackend.scala
@@ -291,7 +291,7 @@ class SlickBackend( val driver: JdbcDriver, mapper:Mapper ) extends QueryableBac
               val new_scope = scope+(arg.symbol -> sq.Ref(sq_symbol))
               val sq_rhs = s2sq(body, new_scope).node
               new Query( term.decoded match {
-                case "filter"     => sq.Filter( sq_symbol, sq_lhs, sq_rhs )
+                case "filter"     => sq.Filter.ifRefutable( sq_symbol, sq_lhs, sq_rhs )
                 case "sortBy"     => sq.SortBy( sq_symbol, sq_lhs, flattenAndPrepareForSortBy(sq_rhs) )
                 case "map"        => sq.Bind( sq_symbol, sq_lhs, sq.Pure(sq_rhs) )
                 case "flatMap"    => sq.Bind( sq_symbol, sq_lhs, sq_rhs )

--- a/src/main/scala/scala/slick/lifted/AbstractTable.scala
+++ b/src/main/scala/scala/slick/lifted/AbstractTable.scala
@@ -24,7 +24,7 @@ abstract class AbstractTable[T](val schemaName: Option[String], val tableName: S
     val fv = Library.==.typed[Boolean](Node(targetColumns(aliased.value)), Node(sourceColumns))
     val fk = ForeignKey(name, this, q.unpackable.asInstanceOf[ShapedValue[TT, _]],
       targetTable, unpackp, sourceColumns, targetColumns, onUpdate, onDelete)
-    new ForeignKeyQuery[TT, U](Filter(generator, Node(q), fv), q.unpackable, IndexedSeq(fk), q, generator, aliased.value)
+    new ForeignKeyQuery[TT, U](Filter.ifRefutable(generator, Node(q), fv), q.unpackable, IndexedSeq(fk), q, generator, aliased.value)
   }
 
   def primaryKey[T](name: String, sourceColumns: T)(implicit shape: Shape[T, _, _]): PrimaryKey = PrimaryKey(name, ExtraUtil.linearizeFieldRefs(Node(shape.pack(sourceColumns))))

--- a/src/main/scala/scala/slick/lifted/Constraint.scala
+++ b/src/main/scala/scala/slick/lifted/Constraint.scala
@@ -75,7 +75,7 @@ class ForeignKeyQuery[E <: TableNode, U](
     val conditions =
       newFKs.map(fk => Library.==.typed[Boolean](Node(fk.targetColumns(aliasedValue)), Node(fk.sourceColumns))).
         reduceLeft[Node]((a, b) => Library.And.typed[Boolean](a, b))
-    val newDelegate = Filter(generator, Node(targetBaseQuery), conditions)
+    val newDelegate = Filter.ifRefutable(generator, Node(targetBaseQuery), conditions)
     new ForeignKeyQuery[E, U](newDelegate, base, newFKs, targetBaseQuery, generator, aliasedValue)
   }
 }

--- a/src/main/scala/scala/slick/lifted/Query.scala
+++ b/src/main/scala/scala/slick/lifted/Query.scala
@@ -33,7 +33,7 @@ abstract class Query[+E, U] extends Rep[Seq[U]] with EncodeRef { self =>
     val generator = new AnonSymbol
     val aliased = unpackable.encodeRef(generator)
     val fv = f(aliased.value)
-    new WrappingQuery[E, U](Filter(generator, Node(this), Node(wt(fv))), unpackable)
+    new WrappingQuery[E, U](Filter.ifRefutable(generator, Node(this), Node(wt(fv))), unpackable)
   }
 
   def withFilter[T : CanBeQueryCondition](f: E => T) = filter(f)


### PR DESCRIPTION
This used to work in ScalaQuery but was broken at some point during the
transition to the new AST. It did go by unnoticed because a bug in Scala
2.10.0 prevented these filter calls from being generated in the first
place (https://issues.scala-lang.org/browse/SI-6968). As a further
complication, the existing code for removing these nodes in
Filter.nodeDelegate along with an unnecessary Node.apply call in Dump
made them disappear from the AST dumps even though they were still in
the tree!

The fix for SI-6968 in Scala 2.10.1-RC1 finally caused failures due to
the unexpected query shape (with an unnecessary Filter) when dealing
with GroupBy nodes in convertToComprehensions.

This fix removes the extra Node.apply in Dump and the "hidden" narrowing
in Filter.nodeDelegate, replacing it with an explicit factory method
Filter.ifRefutable.

Fixes issue #105. Testable by switching to Scala 2.10.1-RC1.

Review by @cvogt 
