### PR TITLE
Add MiMa to 1.0 branch.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,6 +3,9 @@ import Keys._
 import Tests._
 import com.typesafe.sbt.site.SphinxSupport.Sphinx
 import com.typesafe.sbt.SbtSite.site
+import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
+import com.typesafe.tools.mima.plugin.MimaKeys.{previousArtifact, binaryIssueFilters}
+import com.typesafe.tools.mima.core.{ProblemFilters, MissingClassProblem}
 
 object SlickBuild extends Build {
 
@@ -63,12 +66,17 @@ object SlickBuild extends Build {
       testOnly <<= inputTask { argTask => (argTask) map { args => }}
     )).aggregate(slickProject, slickTestkitProject)
   lazy val slickProject = Project(id = "slick", base = file("."),
-    settings = Project.defaultSettings ++ sharedSettings ++ fmppSettings ++ site.settings ++ site.sphinxSupport() ++ inConfig(config("macro"))(Defaults.configSettings) ++ Seq(
+    settings = Project.defaultSettings ++ sharedSettings ++ fmppSettings ++ site.settings ++ site.sphinxSupport() ++ mimaDefaultSettings ++ inConfig(config("macro"))(Defaults.configSettings) ++ Seq(
       name := "Slick",
       description := "Scala Language-Integrated Connection Kit",
       scalacOptions in doc <++= (version).map(v => Seq("-doc-title", "Slick", "-doc-version", v)),
       test := (),
       testOnly <<= inputTask { argTask => (argTask) map { args => }},
+      previousArtifact := Some("com.typesafe.slick" % "slick_2.10" % "1.0.0"),
+      binaryIssueFilters ++= Seq(
+        ProblemFilters.exclude[MissingClassProblem]("scala.slick.util.MacroSupportInterpolationImpl$"),
+        ProblemFilters.exclude[MissingClassProblem]("scala.slick.util.MacroSupportInterpolationImpl")
+      ),
       ivyConfigurations += config("macro").hide.extend(Compile),
       libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "macro"),
       unmanagedClasspath in Compile <++= fullClasspath in config("macro"),

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-scalacOptions += "-deprecation"addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
+scalacOptions += "-deprecation"addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.4")


### PR DESCRIPTION
Use mima-report-binary-issues in sbt to check for binary compatibility
of the main Slick project with release 1.0.0. The macro implementations
used by Slick are excluded because they are only used at compile time.

Review by @cvogt 
