### PR TITLE
Allow subtypes in OptionMappers

### DIFF
--- a/src/main/scala/scala/slick/lifted/OptionMapper.scala
+++ b/src/main/scala/scala/slick/lifted/OptionMapper.scala
@@ -9,10 +9,10 @@ object OptionMapper2 {
   val plain = new OptionMapper2[Any,Any,Any,Any,Any,Any] { def apply(n: Column[Any]): Column[Any] = n }
   val option = new OptionMapper2[Any,Any,Any,Any,Any,Option[Any]] { def apply(n: Column[Any]): Column[Option[Any]] = n.? }
 
-  @inline implicit def getOptionMapper2TT[B1, B2 : BaseTypeMapper, BR] = OptionMapper2.plain .asInstanceOf[OptionMapper2[B1, B2, BR, B1,         B2,         BR]]
-  @inline implicit def getOptionMapper2TO[B1, B2 : BaseTypeMapper, BR] = OptionMapper2.option.asInstanceOf[OptionMapper2[B1, B2, BR, B1,         Option[B2], Option[BR]]]
-  @inline implicit def getOptionMapper2OT[B1, B2 : BaseTypeMapper, BR] = OptionMapper2.option.asInstanceOf[OptionMapper2[B1, B2, BR, Option[B1], B2,         Option[BR]]]
-  @inline implicit def getOptionMapper2OO[B1, B2 : BaseTypeMapper, BR] = OptionMapper2.option.asInstanceOf[OptionMapper2[B1, B2, BR, Option[B1], Option[B2], Option[BR]]]
+  @inline implicit def getOptionMapper2TT[B1, B2 : BaseTypeMapper, P2 <: B2, BR] = OptionMapper2.plain .asInstanceOf[OptionMapper2[B1, B2, BR, B1,         P2,         BR]]
+  @inline implicit def getOptionMapper2TO[B1, B2 : BaseTypeMapper, P2 <: B2, BR] = OptionMapper2.option.asInstanceOf[OptionMapper2[B1, B2, BR, B1,         Option[P2], Option[BR]]]
+  @inline implicit def getOptionMapper2OT[B1, B2 : BaseTypeMapper, P2 <: B2, BR] = OptionMapper2.option.asInstanceOf[OptionMapper2[B1, B2, BR, Option[B1], P2,         Option[BR]]]
+  @inline implicit def getOptionMapper2OO[B1, B2 : BaseTypeMapper, P2 <: B2, BR] = OptionMapper2.option.asInstanceOf[OptionMapper2[B1, B2, BR, Option[B1], Option[P2], Option[BR]]]
 }
 
 @implicitNotFound("Cannot perform option-mapped operation\n      with type: (${P1}, ${P2}, ${P3}) => ${R}\n  for base type: (${B1}, ${B2}, ${B3}) => ${BR}")
@@ -22,14 +22,14 @@ object OptionMapper3 {
   val plain = new OptionMapper3[Any,Any,Any,Any,Any,Any,Any,Any] { def apply(n: Column[Any]): Column[Any] = n }
   val option = new OptionMapper3[Any,Any,Any,Any,Any,Any,Any,Option[Any]] { def apply(n: Column[Any]): Column[Option[Any]] = n.? }
 
-  @inline implicit def getOptionMapper3TTT[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.plain .asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         B2,         B3,         BR]]
-  @inline implicit def getOptionMapper3TTO[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         B2,         Option[B3], Option[BR]]]
-  @inline implicit def getOptionMapper3TOT[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         Option[B2], B3,         Option[BR]]]
-  @inline implicit def getOptionMapper3TOO[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         Option[B2], Option[B3], Option[BR]]]
-  @inline implicit def getOptionMapper3OTT[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], B2,         B3,         Option[BR]]]
-  @inline implicit def getOptionMapper3OTO[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], B2,         Option[B3], Option[BR]]]
-  @inline implicit def getOptionMapper3OOT[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], Option[B2], B3,         Option[BR]]]
-  @inline implicit def getOptionMapper3OOO[B1, B2 : BaseTypeMapper, B3 : BaseTypeMapper, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], Option[B2], Option[B3], Option[BR]]]
+  @inline implicit def getOptionMapper3TTT[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.plain .asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         P2,         P3,         BR]]
+  @inline implicit def getOptionMapper3TTO[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         P2,         Option[P3], Option[BR]]]
+  @inline implicit def getOptionMapper3TOT[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         Option[P2], P3,         Option[BR]]]
+  @inline implicit def getOptionMapper3TOO[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, B1,         Option[P2], Option[P3], Option[BR]]]
+  @inline implicit def getOptionMapper3OTT[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], P2,         P3,         Option[BR]]]
+  @inline implicit def getOptionMapper3OTO[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], P2,         Option[P3], Option[BR]]]
+  @inline implicit def getOptionMapper3OOT[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], Option[P2], P3,         Option[BR]]]
+  @inline implicit def getOptionMapper3OOO[B1, B2 : BaseTypeMapper, P2 <: B2, B3 : BaseTypeMapper, P3 <: B3, BR] = OptionMapper3.option.asInstanceOf[OptionMapper3[B1, B2, B3, BR, Option[B1], Option[P2], Option[P3], Option[BR]]]
 }
 
 object OptionMapperDSL {


### PR DESCRIPTION
I have an ADT defined as follows:

```
object ExampleEnumeration extends EnumerationBase {
  sealed trait Value extends ValueBase
  case object Foo extends Value
  case object Bar extends Value
}

trait EnumerationBase {
  trait ValueBase
  // unrelated reflection magic here
}
```

I have defined a `BaseTypeMapper` for `[V <: EnumerationBase#ValueBase]` and a table that uses it:

```
object MyTable extends Table[(String, Value)]("mytable") {
  val bang = column[String]("bang")
  val biff = column[Value]("biff")
}
```

However, when using the table I was getting a compiler error:

```
for {
  m <- MyTable if m.biff === Foo
} yield m.bang

Cannot perform option-mapped operation
[error]       with type: (ExampleEnumeration.Value, ExampleEnumeration.Foo.type) => R
[error]   for base type: (ExampleEnumeration.Value, ExampleEnumeration.Value) => Boolean
```

This is because the current `OptionMapper2` requires that `B2 =:= P2`, which is not true for `Foo.type <:< Value`. 

A simple workaround was to just widen Foo to Value manually.

```
for {
  m <- MyTable if m.biff === (Foo:Value)
} yield m.bang
```

This commit fixes OptionMappers so that the cast is not required.
