### PR TITLE
Rename .elements to .iterator.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
@@ -46,7 +46,7 @@ class InvokerTest extends TestkitTest[JdbcTestDB] {
     val r6t: Array[Int] = r6
     assertEquals(Array(1, 2, 3, 4, 5).toList, r6.toList)
 
-    val it = q.elements
+    val it = q.iterator
     val sum = try {
       it.reduceLeft(_ + _)
     } finally it.close()
@@ -86,7 +86,7 @@ class InvokerTest extends TestkitTest[JdbcTestDB] {
 
     def f() = CloseableIterator close db.createSession after { session =>
       setUp(session)
-      q.elements()(session)
+      q.iterator()(session)
     }
 
     def g() = CloseableIterator close db.createSession after { session =>

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -76,9 +76,9 @@ class PlainSQLTest extends TestkitTest[JdbcTestDB] {
     }
     assertEquals(Set(User(1,"szeiger"), User(2,"guest"), User(0,"admin"), User(3,"foo")), s4)
 
-    println("All users with elements.foreach:")
+    println("All users with iterator.foreach:")
     var s5 = Set[User]()
-    for(s <- getUsers(None).elements) {
+    for(s <- getUsers(None).iterator) {
       println("  "+s)
       s5 += s
     }

--- a/slick-testkit/src/test/scala/scala/slick/benchmark/IteratorPerformanceBenchmark.scala
+++ b/slick-testkit/src/test/scala/scala/slick/benchmark/IteratorPerformanceBenchmark.scala
@@ -38,16 +38,16 @@ object IteratorPerformanceBenchmark {
             i => buf += i
           }, 0)
         }
-        measure("elements loop") {
-          val it = inv.elements()
+        measure("iterator loop") {
+          val it = inv.iterator()
           try {
             while (it.hasNext) buf += it.next
           } finally {
             it.close()
           }
         }
-        measure("elements.foreach") {
-          inv.elements().foreach(i => buf += i)
+        measure("iterator.foreach") {
+          inv.iterator().foreach(i => buf += i)
         }
         r += 1
       }

--- a/src/main/scala/scala/slick/jdbc/ResultSetInvoker.scala
+++ b/src/main/scala/scala/slick/jdbc/ResultSetInvoker.scala
@@ -15,7 +15,7 @@ abstract class ResultSetInvoker[+R] extends UnitInvokerMixin[R] { self =>
 
   protected def createResultSet(session: JdbcBackend#Session): ResultSet
 
-  def elementsTo(param: Unit, maxRows: Int)(implicit session: JdbcBackend#Session): CloseableIterator[R] = {
+  def iteratorTo(param: Unit, maxRows: Int)(implicit session: JdbcBackend#Session): CloseableIterator[R] = {
     val rs = createResultSet(session)
     if(rs eq null) CloseableIterator.empty
     else new PositionedResultIterator[R](rs, maxRows) {

--- a/src/main/scala/scala/slick/jdbc/StatementInvoker.scala
+++ b/src/main/scala/scala/slick/jdbc/StatementInvoker.scala
@@ -12,7 +12,7 @@ abstract class StatementInvoker[-P, +R] extends Invoker[P, R] { self =>
 
   protected def setParam(param: P, st: PreparedStatement): Unit
 
-  def elementsTo(param: P, maxRows: Int)(implicit session: JdbcBackend#Session): CloseableIterator[R] =
+  def iteratorTo(param: P, maxRows: Int)(implicit session: JdbcBackend#Session): CloseableIterator[R] =
     results(param, maxRows).fold(r => new CloseableIterator.Single[R](r.asInstanceOf[R]), identity)
 
   /**


### PR DESCRIPTION
Scala did this in 2.8 and we should be compatible with the Scala
collections API where possible.

Fixes issue #136.

Review by @cvogt 
