### PR TITLE
Expand symbols in the "by" clause of a GroupBy node.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -119,14 +119,22 @@ class AggregateTest(val tdb: TestDB) extends TestkitTest {
       ((2,Some(1)),1), ((2,Some(2)),1), ((2,Some(5)),1),
       ((3,Some(1)),1), ((3,Some(9)),1)), r4)
 
+    println("=========================================================== q5")
+    val q5 = Query(T)
+      .filter(_.a === 1)
+      .map(t => (t.a, t.b))
+      .sortBy(_._2)
+      .groupBy(x => (x._1, x._2))
+      .map { case (a, _) => (a._1, a._2) }
+    assertEquals(Set((1, Some(1)), (1, Some(2)), (1, Some(3))), q5.run.toSet)
     U.insert(4)
 
-    println("=========================================================== q5")
-    val q5 = (for {
+    println("=========================================================== q6")
+    val q6 = (for {
       (u, t) <- U leftJoin T on (_.id === _.a)
     } yield (u, t)).groupBy(_._1.id).map {
       case (id, q) => (id, q.length, q.map(_._1).length, q.map(_._2).length)
     }
-    assertEquals(Set((1, 3, 3, 3), (2, 3, 3, 3), (3, 2, 2, 2), (4, 1, 1, 0)), q5.run.toSet)
+    assertEquals(Set((1, 3, 3, 3), (2, 3, 3, 3), (3, 2, 2, 2), (4, 1, 1, 0)), q6.run.toSet)
   }
 }


### PR DESCRIPTION
A proper fix would entail removing the "by" Symbol from GroupBy (but we
cannot do that in 1.0.x due to binary compatibility constraints). It
should not be needed anymore in the modern Slick AST. ExpandRefs
incorrectly assumed that only "from" clauses would have symbols so we add
a special case for GroupBy for now.

Fixes issue #141. Test in AggregateTest.groupBy (q5).

Review by @cvogt 
