### PR TITLE
Flatten nested ProductNodes in GroupBy keys.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -154,5 +154,10 @@ class AggregateTest extends TestkitTest[RelationalTestDB] {
       case (grp, t) => (grp._1, grp._2, t.map(_.col4).sum)
     }
     assertEquals(Set(("baz","quux",Some(4)), ("foo","quux",Some(3)), ("foo","bar",Some(3))), q1.run.toSet)
+
+    val q2 = Tabs.groupBy(t => ((t.col1, t.col2), t.col3)).map {
+      case (grp, t) => (grp._1._1, grp._1._2, t.map(_.col4).sum)
+    }
+    assertEquals(Set(("baz","quux",Some(4)), ("foo","quux",Some(3)), ("foo","bar",Some(3))), q2.run.toSet)
   }
 }

--- a/src/main/scala/scala/slick/compiler/Relational.scala
+++ b/src/main/scala/scala/slick/compiler/Relational.scala
@@ -101,7 +101,9 @@ class ConvertToComprehensions extends Phase {
         case FwdPath(gen2 :: ElementSymbol(idx) :: rest) if gen2 == gen && (idx == 1 || idx == 2) =>
           Phase.fuseComprehensions.select(rest, if(idx == 2) Ref(gen) else newBy)(0)
       }, keepType = true)
-      Comprehension(Seq(gen -> from), groupBy = Some(newBy),
+      // Flatten the GROUP BY conditions (not all DBs support tuple syntax)
+      val newGroupBy = Some(ProductNode(Seq(newBy)).flatten.withComputedTypeNoRec)
+      Comprehension(Seq(gen -> from), groupBy = newGroupBy,
         select = Some(Pure(newSel).withComputedTypeNoRec)).nodeTyped(b.nodeType)
     // Bind to Comprehension
     case b @ Bind(gen, from, select) =>


### PR DESCRIPTION
Databases without tuple syntax obviously don't support tuples in
"group by" clauses, so we have to flatten them. We can safely do this
in the convertToComprehensions phase. It should not affect semantics
for databases that would support tuples in this case.

Test case in AggregateTest.testGroup3. Fixes issue #207.

Review by @cvogt 
