### PR TITLE
Fix build for building against Scala 2.11

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.12.4

--- a/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
+++ b/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
@@ -116,8 +116,8 @@ final class BooleanColumnExtensionMethods[P1](val c: Column[P1]) extends AnyVal 
 final class StringColumnExtensionMethods[P1](val c: Column[P1]) extends AnyVal with ExtensionMethods[String, P1] {
   def length[R](implicit om: o#to[Int, R]) =
     om.column(Library.Length, n)
-  def like[P2, R](e: Column[P2], esc: Char = '\0')(implicit om: o#arg[String, P2]#to[Boolean, R]) =
-    if(esc == '\0') om.column(Library.Like, n, e.toNode)
+  def like[P2, R](e: Column[P2], esc: Char = '\u0000')(implicit om: o#arg[String, P2]#to[Boolean, R]) =
+    if(esc == '\u0000') om.column(Library.Like, n, e.toNode)
     else om.column(Library.Like, n, e.toNode, LiteralNode(esc))
   def ++[P2, R](e: Column[P2])(implicit om: o#arg[String, P2]#to[String, R]) =
     om.column(Library.Concat, n, e.toNode)

--- a/src/main/scala/scala/slick/lifted/Shape.scala
+++ b/src/main/scala/scala/slick/lifted/Shape.scala
@@ -2,6 +2,7 @@ package scala.slick.lifted
 
 import scala.language.{existentials, implicitConversions}
 import scala.annotation.implicitNotFound
+import scala.annotation.unchecked.uncheckedVariance
 import scala.slick.SlickException
 import scala.slick.util.{ProductWrapper, TupleSupport}
 import scala.slick.ast._
@@ -19,7 +20,7 @@ import scala.slick.ast._
  */
 @implicitNotFound(msg = "No Shape found for unpacking ${Mixed_} to ${Unpacked_} and packing it to ${Packed_}")
 abstract class Shape[-Mixed_, Unpacked_, Packed_] {
-  type Mixed = Mixed_
+  type Mixed = Mixed_ @uncheckedVariance
   type Unpacked = Unpacked_
   type Packed = Packed_
 

--- a/src/main/scala/scala/slick/memory/QueryInterpreter.scala
+++ b/src/main/scala/scala/slick/memory/QueryInterpreter.scala
@@ -384,7 +384,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
   def compileLikePattern(s: String, escape: Option[Char]): Pattern = {
     val b = new StringBuilder append '^'
     val len = s.length
-    val esc = escape.getOrElse('\0')
+    val esc = escape.getOrElse('\u0000')
     var i = 0
     while(i < len) {
       s.charAt(i) match {


### PR DESCRIPTION
- Allow building with local Scala version again.
- Upgrade to sbt 0.12.4 (0.12.3 is not compatible with Scala 2.11).
- Fix soundness problem in Shape with an explicit uncheckedVariance
  annotation (it should be sound the way we're using it but it is not
  sound in general and Scala 2.10 did not detect that).
- Change octal literals (deprecated in 2.11) to unicode literals

Review by @cvogt 
