### PR TITLE
Allow drivers to customize DDLInvoker

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
@@ -21,6 +21,7 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
   def createUnitQueryInvoker[R](tree: Node) = new UnitQueryInvoker[R](tree)
   def createUpdateInvoker[T](tree: Node) = new UpdateInvoker[T](tree)
   def createQueryInvoker[P,R](tree: Node): QueryInvoker[P,R] = new QueryInvoker[P, R](tree)
+  def createDDLInvoker(ddl: SchemaDescription) = new DDLInvoker(ddl)
 
   // Parameters for invokers -- can be overridden by drivers as needed
   val invokerMutateConcurrency: ResultSetConcurrency = ResultSetConcurrency.Updatable

--- a/src/main/scala/scala/slick/driver/JdbcProfile.scala
+++ b/src/main/scala/scala/slick/driver/JdbcProfile.scala
@@ -41,7 +41,7 @@ trait JdbcProfile extends SqlProfile with JdbcTableComponent
   }
 
   trait Implicits extends LowPriorityImplicits with super.Implicits with ImplicitColumnTypes {
-    implicit def ddlToDDLInvoker(d: DDL): DDLInvoker = new DDLInvoker(d)
+    implicit def ddlToDDLInvoker(d: DDL): DDLInvoker = createDDLInvoker(d)
     implicit def queryToDeleteInvoker(q: Query[_ <: Table[_], _]): DeleteInvoker = new DeleteInvoker(deleteCompiler.run(Node(q)).tree)
     implicit def parameterizedQueryToQueryInvoker[P, R](q: ParameterizedQuery[P, R]): QueryInvoker[P, R] = createQueryInvoker[P, R](q.tree)
     implicit def appliedQueryToAppliedQueryInvoker[R](q: AppliedQuery[R]): MutatingUnitInvoker[R] = createQueryInvoker[Any, R](q.tree)(q.param)

--- a/src/main/scala/scala/slick/memory/DistributedProfile.scala
+++ b/src/main/scala/scala/slick/memory/DistributedProfile.scala
@@ -27,6 +27,7 @@ trait DistributedProfile extends MemoryQueryingProfile { driver: DistributedDriv
   def buildSequenceSchemaDescription(seq: Sequence[_]): SchemaDescription = ???
   def buildTableSchemaDescription(table: Table[_]): SchemaDescription = ???
   def createDistributedQueryInterpreter(param: Any, session: Backend#Session) = new DistributedQueryInterpreter(param, session)
+  def createDDLInvoker(sd: SchemaDescription): DDLInvoker = ???
 
   val emptyHeapDB = HeapBackend.createEmptyDatabase
 

--- a/src/main/scala/scala/slick/memory/MemoryProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryProfile.scala
@@ -28,6 +28,7 @@ trait MemoryProfile extends MemoryQueryingProfile { driver: MemoryDriver =>
 
   def createQueryExecutor[R](tree: Node, param: Any): QueryExecutor[R] = new QueryExecutorDef[R](tree, param)
   def createInsertInvoker[T](tree: scala.slick.ast.Node): InsertInvoker[T] = new InsertInvokerDef[T](tree)
+  def createDDLInvoker(sd: SchemaDescription): DDLInvoker = ???
   def buildSequenceSchemaDescription(seq: Sequence[_]): SchemaDescription = ???
   def buildTableSchemaDescription(table: Table[_]): SchemaDescription = new TableDDL(table)
 

--- a/src/main/scala/scala/slick/profile/BasicProfile.scala
+++ b/src/main/scala/scala/slick/profile/BasicProfile.scala
@@ -104,6 +104,9 @@ trait StandardParameterizedQueries { driver: BasicDriver =>
 
 trait BasicInvokerComponent { driver: BasicDriver =>
 
+  /** Create a DDLInvoker -- this method should be implemented by drivers as needed */
+  def createDDLInvoker(ddl: SchemaDescription): DDLInvoker
+
   /** Pseudo-invoker for running DDL statements. */
   trait DDLInvoker {
     /** Create the entities described by this DDL object */


### PR DESCRIPTION
Drivers currently can't override the functionality provided by `DDLInvoker`. For a specific driver for a currently unsupported database I write, the driver has to issue some SQL statements that don't work with `PreparedStatement`s. The driver would need to provide a custom `DDLInvoker` to execute all DDL queries with regular `Statement`s.

This commit adds a `createDDLInvoker` factory method similar to `createInsertInvoker`, which is then used by the implicit method `ddlToDDLInvoker`.

Regards,
  Gerolf
