### PR TITLE
Inline lifted count(*) aggregates over scalar Comprehensions.

### DIFF
--- a/src/main/scala/scala/slick/compiler/Relational.scala
+++ b/src/main/scala/scala/slick/compiler/Relational.scala
@@ -270,7 +270,8 @@ class FuseComprehensions extends Phase {
           // sub-query somewhere in 'from' position. Not much we can do about this though.
           s match {
             case Library.CountAll =>
-              c2.copy(select = Some(Pure(ProductNode(Seq(Library.Count(ConstColumn(1)))))))
+              if(c2.from.isEmpty) ConstColumn(1)
+              else c2.copy(select = Some(Pure(ProductNode(Seq(Library.Count(ConstColumn(1)))))))
             case s =>
               val c3 = ensureStruct(c2)
               // All standard aggregate functions operate on a single column
@@ -291,7 +292,7 @@ class FuseComprehensions extends Phase {
         seenGens += gen -> ch
         ch
       case (None, ch) => tr(ch)
-    }.asInstanceOf[Comprehension]
+    }
     if(lift.isEmpty) c2
     else {
       val newFrom = lift.map { case (a, f, s, c2) =>


### PR DESCRIPTION
count(*) in a sub-Comprehension is usually turned into a count(1) but if
the sub-Comprehension is known to be scalar, it can be lifted out and
inlined as a constant 1.

We do this mainly for the benefit of MS Access (which does not support
the subquery in this case) but we can safely run it as part of the
standard query compiler.

Fixes ticket 230. No extra test (NewQuerySemanticsTest.testSubQuery was
broken on Access).

Review by @cvogt 
