### PR TITLE
Quote the table name correctly in InsertBuilder.

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -428,7 +428,7 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
   class InsertBuilder(val node: Node) {
 
     protected[this] val Insert(_, table: TableNode, _, ProductNode(columns)) = node
-    protected[this] def qtable = quoteIdentifier(table.tableName)
+    protected[this] def qtable = quoteTableName(table)
     protected[this] def qcolumns = columns.map { case Select(_, fs: FieldSymbol) => quoteIdentifier(fs.name) }.mkString(",")
     protected[this] def qvalues = columns.map(_ => "?").mkString(",")
 


### PR DESCRIPTION
This was still using quoteIdentifier instead of quoteTableName so it
would not work with schema names.

Replaces #198 (which was targeting the old 1.0 branch).

Review by @cvogt 
