### PR TITLE
Fuse simple mappings before resolving GroupBy.

### DIFF
--- a/src/main/scala/scala/slick/ast/Util.scala
+++ b/src/main/scala/scala/slick/ast/Util.scala
@@ -89,7 +89,7 @@ object NodeOps {
   }
 
   def replace(tree: Node, f: PartialFunction[Node, Node], keepType: Boolean): Node =
-    f.applyOrElse(tree, ({ case n: Node => n.nodeMapChildren(_.replace(f), keepType) }): PartialFunction[Node, Node])
+    f.applyOrElse(tree, ({ case n: Node => n.nodeMapChildren(_.replace(f, keepType), keepType) }): PartialFunction[Node, Node])
 }
 
 /** Some less general but still useful methods for the code generators. */

--- a/src/main/scala/scala/slick/compiler/Relational.scala
+++ b/src/main/scala/scala/slick/compiler/Relational.scala
@@ -74,7 +74,30 @@ class ConvertToComprehensions extends Phase {
     case n => Seq((s, n))
   }
 
-  def convert(n: Node): Node = (n.nodeMapChildren(convert, keepType = true) match {
+  def convert(n: Node): Node = convert1(n.nodeMapChildren(convert, keepType = true)) match {
+    case c1 @ Comprehension(from1, where1, None, orderBy1,
+        Some(c2 @ Comprehension(from2, where2, None, orderBy2, select, None, None)),
+        fetch, offset) =>
+      c2.copy(from = from1 ++ from2, where = where1 ++ where2,
+        orderBy = orderBy2 ++ orderBy1, fetch = fetch, offset = offset
+      ).nodeTyped(c1.nodeType)
+    case n => n
+  }
+
+  def convert1(n: Node): Node = n match {
+    // Fuse simple mappings. This enables the use of multiple mapping steps
+    // for extracting aggregated values from groups. We have to do it here
+    // because Comprehension fusion comes after the special rewriting that
+    // we have to do for GroupBy aggregation.
+    case Bind(ogen, Comprehension(Seq((igen, from)), Nil, None, Nil, Some(Pure(isel, _)), None, None), Pure(osel, oident)) =>
+      logger.debug("Fusing simple mapping:", n)
+      val sel = osel.replace({
+        case FwdPath(base :: rest) if base == ogen =>
+          rest.foldLeft(isel)(_ select _)
+      }, keepType = true)
+      val res = Bind(igen, from, Pure(sel, oident).nodeTyped(n.nodeType)).nodeTyped(n.nodeType)
+      logger.debug("Fused to:", res)
+      convert1(res)
     // Table to Comprehension
     case t: TableNode =>
       val gen = new AnonSymbol
@@ -119,14 +142,6 @@ class ConvertToComprehensions extends Phase {
         if(take == Some(0)) Comprehension(from = mkFrom(new AnonSymbol, from), where = Seq(LiteralNode(false)))
         else Comprehension(from = mkFrom(new AnonSymbol, from), fetch = take.map(_.toLong), offset = drop2.map(_.toLong))
       c.nodeTyped(td.nodeType)
-    case n => n
-  }) match {
-    case c1 @ Comprehension(from1, where1, None, orderBy1,
-        Some(c2 @ Comprehension(from2, where2, None, orderBy2, select, None, None)),
-        fetch, offset) =>
-      c2.copy(from = from1 ++ from2, where = where1 ++ where2,
-        orderBy = orderBy2 ++ orderBy1, fetch = fetch, offset = offset
-      ).nodeTyped(c1.nodeType)
     case n => n
   }
 


### PR DESCRIPTION
This enables the use of multiple mapping steps for extracting
aggregated values from groups.

Test in AggregateTest.testMultiMapAggregates. Fixes issues #186, #187,
#189.

Review by @cvogt 
