### PR TITLE
Set path to databases.properties through system property.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -28,7 +28,7 @@ object TestDB {
   }
   private lazy val dbProps = {
     val p = new Properties
-    val f = new File("test-dbs", "databases.properties")
+    val f = new File(sys.props.getOrElse("slick.testkit.dbprops", "test-dbs/databases.properties"))
     if(f.isFile) {
       val in = new FileInputStream(f)
       try { p.load(in) } finally { in.close() }


### PR DESCRIPTION
This makes it possible to easily run tests on multiple testing VMs with
different database configurations from the same checkout of Slick.

Review by @cvogt
