### PR TITLE
Specify NULL when creating nullable TIMESTAMP columns on MySQL.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/DataTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/DataTypeTest.scala
@@ -145,8 +145,17 @@ class DataTypeTest(val tdb: TestDB) extends TestkitTest {
   def testTime =
     roundtrip("time_t1", Time.valueOf("17:53:48"))
 
-  def testTimestamp =
+  def testTimestamp = {
     roundtrip[Timestamp]("timestamp_t1", Timestamp.valueOf("2012-12-24 17:53:48.0"))
+
+    object T2 extends Table[Option[Timestamp]]("timestamp_t2") {
+      def t = column[Option[Timestamp]]("t")
+      def * = t
+    }
+    T2.ddl.create
+    T2.insert(None)
+    assertEquals(None, Query(T2).first)
+  }
 
   def testUUID =
     roundtrip[UUID]("uuid_t1", UUID.randomUUID(), literal = false)

--- a/src/main/scala/scala/slick/driver/MySQLDriver.scala
+++ b/src/main/scala/scala/slick/driver/MySQLDriver.scala
@@ -111,6 +111,7 @@ trait MySQLDriver extends ExtendedDriver { driver =>
     override protected def appendOptions(sb: StringBuilder) {
       if(defaultLiteral ne null) sb append " DEFAULT " append defaultLiteral
       if(notNull) sb append " NOT NULL"
+      else if(sqlType.toUpperCase == "TIMESTAMP") sb append " NULL"
       if(autoIncrement) sb append " AUTO_INCREMENT"
       if(primaryKey) sb append " PRIMARY KEY"
     }


### PR DESCRIPTION
MySQL defaults to non-nullable TIMESTAMP columns, so they need to be
explicitly marked nullable in the table DDL.

Test in DataTypeTest.testTimestamp. Fixes issue #98.

Review by @cvogt 
