### PR TITLE
Improve applicability of .run and .list 

### DIFF
--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/ExecutorTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/ExecutorTest.scala
@@ -1,0 +1,16 @@
+package scala.slick.test.jdbc
+
+import scala.slick.testutil._
+import scala.slick.testutil.TestDBs._
+import com.typesafe.slick.testkit.util.JdbcTestDB
+
+object ExecutorTest extends DBTestObject()
+class ExecutorTest(val tdb: JdbcTestDB) extends DBTest {
+  import tdb.profile.backend.Database.dynamicSession
+  import tdb.profile.simple._
+  def all[E](q: Query[_, E]) = {
+  	// static tests if the implicit conversions can be applied
+    q.list
+    q.run
+  }
+}

--- a/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
@@ -39,7 +39,6 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
       CompiledStatement(_, sres: SQLBuilder.Result, _),
       CompiledMapping(converter, _)) = tree
 
-    def selectStatement = getStatement
     protected def getStatement = sres.sql
     protected def setParam(param: P, st: PreparedStatement): Unit = sres.setter(new PositionedParameters(st), param)
     protected def extractValue(pr: PositionedResult): R = converter.read(pr).asInstanceOf[R]

--- a/src/main/scala/scala/slick/driver/JdbcProfile.scala
+++ b/src/main/scala/scala/slick/driver/JdbcProfile.scala
@@ -35,7 +35,7 @@ trait JdbcProfile extends SqlProfile with JdbcTableComponent
   final def buildSequenceSchemaDescription(seq: Sequence[_]): DDL = createSequenceDDLBuilder(seq).buildDDL
 
   trait LowPriorityImplicits {
-    implicit def queryToAppliedQueryInvoker[T, U](q: Query[T, _ <: U]): UnitQueryInvoker[U] = createUnitQueryInvoker[U](queryCompiler.run(q.toNode).tree)
+    implicit def queryToAppliedQueryInvoker[U](q: Query[_,U]): UnitQueryInvoker[U] = createUnitQueryInvoker[U](queryCompiler.run(q.toNode).tree)
     implicit def queryToUpdateInvoker[E, U](q: Query[E, U]): UpdateInvoker[U] = createUpdateInvoker(updateCompiler.run(q.toNode).tree, ())
   }
 

--- a/src/main/scala/scala/slick/profile/BasicProfile.scala
+++ b/src/main/scala/scala/slick/profile/BasicProfile.scala
@@ -41,15 +41,15 @@ trait BasicProfile extends BasicInvokerComponent with BasicExecutorComponent { d
     implicit val slickDriver: driver.type = driver
     implicit def ddlToDDLInvoker(d: SchemaDescription): DDLInvoker
 
-    implicit def queryToQueryExecutor[E, U](q: Query[E, U]): QueryExecutor[Seq[U]] = createQueryExecutor[Seq[U]](queryCompiler.run(q.toNode).tree, ())
-    implicit def shapedValueToQueryExecutor[T, U](u: ShapedValue[T, U]): QueryExecutor[Seq[U]] = createQueryExecutor[Seq[U]](queryCompiler.run(u.toNode).tree, ())
+    implicit def queryToQueryExecutor[U](q: Query[_, U]): QueryExecutor[Seq[U]] = createQueryExecutor[Seq[U]](queryCompiler.run(q.toNode).tree, ())
+    implicit def shapedValueToQueryExecutor[U](u: ShapedValue[_, U]): QueryExecutor[Seq[U]] = createQueryExecutor[Seq[U]](queryCompiler.run(u.toNode).tree, ())
     implicit def runnableCompiledToQueryExecutor[RU](c: RunnableCompiled[_, RU]): QueryExecutor[RU] = createQueryExecutor[RU](c.compiledQuery, c.param)
     // We can't use this direct way due to SI-3346
     def recordToQueryExecutor[M, R](q: M)(implicit shape: Shape[_ <: ShapeLevel.Flat, M, R, _]): QueryExecutor[R] = createQueryExecutor[R](queryCompiler.run(shape.toNode(q)).tree, ())
     implicit final def recordToUnshapedQueryExecutor[M <: Rep[_]](q: M): UnshapedQueryExecutor[M] = new UnshapedQueryExecutor[M](q)
 
     implicit def columnBaseToInsertInvoker[T](c: ColumnBase[T]) = createInsertInvoker[T](insertCompiler.run(c.toNode).tree)
-    implicit def shapedValueToInsertInvoker[T, U](u: ShapedValue[T, U]) = createInsertInvoker[U](insertCompiler.run(u.toNode).tree)
+    implicit def shapedValueToInsertInvoker[U](u: ShapedValue[_, U]) = createInsertInvoker[U](insertCompiler.run(u.toNode).tree)
     implicit def queryToInsertInvoker[U](q: Query[_, U]) = createInsertInvoker[U](insertCompiler.run(q.toNode).tree)
 
     // Work-around for SI-3346


### PR DESCRIPTION
(by not requiring knowledge about the packed type)

FYI: removed .selectStatement from Invoker (in favor of Executor) because of ambiguous implicits
