### PR TITLE
Support schema names for tables in all statements except INSERTs.

### DIFF
--- a/slick-testkit/src/test/scala/scala/slick/test/lifted/SchemaSupportTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/lifted/SchemaSupportTest.scala
@@ -1,0 +1,40 @@
+package scala.slick.test.lifted
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Test case for the SQL schema support in table definitions */
+class SchemaSupportTest {
+
+  @Test def testSchemaSupport {
+    import scala.slick.driver.H2Driver.simple._
+
+    object T extends Table[Int](Some("myschema"), "mytable") {
+      def id = column[Int]("id")
+      def * = id
+    }
+
+    val s1 = Query(T).filter(_.id < 5).selectStatement
+    println(s1)
+    assertTrue("select ... from uses schema name", s1 contains """from "myschema"."mytable" """)
+
+    //val s2 = T.insertStatement
+    //println(s2)
+
+    val s3 = Query(T).filter(_.id < 5).updateStatement
+    println(s3)
+    assertTrue("update uses schema name", s3 contains """update "myschema"."mytable" """)
+
+    val s4 = Query(T).filter(_.id < 5).deleteStatement
+    println(s4)
+    assertTrue("delete uses schema name", s4 contains """delete from "myschema"."mytable" """)
+
+    val s5 = T.ddl.createStatements
+    s5.foreach(println)
+    s5.foreach(s => assertTrue("DDL (create) uses schema name", s contains """ "myschema"."mytable" """))
+
+    val s6 = T.ddl.dropStatements
+    s6.foreach(println)
+    s6.foreach(s => assertTrue("DDL (drop) uses schema name", s contains """ "myschema"."mytable" """))
+  }
+}

--- a/src/main/scala/scala/slick/ast/Node.scala
+++ b/src/main/scala/scala/slick/ast/Node.scala
@@ -393,6 +393,7 @@ object Path {
 abstract class TableNode extends Node {
   def nodeShaped_* : ShapedValue[_, _]
   def tableName: String
+  //def schemaName: Option[String]
   def nodeTableSymbol: TableSymbol = TableSymbol(tableName)
   override def toString = "Table " + tableName
 }


### PR DESCRIPTION
The InsertBuilder API needs to change in a binary-incompatible way so we
cannot do this last bit in 1.0.x. The new quoteTableName method belongs
into BasicSQLUtilsComponent next to quoteIdentifier. It is placed as a
private method into BasicStatementBuilderComponent to ensure binary
compatibility with Slick 1.0.0. There should be a TableNode.schemaName
method but we cannot add that, either, without breaking binary
compatibility, so we pattern-match in quoteTableName instead. This needs
to be cleaned up after merging 1.0 back into master.

Test case in SchemaSupportTest. Ideally, all TestKit tests would use
schema names, but that will require some major work on TestKit.

Fixes issue #19. Review by @cvogt 
