### PR TITLE
Allow identity (primary key auto-increment) types to be overridden.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -138,4 +138,13 @@ class JdbcTypeTest extends TestkitTest[JdbcTestDB] {
 
   def testUUID =
     roundtrip[UUID]("uuid_t1", UUID.randomUUID(), literal = false)
+
+  def testOverrideIdentityType {
+    class T1(tag: Tag) extends Table[Int](tag, "t1") {
+      def id = column[Int]("id", O.PrimaryKey, O.AutoInc, O.DBType("_FOO_BAR_"))
+      def * = id
+    }
+    val t1 = TableQuery[T1]
+    assertTrue(t1.ddl.createStatements.mkString.contains("_FOO_BAR_"))
+  }
 }

--- a/src/main/scala/scala/slick/driver/AccessDriver.scala
+++ b/src/main/scala/scala/slick/driver/AccessDriver.scala
@@ -187,11 +187,9 @@ trait AccessDriver extends JdbcDriver { driver =>
   class ColumnDDLBuilder(column: FieldSymbol) extends super.ColumnDDLBuilder(column) {
     override def appendColumn(sb: StringBuilder) {
       sb append quoteIdentifier(column.name) append ' '
-      if(autoIncrement) {
-        sb append "AUTOINCREMENT"
-        autoIncrement = false
-      }
+      if(autoIncrement && !customSqlType) sb append "AUTOINCREMENT"
       else sb append sqlType
+      autoIncrement = false
       appendOptions(sb)
     }
 

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -562,6 +562,7 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
   class ColumnDDLBuilder(column: FieldSymbol) {
     protected val tmDelegate = typeInfoFor(column.tpe)
     protected var sqlType: String = null
+    protected var customSqlType: Boolean = false
     protected var notNull = !tmDelegate.nullable
     protected var autoIncrement = false
     protected var primaryKey = false
@@ -571,6 +572,7 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
     protected def init() {
       for(o <- column.options) handleColumnOption(o)
       if(sqlType eq null) sqlType = tmDelegate.sqlTypeName
+      else customSqlType = true
     }
 
     protected def handleColumnOption(o: ColumnOption[_]): Unit = o match {

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -73,11 +73,9 @@ trait PostgresDriver extends JdbcDriver { driver =>
   class ColumnDDLBuilder(column: FieldSymbol) extends super.ColumnDDLBuilder(column) {
     override def appendColumn(sb: StringBuilder) {
       sb append quoteIdentifier(column.name) append ' '
-      if(autoIncrement) {
-        sb append "SERIAL"
-        autoIncrement = false
-      }
+      if(autoIncrement && !customSqlType) sb append "SERIAL"
       else sb append sqlType
+      autoIncrement = false
       appendOptions(sb)
     }
 


### PR DESCRIPTION
PostgreSQL and Access require a special type / syntax for these types.
We now honor the O.DBType column option for custom SQL types in this
case.

Test in JdbcTypeTest.testOverrideIdentityType. Fixes issue #193.

Review by @cvogt 
