### PR TITLE
Add a separate compiler phase for boolean emulation.

### DIFF
--- a/slick-testkit/src/test/resources/logback-test.xml
+++ b/slick-testkit/src/test/resources/logback-test.xml
@@ -24,6 +24,7 @@
     <logger name="scala.slick.compiler.FuseComprehensions"        level="${log.qcomp.fuseComprehensions:-inherited}" />
     <logger name="scala.slick.compiler.FixRowNumberOrdering"      level="${log.qcomp.fixRowNumberOrdering:-inherited}" />
     <logger name="scala.slick.compiler.HoistClientOps"            level="${log.qcomp.hoistClientOps:-inherited}" />
+    <logger name="scala.slick.compiler.RewriteBooleans"           level="${log.qcomp.rewriteBooleans:-inherited}" />
     <logger name="scala.slick.compiler.CodeGen"                   level="${log.qcomp.codeGen:-inherited}" />
     <logger name="scala.slick.compiler.InsertCompiler"            level="${log.qcomp.insertCompiler:-inherited}" />
     <logger name="scala.slick.jdbc.JdbcBackend.statement"         level="${log.session:-info}" />

--- a/src/main/scala/scala/slick/compiler/QueryCompiler.scala
+++ b/src/main/scala/scala/slick/compiler/QueryCompiler.scala
@@ -124,6 +124,9 @@ object Phase {
   val fuseComprehensions = new FuseComprehensions
   val fixRowNumberOrdering = new FixRowNumberOrdering
   val hoistClientOps = new HoistClientOps
+
+  /** Extra phases that are not enabled by default */
+  val rewriteBooleans = new RewriteBooleans
 }
 
 /** The current state of a compiler run, consisting of immutable state of

--- a/src/main/scala/scala/slick/compiler/RewriteBooleans.scala
+++ b/src/main/scala/scala/slick/compiler/RewriteBooleans.scala
@@ -1,0 +1,74 @@
+package scala.slick.compiler
+
+import scala.slick.ast._
+import Util.nodeToNodeOps
+import TypeUtil._
+
+/** For SQL back-ends which do not support real boolean types for fields and
+  * general expressions but which do have special boolean expressions and
+  * operators, this phase injects conversions between fake and real boolean
+  * values.
+  *
+  * The default for booleans in the AST is to use the fake type. There are
+  * specific places where a real boolean is required or produced, so we
+  * inject a call to ToRealBoolean or ToFakeBoolean as needed. */
+class RewriteBooleans extends Phase {
+  import RewriteBooleans._
+  val name = "rewriteBooleans"
+
+  def apply(state: CompilerState) =
+    state.map { n => ClientSideOp.mapServerSide(n)(rewriteRec) }
+
+  def rewriteRec(n: Node): Node = {
+    val n2 = n.nodeMapChildren(rewriteRec, true)
+    val n3 = rewrite(n2)
+    if(n3 ne n2) logger.debug(s"Rewriting $n2 to $n3")
+    n3
+  }
+
+  /** Rewrite a single Node. This method can be overridden in subclasses to
+    * change the situations in which conversions are applied. */
+  def rewrite(n: Node): Node = n match {
+    // These boolean operators accept and produce real booleans
+    case Apply(sym @ (Library.And | Library.Or | Library.Not), ch) =>
+      toFake(Apply(sym, ch.map(n => toReal(n)))(n.nodeType))
+    // All other boolean-typed operators produce real booleans but accept fake ones
+    case Apply(sym, ch) :@ tpe if isBooleanLike(tpe) =>
+      toFake(Apply(sym, ch)(n.nodeType))
+    // Where clauses, join conditions and case clauses need real boolean predicates
+    case n @ Comprehension(_, where, _, _, _, _, _) =>
+      n.copy(where = where.map(toReal)).nodeTyped(n.nodeType)
+    case n @ Join(_, _, _, _, _, on) =>
+      n.copy(on = toReal(on)).nodeTyped(n.nodeType)
+    case n @ IfThen(left, _) =>
+      n.copy(left = toReal(left))
+    case n => n
+  }
+
+  /** Create a conversion to a fake boolean, cancelling out an existing
+    * conversion to a real boolean. */
+  def toFake(n: Node) = n match {
+    case ToRealBoolean(ch) => ch
+    case _ => ToFakeBoolean.typed(n.nodeType, n)
+  }
+
+  /** Create a conversion to a real boolean, cancelling out an existing
+    * conversion to a fake boolean. */
+  def toReal(n: Node) = n match {
+    case ToFakeBoolean(ch) => ch
+    case _ => ToRealBoolean.typed(n.nodeType, n)
+  }
+
+  /** Check if a type is equivalent to the Scala Boolean type or a (possibly
+    * nested) Option of that type. */
+  def isBooleanLike(t: Type): Boolean = t match {
+    case t: TypedType[_] if t.scalaType == ScalaBaseType.booleanType => true
+    case t: OptionType => isBooleanLike(t.elementType)
+    case _ => false
+  }
+}
+
+object RewriteBooleans {
+  val ToFakeBoolean = new FunctionSymbol("RewriteBooleans.ToFakeBoolean")
+  val ToRealBoolean = new FunctionSymbol("RewriteBooleans.ToRealBoolean")
+}

--- a/src/main/scala/scala/slick/driver/DerbyDriver.scala
+++ b/src/main/scala/scala/slick/driver/DerbyDriver.scala
@@ -6,7 +6,7 @@ import scala.slick.ast._
 import scala.slick.jdbc.JdbcType
 import scala.slick.util.MacroSupport.macroSupportInterpolation
 import scala.slick.profile.{RelationalProfile, SqlProfile, Capability}
-import slick.compiler.CompilerState
+import scala.slick.compiler.{Phase, QueryCompiler, CompilerState}
 
 /**
  * Slick driver for Derby/JavaDB.
@@ -57,6 +57,7 @@ trait DerbyDriver extends JdbcDriver { driver =>
     - RelationalProfile.capabilities.zip
   )
 
+  override val compiler = QueryCompiler.relational + Phase.rewriteBooleans
   override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
   override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new TableDDLBuilder(table)
@@ -73,7 +74,6 @@ trait DerbyDriver extends JdbcDriver { driver =>
   class QueryBuilder(tree: Node, state: CompilerState) extends super.QueryBuilder(tree, state) {
     override protected val scalarFrom = Some("sysibm.sysdummy1")
     override protected val supportsTuples = false
-    override protected val useIntForBoolean = true
 
     override def expr(c: Node, skipParens: Boolean = false): Unit = c match {
       case a @ Library.Cast(ch @ _*) =>

--- a/src/main/scala/scala/slick/driver/SQLServerDriver.scala
+++ b/src/main/scala/scala/slick/driver/SQLServerDriver.scala
@@ -5,7 +5,7 @@ import scala.slick.ast._
 import scala.slick.jdbc.{PositionedResult, JdbcType}
 import scala.slick.util.MacroSupport.macroSupportInterpolation
 import scala.slick.profile.{SqlProfile, Capability}
-import scala.slick.compiler.CompilerState
+import scala.slick.compiler.{Phase, QueryCompiler, CompilerState}
 import java.sql.{Timestamp, Date, Time}
 
 /**
@@ -34,6 +34,7 @@ trait SQLServerDriver extends JdbcDriver { driver =>
     - SqlProfile.capabilities.sequence
   )
 
+  override val compiler = QueryCompiler.relational + Phase.rewriteBooleans
   override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
   override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder = new ColumnDDLBuilder(column)
@@ -50,7 +51,6 @@ trait SQLServerDriver extends JdbcDriver { driver =>
   class QueryBuilder(tree: Node, state: CompilerState) extends super.QueryBuilder(tree, state) with RowNumberPagination {
     override protected val supportsTuples = false
     override protected val concatOperator = Some("+")
-    override protected val useIntForBoolean = true
 
     override protected def buildSelectModifiers(c: Comprehension) {
       (c.fetch, c.offset) match {


### PR DESCRIPTION
For databases like Derby and SQL Server which have some special boolean
expressions but no first-class boolean type, Slick has always emulated
booleans with a numeric type. The conversion between these emulated
booleans and the real booleans in the codeGen phase, however, did not
work properly.

This change adds a new optional compiler phase "rewriteBooleans" that
can be added to the query compiler by a database driver. This phase
inserts conversions between real and fake booleans (in the form of
function calls) at the appropriate places and leaves the interpretation
of these special functions to the code generator. The default
implementation in JdbcStatementBuilderComponent should be suitable for
all databases that use some numeric type with values 1 and 0 for the
emulated booleans.

The useIntForBoolean flag and all associated logic in QueryBuilder are
no longer needed.

Fixes issue #88. Tests in RelationalTypeTest.testBoolean.

Review by @cvogt 
