### PR TITLE
Improve threadLocalSession API

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
@@ -96,7 +96,7 @@ class InvokerTest extends TestkitTest[JdbcTestDB] {
     val it = f()
     it.use { assertEquals((1 to 1000).toList, it.toStream.toList) }
     assertFail(g())
-    db.withSession { s: Session => T.ddl.drop(s) }
+    db.withSession(T.ddl.drop(_))
     val it2 = f()
     it2.use { assertEquals((1 to 1000).toList, it2.toStream.toList) }
   }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -215,13 +215,13 @@ abstract class ExternalJdbcTestDB(confName: String) extends JdbcTestDB(confName)
   override def cleanUpBefore() {
     if(!drop.isEmpty || !create.isEmpty) {
       println("[Creating test database "+this+"]")
-      databaseFor(adminDBURL, adminUser, adminPassword) withSession { implicit session: profile.Backend#Session =>
+      databaseFor(adminDBURL, adminUser, adminPassword) withSession { implicit session =>
         for(s <- drop) (Q.u + s).execute
         for(s <- create) (Q.u + s).execute
       }
     }
     if(!postCreate.isEmpty) {
-      createDB() withSession { implicit session: profile.Backend#Session =>
+      createDB() withSession { implicit session  =>
         for(s <- postCreate) (Q.u + s).execute
       }
     }
@@ -230,7 +230,7 @@ abstract class ExternalJdbcTestDB(confName: String) extends JdbcTestDB(confName)
   override def cleanUpAfter() {
     if(!drop.isEmpty) {
       println("[Dropping test database "+this+"]")
-      databaseFor(adminDBURL, adminUser, adminPassword) withSession { implicit session: profile.Backend#Session =>
+      databaseFor(adminDBURL, adminUser, adminPassword) withSession { implicit session =>
         for(s <- drop) (Q.u + s).execute
       }
     }

--- a/slick-testkit/src/test/scala/scala/slick/benchmark/IteratorPerformanceBenchmark.scala
+++ b/slick-testkit/src/test/scala/scala/slick/benchmark/IteratorPerformanceBenchmark.scala
@@ -2,7 +2,6 @@ package scala.slick.benchmark
 
 import collection.mutable.ArrayBuffer
 import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
 
 object IteratorPerformanceBenchmark {
   def main(args: Array[String]) {
@@ -13,7 +12,7 @@ object IteratorPerformanceBenchmark {
 
       def * = key ~ value
     }
-    Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver") withSession {
+    Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver") withSession { implicit session =>
       Props.ddl.create
       val count = 10000
       val size = 1000

--- a/slick-testkit/src/test/scala/scala/slick/test/direct/QueryableTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/direct/QueryableTest.scala
@@ -42,7 +42,7 @@ object Singleton{
 }
 
 class QueryableTest(val tdb: JdbcTestDB) extends DBTest {
-  import tdb.driver.backend.Database.threadLocalSession
+  import tdb.driver.backend.Database.dynamicSession
 
   object backend extends SlickBackend(tdb.driver,AnnotationMapper)
 
@@ -50,8 +50,8 @@ class QueryableTest(val tdb: JdbcTestDB) extends DBTest {
     def enableAssertQuery[T:TypeTag:ClassTag]( q:Queryable[T] ) = new{
       def assertQuery( matcher : ast.Node => Unit ) = {
         //backend.dump(q)
-        println( backend.toSql(q,threadLocalSession) )
-        println( backend.result(q,threadLocalSession) )
+        println( backend.toSql(q,dynamicSession) )
+        println( backend.result(q,dynamicSession) )
         try{
           matcher( backend.toQuery( q )._2.node : @unchecked ) : @unchecked
           print(".")
@@ -85,15 +85,15 @@ class QueryableTest(val tdb: JdbcTestDB) extends DBTest {
     def fail : Unit = fail()
     def success{ print(".") }
     def assertEqualMultiSet[T]( lhs:scala.collection.Traversable[T], rhs:scala.collection.Traversable[T] ) = assertEquals( rhs.groupBy(x=>x), lhs.groupBy(x=>x) )
-    def assertMatch[T:TypeTag:ClassTag]( queryable:Queryable[T], expected: Traversable[T] ) = assertEqualMultiSet( backend.result(queryable,threadLocalSession), expected)
+    def assertMatch[T:TypeTag:ClassTag]( queryable:Queryable[T], expected: Traversable[T] ) = assertEqualMultiSet( backend.result(queryable,dynamicSession), expected)
     def assertNotEqualMultiSet[T]( lhs:scala.collection.Traversable[T], rhs:scala.collection.Traversable[T] ) = assertEquals( lhs.groupBy(x=>x), rhs.groupBy(x=>x) )
     def assertNoMatch[T:TypeTag:ClassTag]( queryable:Queryable[T], expected: Traversable[T] ) = try{
-      assertEqualMultiSet( backend.result(queryable,threadLocalSession), expected)
+      assertEqualMultiSet( backend.result(queryable,dynamicSession), expected)
     } catch {
       case e:AssertionError => 
       case e:Throwable => throw e
     }
-    def assertMatchOrdered[T:TypeTag:ClassTag]( queryable:Queryable[T], expected: Traversable[T] ) = assertEquals( expected, backend.result(queryable,threadLocalSession) )
+    def assertMatchOrdered[T:TypeTag:ClassTag]( queryable:Queryable[T], expected: Traversable[T] ) = assertEquals( expected, backend.result(queryable,dynamicSession) )
   }
 
   object SingletonInClass{
@@ -118,7 +118,7 @@ class QueryableTest(val tdb: JdbcTestDB) extends DBTest {
       ("French_Roast_Decaf", 5, None)
     )
     
-    db withSession {
+    db withDynSession {
       // create test table
       sqlu"create table COFFEES(COF_NAME varchar(255), SALES int, FLAVOR varchar(255) NULL)".execute
       (for {
@@ -310,9 +310,9 @@ class QueryableTest(val tdb: JdbcTestDB) extends DBTest {
         inMem.map( c=> (c.name,c.sales,c) )
       )
       // length
-      assertEquals( backend.result(query.length,threadLocalSession), inMem.length )
+      assertEquals( backend.result(query.length,dynamicSession), inMem.length )
 
-      val iquery = ImplicitQueryable( query, backend, threadLocalSession )
+      val iquery = ImplicitQueryable( query, backend, dynamicSession )
       assertEquals( iquery.length, inMem.length )
       
       // iquery.filter( _.sales > 10.0 ).map( _.name ) // currently crashed compiler

--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/EmbeddingTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/EmbeddingTest.scala
@@ -9,9 +9,9 @@ import com.typesafe.slick.testkit.util.JdbcTestDB
 object EmbeddingTest extends DBTestObject(H2Mem)
 
 class EmbeddingTest(val tdb: JdbcTestDB) extends DBTest {
-  import tdb.profile.backend.Database.threadLocalSession
+  import tdb.profile.backend.Database.dynamicSession
 
-  @Test def testRaw(): Unit = db withSession {
+  @Test def testRaw(): Unit = db withDynSession {
     import scala.slick.jdbc.{StaticQuery => Q, GetResult}
 
     (Q.u + "create table USERS(ID int not null primary key, NAME varchar(255))").execute

--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/MetaTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/MetaTest.scala
@@ -14,7 +14,6 @@ object MetaTest extends DBTestObject(H2Mem, SQLiteMem, Postgres, MySQL, DerbyMem
 
 class MetaTest(val tdb: JdbcTestDB) extends DBTest {
   import tdb.profile.simple._
-  import Database.threadLocalSession
 
   object Users extends Table[(Int, String, Option[String])]("users") {
     def id = column[Int]("id", O.PrimaryKey)
@@ -35,7 +34,7 @@ class MetaTest(val tdb: JdbcTestDB) extends DBTest {
 
   @Test def test() {
 
-    db withSession {
+    db withSession { implicit session =>
 
       val ddl = (Users.ddl ++ Orders.ddl)
       println("DDL used to create tables:")

--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/StatementParametersTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/StatementParametersTest.scala
@@ -14,7 +14,7 @@ class StatementParametersTest(val tdb: JdbcTestDB) extends DBTest {
 
   @Test def testExplicit() {
     println("*** Explicit ***")
-    db withSession { s1:Session =>
+    db withSession { s1 =>
       pr("start")(s1)
       ResultSetType.ScrollInsensitive(s1) { s2 =>
         pr("in ScrollInsensitive block")(s2)
@@ -32,8 +32,9 @@ class StatementParametersTest(val tdb: JdbcTestDB) extends DBTest {
 
   @Test def testImplicit() {
     println("*** Implicit ***")
-    import Database.threadLocalSession
-    db withSession {
+    import Database.dynamicSession
+
+    db withDynSession {
       pr("start")
       check(ResultSetType.Auto, ResultSetConcurrency.Auto, ResultSetHoldability.Auto)
       ResultSetType.ScrollInsensitive {

--- a/slick-testkit/src/test/scala/scala/slick/test/memory/DistributedQueryingTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/memory/DistributedQueryingTest.scala
@@ -41,7 +41,7 @@ class DistributedQueryingTest {
       try {
         val db2 = tdb2.createDB()
         val db = DistributedBackend.Database(db1, db2)
-        db.withSession { s: DistributedBackend#Session =>
+        db.withSession { s =>
           f(s.sessions(0).asInstanceOf[tdb1.profile.Backend#Session], s.sessions(1).asInstanceOf[tdb2.profile.Backend#Session], s)
         }
       } finally tdb2.cleanUpAfter()

--- a/slick-testkit/src/test/scala/scala/slick/testutil/TestDBs.scala
+++ b/slick-testkit/src/test/scala/scala/slick/testutil/TestDBs.scala
@@ -71,7 +71,7 @@ object TestDBs {
     val url = "jdbc:derby:memory:"+dbName+";create=true"
     override def cleanUpBefore() = {
       val dropUrl = "jdbc:derby:memory:"+dbName+";drop=true"
-      try { profile.backend.Database.forURL(dropUrl, driver = jdbcDriver) withSession { s:profile.Backend#Session => s.conn } }
+      try { profile.backend.Database.forURL(dropUrl, driver = jdbcDriver) withSession(_.conn) }
       catch { case e: SQLException => }
     }
   }
@@ -81,7 +81,7 @@ object TestDBs {
     val url = "jdbc:derby:"+TestDB.testDBPath+"/"+dbName+";create=true"
     override def cleanUpBefore() = {
       val dropUrl = "jdbc:derby:"+TestDB.testDBPath+"/"+dbName+";shutdown=true"
-      try { profile.backend.Database.forURL(dropUrl, driver = jdbcDriver) withSession { s:profile.Backend#Session => s.conn } }
+      try { profile.backend.Database.forURL(dropUrl, driver = jdbcDriver) withSession(_.conn) }
       catch { case e: SQLException => }
       TestDB.deleteDBFiles(dbName)
     }

--- a/src/main/scala/scala/slick/jdbc/ResultSetConcurrency.scala
+++ b/src/main/scala/scala/slick/jdbc/ResultSetConcurrency.scala
@@ -6,7 +6,7 @@ sealed abstract class ResultSetConcurrency(val intValue: Int) { self =>
 
   def apply[T](base: JdbcBackend#Session)(f: JdbcBackend#Session => T): T = f(base.forParameters(rsConcurrency = self))
 
-  def apply[T](f: => T)(implicit base: JdbcBackend#Session): T = apply(base)(_.asThreadLocal(f))
+  def apply[T](f: => T)(implicit base: JdbcBackend#Session): T = apply(base)(_.asDynamicSession(f))
 
   def withDefault(r: ResultSetConcurrency) = this
 }

--- a/src/main/scala/scala/slick/jdbc/ResultSetHoldability.scala
+++ b/src/main/scala/scala/slick/jdbc/ResultSetHoldability.scala
@@ -6,7 +6,7 @@ sealed abstract class ResultSetHoldability(val intValue: Int) { self =>
 
   def apply[T](base: JdbcBackend#Session)(f: JdbcBackend#Session => T): T = f(base.forParameters(rsHoldability = self))
 
-  def apply[T](f: => T)(implicit base: JdbcBackend#Session): T = apply(base)(_.asThreadLocal(f))
+  def apply[T](f: => T)(implicit base: JdbcBackend#Session): T = apply(base)(_.asDynamicSession(f))
 
   def withDefault(r: ResultSetHoldability) = this
 }

--- a/src/main/scala/scala/slick/jdbc/ResultSetType.scala
+++ b/src/main/scala/scala/slick/jdbc/ResultSetType.scala
@@ -6,7 +6,7 @@ sealed abstract class ResultSetType(val intValue: Int) { self =>
 
   def apply[T](base: JdbcBackend#Session)(f: JdbcBackend#Session => T): T = f(base.forParameters(rsType = self))
 
-  def apply[T](f: => T)(implicit base: JdbcBackend#Session): T = apply(base)(_.asThreadLocal(f))
+  def apply[T](f: => T)(implicit base: JdbcBackend#Session): T = apply(base)(_.asDynamicSession(f))
 
   def withDefault(r: ResultSetType) = this
 }


### PR DESCRIPTION
threadLocalSession is renamed to dynamicSession to be consistent with
Scala terminology (Java calls it thread-local).

The withSession/withTransaction methods that make use of dynamicSession
are renamed to withDynSession/withDynTransaction to avoid overloading
the standard withSession/withTransaction methods. This makes it possible
to use the standard methods without explicit type annotations, e.g.

  db withSession { implicit session => ... }

instead of

  db withSession { implicit session: Session => ... }

Fixes issue #117.

Review by @cvogt 
