### PR TITLE
Quote table and fk names in MySQL ALTER TABLE statements

### DIFF
--- a/src/main/scala/scala/slick/driver/MySQLDriver.scala
+++ b/src/main/scala/scala/slick/driver/MySQLDriver.scala
@@ -113,7 +113,7 @@ trait MySQLDriver extends JdbcDriver { driver =>
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {
     override protected def dropForeignKey(fk: ForeignKey) = {
-      "ALTER TABLE " + table.tableName + " DROP FOREIGN KEY " + fk.name
+      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP FOREIGN KEY " + quoteIdentifier(fk.name)
     }
   }
 


### PR DESCRIPTION
Slick generates unquoted ALTER TABLE statements for MySQL, for example:

```
ALTER TABLE group DROP FOREIGN KEY foo_fk;
```

This will fail with a MySQL syntax error. This commit fixes things so that we get quoted identifiers:

```
ALTER TABLE `group` DROP FOREIGN KEY `foo_fk`;
```
