### PR TITLE
Proper rewriting of aggregation functions over explicit joins.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -118,5 +118,15 @@ class AggregateTest(val tdb: TestDB) extends TestkitTest {
     assertEquals(List( ((1,Some(1)),1), ((1,Some(2)),1), ((1,Some(3)),1),
       ((2,Some(1)),1), ((2,Some(2)),1), ((2,Some(5)),1),
       ((3,Some(1)),1), ((3,Some(9)),1)), r4)
+
+    U.insert(4)
+
+    println("=========================================================== q5")
+    val q5 = (for {
+      (u, t) <- U leftJoin T on (_.id === _.a)
+    } yield (u, t)).groupBy(_._1.id).map {
+      case (id, q) => (id, q.length, q.map(_._1).length, q.map(_._2).length)
+    }
+    assertEquals(Set((1, 3, 3, 3), (2, 3, 3, 3), (3, 2, 2, 2), (4, 1, 1, 0)), q5.run.toSet)
   }
 }


### PR DESCRIPTION
Aggregations over the left or right side of an explicit join were not
properly translated in ConvertToComprehensions.convertSimpleGrouping.

We still have a design problem here: In SQL, a count over a single column
disregards NULL values whereas a count(*) counts all rows of a view. This
distinction should not exist in collection semantics (and it cannot be
implemented in ConvertToComprehensions, long after TableRefExpansions have
been eliminated, since there is no way of telling a count of a single
column from a count of a view of which we only use a single column later).

For now, the fix is to count the first column of the projection. This is
in line with the behaviour in 1.0.0, allows the correct handling of
single-column projections and produces the right result in most cases of
counting joined tables.

We should improve this further when we add proper support for nested
collections.

Fixes issue #135. Test in AggregateTest.testGroupBy.

Review by @cvogt 
