### PR TITLE
Use bind variables for types which do not support literals.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -96,7 +96,7 @@ class JdbcTypeTest extends TestkitTest[JdbcTestDB] {
     }
   }
 
-  private def roundtrip[T : BaseColumnType](tn: String, v: T, literal: Boolean = true, bind: Boolean = true) {
+  private def roundtrip[T : BaseColumnType](tn: String, v: T) {
     class T1(tag: Tag) extends Table[(Int, T)](tag, tn) {
       def id = column[Int]("id")
       def data = column[T]("data")
@@ -107,14 +107,10 @@ class JdbcTypeTest extends TestkitTest[JdbcTestDB] {
     t1.ddl.create
     t1.insert((1, v))
     assertEquals(v, t1.map(_.data).first)
-    if(literal) {
-      assertEquals(Some(1), t1.filter(_.data === v).map(_.id).firstOption)
-      assertEquals(None, t1.filter(_.data =!= v).map(_.id).firstOption)
-    }
-    if(bind) {
-      assertEquals(Some(1), t1.filter(_.data === v.bind).map(_.id).firstOption)
-      assertEquals(None, t1.filter(_.data =!= v.bind).map(_.id).firstOption)
-    }
+    assertEquals(Some(1), t1.filter(_.data === v).map(_.id).firstOption)
+    assertEquals(None, t1.filter(_.data =!= v).map(_.id).firstOption)
+    assertEquals(Some(1), t1.filter(_.data === v.bind).map(_.id).firstOption)
+    assertEquals(None, t1.filter(_.data =!= v.bind).map(_.id).firstOption)
   }
 
   def testDate =
@@ -137,7 +133,7 @@ class JdbcTypeTest extends TestkitTest[JdbcTestDB] {
   }
 
   def testUUID =
-    roundtrip[UUID]("uuid_t1", UUID.randomUUID(), literal = false)
+    roundtrip[UUID]("uuid_t1", UUID.randomUUID())
 
   def testOverrideIdentityType {
     class T1(tag: Tag) extends Table[Int](tag, "t1") {

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -190,10 +190,11 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
 
     def expr(n: Node, skipParens: Boolean = false): Unit = n match {
       case n @ LiteralNode(v) =>
-        if(n.volatileHint) b +?= { (p, param) => typeInfoFor(n.tpe).setValue(v, p) }
+        val ti = typeInfoFor(n.tpe)
+        if(n.volatileHint || !ti.hasLiteralForm) b +?= { (p, param) => ti.setValue(v, p) }
         else if((true == v) && useIntForBoolean) b"\(1=1\)"
         else if((false == v) && useIntForBoolean) b"\(1=0\)"
-        else b += typeInfoFor(n.tpe).valueToSQLLiteral(v)
+        else b += ti.valueToSQLLiteral(v)
       case QueryParameter(extractor, tpe) => b +?= { (p, param) =>
         typeInfoFor(tpe).setValue(extractor(param), p)
       }

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -114,6 +114,7 @@ trait PostgresDriver extends JdbcDriver { driver =>
       override def nextValue(r: PositionedResult) = r.nextObject().asInstanceOf[UUID]
       override def updateValue(v: UUID, r: PositionedResult) = r.updateObject(v)
       override def valueToSQLLiteral(value: UUID) = "'" + value + "'"
+      override def hasLiteralForm = true
     }
   }
 }


### PR DESCRIPTION
JdbcType gets a new method hasLiteralForm to check if a literal
representation is supported. This must return false in cases where
valueToSQLLiteral would otherwise throw a SlickException.

QueryBuilder (and driver-specific subclasses thereof) uses this method
to treat LiteralNodes as volatile (i.e. using bind variables) as needed.

In addition to the types which already threw an exception, Blob and Clob
are marked as not having a literal form in JdbcTypesComponent.

Tests in JdbcTypeTest (all tests now execute with both, volatile-hinted
and not volatile-hinted literals). Fixes issue #225.

Review by @cvogt 
