### PR TITLE
Always add parentheses around subqueries in a SELECT clause.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
@@ -433,4 +433,23 @@ class NewQuerySemanticsTest(val tdb: TestDB) extends TestkitTest {
     (TableA.ddl ++ TableB.ddl ++ TableC.ddl).create
     queryErr2.run
   }
+
+  def testSubquery {
+    object A extends Table[Int]("A_subquery") {
+      def id = column[Int]("id")
+      def * = id
+    }
+    A.ddl.create
+    A.insert(42)
+
+    val q0 = Query(A).filter(_.id === 42.bind).length
+    val r0 = q0.run
+    assertEquals(1, r0)
+
+    val q1 = Parameters[Int].flatMap { n =>
+      Query(A).filter(_.id is n).map(a => Query(a).length)
+    }
+    val r1 = q1(42).list
+    assertEquals(List(1), r1)
+  }
 }

--- a/src/main/scala/scala/slick/driver/BasicStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/BasicStatementBuilderComponent.scala
@@ -151,6 +151,10 @@ trait BasicStatementBuilderComponent { driver: BasicDriver =>
     protected def buildSelectPart(n: Node): Unit = n match {
       case Typed(t: TypeMapper[_]) if useIntForBoolean && (t(profile) == driver.typeMapperDelegates.booleanTypeMapperDelegate) =>
         b"case when $n then 1 else 0 end"
+      case c: Comprehension =>
+        b"("
+        buildComprehension(c)
+        b")"
       case n =>
         expr(n, true)
     }


### PR DESCRIPTION
Note that this doesn't catch the cases where the expr() call at the end
falls through to a subquery which is introduced on the fly by
convertToComprehension(). We cannot handle these cases in a compatible
way in 1.0. With the typed ASTs in 2.0, it should be possible to perform
all these conversions before the code generator in an extra compiler
phase so that this fix will work for them as well.

Fixes issue #101. Test case in NewQuerySemanticsTest.testSubquery.

Review by @amirsh 
