### PR TITLE
Skip AutoInc columns by default when inserting data.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -80,4 +80,26 @@ class InsertTest extends TestkitTest[JdbcTestDB] {
       assertEquals((5, "i", "j"), id4)
     }
   }
+
+  def testForced = {
+    class T(tag: Tag) extends Table[(Int, String)](tag, "t_forced") {
+      def id = column[Int]("id", O.AutoInc, O.PrimaryKey)
+      def name = column[String]("name")
+      def * = (id, name)
+      def ins = (id, name)
+    }
+    val ts = TableQuery[T]
+
+    ts.ddl.create
+
+    ts.insert(101, "A")
+    ts.map(_.ins).insertAll((102, "B"), (103, "C"))
+    assertEquals(0, ts.filter(_.id > 100).length.run)
+
+    ifCap(jcap.forceInsert) {
+      ts.forceInsert(104, "A")
+      ts.map(_.ins).forceInsertAll((105, "B"), (106, "C"))
+      assertEquals(3, ts.filter(_.id > 100).length.run)
+    }
+  }
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
@@ -42,7 +42,6 @@ class NewQuerySemanticsTest extends TestkitTest[RelationalTestDB] {
       def state = column[String]("STATE")
       def zip = column[String]("ZIP")
       def * = (id, name, street)
-      def forInsert = (id, name, street, city, state, zip).shaped
     }
     val suppliers = TableQuery[Suppliers]
 
@@ -53,7 +52,6 @@ class NewQuerySemanticsTest extends TestkitTest[RelationalTestDB] {
       def sales = column[Int]("SALES")
       def total = column[Int]("TOTAL")
       def * = (name, supID, price, sales, (total * 10))
-      def forInsert = (name, supID, price, sales, total).shaped
       def totalComputed = sales * price
       def supplier = foreignKey("SUP_FK", supID, suppliers)(_.id)
     }

--- a/src/main/scala/scala/slick/ast/Insert.scala
+++ b/src/main/scala/scala/slick/ast/Insert.scala
@@ -16,3 +16,10 @@ final case class Insert(generator: Symbol, table: Node, map: Node, linear: Node)
     nodeRebuildOrThis(Vector(table2, map2, linear)).nodeTypedOrCopy(if(!nodeHasType || retype) map2.nodeType else nodeType)
   }
 }
+
+/** A column in an Insert operation. */
+final case class InsertColumn(child: Node, fs: FieldSymbol) extends UnaryNode with SimplyTypedNode {
+  type Self = InsertColumn
+  def nodeRebuild(ch: Node) = copy(child = ch)
+  def buildType = child.nodeType
+}

--- a/src/main/scala/scala/slick/compiler/InsertCompiler.scala
+++ b/src/main/scala/scala/slick/compiler/InsertCompiler.scala
@@ -41,7 +41,7 @@ trait InsertCompiler extends Phase {
         })
       case sel @ Select(Ref(s), fs: FieldSymbol) if s == expansionRef =>
         cols += Select(tref, fs).nodeTyped(sel.nodeType)
-        Select(rref, ElementSymbol(cols.size)).nodeTyped(sel.nodeType)
+        InsertColumn(Select(rref, ElementSymbol(cols.size)).nodeTyped(sel.nodeType), fs).nodeTyped(sel.nodeType)
       case Bind(gen, te @ TableExpansion(_, t: TableNode, _), Pure(sel, _)) =>
         setTable(te)
         tr(sel.replace({ case Ref(s) if s == gen => Ref(expansionRef) }, keepType = true))

--- a/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
@@ -88,8 +88,10 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
     protected def retMany(values: Seq[U], individual: Seq[SingleInsertResult]): MultiInsertResult
     protected def retManyBatch(st: Statement, values: Seq[U], updateCounts: Array[Int]): MultiInsertResult
 
-    protected lazy val insertResult = builder.buildInsert
+    protected lazy val insertResult = builder.buildInsert(forced = false)
+    protected lazy val insertForcedResult = builder.buildInsert(forced = true)
     lazy val insertStatement = insertResult.sql
+    lazy val forceInsertStatement = insertForcedResult.sql
     def insertStatementFor[TT](query: Query[TT, U]): String = builder.buildInsert(query).sql
     def insertStatementFor[TT](c: TT)(implicit shape: Shape[_ <: ShapeLevel.Flat, TT, U, _]): String = insertStatementFor(Query(c)(shape))
 
@@ -98,26 +100,46 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
     protected def prepared[T](sql: String)(f: PreparedStatement => T)(implicit session: Backend#Session) =
       session.withPreparedStatement(sql)(f)
 
-    /** Insert a single row. */
-    def insert(value: U)(implicit session: Backend#Session): SingleInsertResult = prepared(insertStatement) { st =>
-      st.clearParameters()
-      converter.set(value, new PositionedParameters(st))
-      val count = st.executeUpdate()
-      retOne(st, value, count)
-    }
+    /** Insert a single row, skipping AutoInc columns. */
+    final def insert(value: U)(implicit session: Backend#Session): SingleInsertResult = internalInsert(false, value)
 
-    /** Insert multiple rows. Uses JDBC's batch update feature if supported by
-      * the JDBC driver. Returns Some(rowsAffected), or None if the database
-      * returned no row count for some part of the batch. If any part of the
-      * batch fails, an exception is thrown. */
-    def insertAll(values: U*)(implicit session: Backend#Session): MultiInsertResult = session.withTransaction {
+    /** Insert a single row, including AutoInc columns. This is not supported
+      * by all database engines (see
+      * [[scala.slick.driver.JdbcProfile.capabilities.forceInsert]]). */
+    final def forceInsert(value: U)(implicit session: Backend#Session): SingleInsertResult = internalInsert(true, value)
+
+    protected def internalInsert(forced: Boolean, value: U)(implicit session: Backend#Session): SingleInsertResult =
+      prepared(if(forced) forceInsertStatement else insertStatement) { st =>
+        st.clearParameters()
+        converter.set(value, new PositionedParameters(st), forced)
+        val count = st.executeUpdate()
+        retOne(st, value, count)
+      }
+
+    /** Insert multiple rows, skipping AutoInc columns.
+      * Uses JDBC's batch update feature if supported by the JDBC driver.
+      * Returns Some(rowsAffected), or None if the database returned no row
+      * count for some part of the batch. If any part of the batch fails, an
+      * exception is thrown. */
+    final def insertAll(values: U*)(implicit session: Backend#Session): MultiInsertResult = internalInsertAll(false, values: _*)
+
+    /** Insert multiple rows, including AutoInc columns.
+      * This is not supported by all database engines (see
+      * [[scala.slick.driver.JdbcProfile.capabilities.forceInsert]]).
+      * Uses JDBC's batch update feature if supported by the JDBC driver.
+      * Returns Some(rowsAffected), or None if the database returned no row
+      * count for some part of the batch. If any part of the batch fails, an
+      * exception is thrown. */
+    final def forceInsertAll(values: U*)(implicit session: Backend#Session): MultiInsertResult = internalInsertAll(true, values: _*)
+
+    protected def internalInsertAll(forced: Boolean, values: U*)(implicit session: Backend#Session): MultiInsertResult = session.withTransaction {
       if(!useBatchUpdates || (values.isInstanceOf[IndexedSeq[_]] && values.length < 2)) {
         retMany(values, values.map(insert))
       } else {
-        prepared(insertStatement) { st =>
+        prepared(if(forced) forceInsertStatement else insertStatement) { st =>
           st.clearParameters()
           for(value <- values) {
-            converter.set(value, new PositionedParameters(st))
+            converter.set(value, new PositionedParameters(st), forced)
             st.addBatch()
           }
           val counts = st.executeBatch()
@@ -255,7 +277,7 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
     def update(value: T)(implicit session: Backend#Session): Int = session.withPreparedStatement(updateStatement) { st =>
       st.clearParameters
       val pp = new PositionedParameters(st)
-      converter.set(value, pp)
+      converter.set(value, pp, true)
       sres.setter(pp, param)
       st.executeUpdate
     }

--- a/src/main/scala/scala/slick/driver/JdbcProfile.scala
+++ b/src/main/scala/scala/slick/driver/JdbcProfile.scala
@@ -60,6 +60,8 @@ trait JdbcProfile extends SqlProfile with JdbcTableComponent
 
 object JdbcProfile {
   object capabilities {
+    /** Can insert into AutoInc columns. */
+    val forceInsert = Capability("jdbc.forceInsert")
     /** Supports mutable result sets */
     val mutable = Capability("jdbc.mutable")
     /** Can return primary key of inserted row */
@@ -71,7 +73,7 @@ object JdbcProfile {
     val other = Capability("jdbc.other")
 
     /** All JDBC capabilities */
-    val all = Set(other, mutable, returnInsertKey, returnInsertOther)
+    val all = Set(other, forceInsert, mutable, returnInsertKey, returnInsertOther)
   }
 }
 

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -16,7 +16,7 @@ import scala.slick.compiler.CompilerState
  * Notes:
  *
  * <ul>
- *   <li>[[scala.slick.profile.SqlProfile.capabilities.typeBlob]]:
+ *   <li>[[scala.slick.profile.RelationalProfile.capabilities.typeBlob]]:
  *   The default implementation of the <code>Blob</code> type uses the
  *   database type <code>lo</code> and the stored procedure
  *   <code>lo_manage</code>, both of which are provided by the "lo"

--- a/src/main/scala/scala/slick/driver/SQLServerDriver.scala
+++ b/src/main/scala/scala/slick/driver/SQLServerDriver.scala
@@ -21,13 +21,15 @@ import java.sql.{Timestamp, Date, Time}
  *   <li>[[scala.slick.profile.SqlProfile.capabilities.sequence]]:
  *     Sequences are not supported because SQLServer does not have this
  *     feature.</li>
+ *   <li>[[scala.slick.driver.JdbcProfile.capabilities.forceInsert]]:
+ *     Inserting explicit values into AutoInc columns with ''forceInsert''
+ *     operations is not supported.</li>
  * </ul>
- *
- * @author szeiger
  */
 trait SQLServerDriver extends JdbcDriver { driver =>
 
   override protected def computeCapabilities: Set[Capability] = (super.computeCapabilities
+    - JdbcProfile.capabilities.forceInsert
     - JdbcProfile.capabilities.returnInsertOther
     - SqlProfile.capabilities.sequence
   )

--- a/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
@@ -44,7 +44,7 @@ trait MemoryQueryingDriver extends RelationalDriver with MemoryQueryingProfile w
 
   trait QueryMappingCompiler extends super.MappingCompiler {
 
-    def createColumnConverter(n: Node, path: Node, option: Boolean): ResultConverter = {
+    def createColumnConverter(n: Node, path: Node, option: Boolean, column: Option[FieldSymbol]): ResultConverter = {
       val Select(_, ElementSymbol(ridx)) = path
       val nullable = typeInfoFor(n.nodeType.structural).nullable
       new ResultConverter {
@@ -54,7 +54,7 @@ trait MemoryQueryingDriver extends RelationalDriver with MemoryQueryingProfile w
           v
         }
         def update(value: Any, pr: RowUpdater) = ???
-        def set(value: Any, pp: RowWriter) = ???
+        def set(value: Any, pp: RowWriter, forced: Boolean) = ???
       }
     }
   }


### PR DESCRIPTION
The new methods forceInsert and forceInsertAll in JdbcProfile can be
used to change that behavior. This only affects inserting values from
the client side. Inserting from another query ignores these
restrictions.

A new capability jdbc.forceInsert describes the ability to do forced
inserts. Surprisingly, SQL Server is the only database in the Slick core
lacking that feature. There used to be more of them a few years ago.

Tests in MapperTest.testMappedEntity (now relying on the soft insert
being the default) and InsertTest.testForced. Fixes issue #27.

Review by @cvogt. I'm on vacation now for one week. Time to catch up :-)
