### PR TITLE
Deprecate notIn, add filterNot for orthogonality and conformity

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -159,7 +159,7 @@ class MainTest extends TestkitTest[JdbcTestDB] { mainTest =>
     println("b7: " + b7.selectStatement)
     println("b8: " + b8.selectStatement)
 
-    val q5 = users where { _.id notIn orders.map(_.userID) }
+    val q5 = users filterNot { _.id in orders.map(_.userID) }
     println("q5: " + q5.selectStatement)
     println("Users without Orders:")
     q5.foreach(o => println("  "+o))

--- a/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
+++ b/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
@@ -56,6 +56,7 @@ trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
 
   def in[P2, R](e: Query[Column[P2], _])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
     om.column(Library.In, n, e.toNode)
+  @deprecated("Use ! or filterNot instead", "2.0.0")
   def notIn[P2, R](e: Query[Column[P2], _])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
     om.column(Library.Not, Library.In.typed(om.liftedType, n, e.toNode))
   def inSet[R](seq: Traversable[B1])(implicit om: o#to[Boolean, R]) =


### PR DESCRIPTION
Deprecate notIn, add filterNot for orthogonality and conformity with Scala collections
see https://github.com/slick/slick/pull/204
