### PR TITLE
Running a query to match a specific UUID in MySQL fails in 1.0.1. For ex...

### DIFF
--- a/src/main/scala/scala/slick/driver/MySQLDriver.scala
+++ b/src/main/scala/scala/slick/driver/MySQLDriver.scala
@@ -184,9 +184,14 @@ trait MySQLDriver extends JdbcDriver { driver =>
       }
     }
 
+    import java.util.UUID
+
     override val uuidJdbcType = new UUIDJdbcType {
       override def sqlType = java.sql.Types.BINARY
       override def sqlTypeName = "BINARY(16)"
+
+      override def valueToSQLLiteral(value: UUID): String =
+        "x'"+value.toString.replace("-", "")+"'"
     }
   }
 }


### PR DESCRIPTION
Running a query to match a specific UUID in MySQL fails in 1.0.1. For example, the following code will fail with error "UUID does not support a literal representation".

  val query = (for (u <- UserRecordTable if u.email === email) yield u)

That failure may be correct for other databases, but MySQL allows a literal representation
of BINARY(16) using an "x" prefix to a string like:

  select \* from user where user_uuid = x'e4d369040f044b6e9561765c356907d3';

As such, modifying the MySQLDriver to support this notation allows the query above to
return results correctly.

Some additional discussion:
  http://stackoverflow.com/questions/17496415/error-when-trying-to-filter-by-uuid-slick/19536219#19

My original patch was for 1.0.1 but I'm not sure how to apply to that revision specifically, so I'm targeting this to 2.0.\* instead.
