### PR TITLE
Make TableQuery extensible.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MapperTest.scala
@@ -25,8 +25,9 @@ class MapperTest extends TestkitTest[JdbcTestDB] {
         ({ case (f, l) => User(None, f, l) }, { u:User => Some((u.first, u.last)) })
       def asFoo = forUpdate <> ((u: User) => Foo(u), (f: Foo[User]) => Some(f.value))
     }
-    val users = TableQuery[Users]
-    val usersByID = users.findBy(_.id)
+    object users extends TableQuery(new Users(_)) {
+      val byID = this.findBy(_.id)
+    }
 
     users.ddl.create
     users.map(_.baseProjection).insert("Homer", "Simpson")
@@ -46,7 +47,7 @@ class MapperTest extends TestkitTest[JdbcTestDB] {
     assertTrue(Query(users.where(_.id === 1).exists).first)
 
     users.where(_.id between(1, 2)).foreach(println)
-    println("ID 3 -> " + usersByID(3).first)
+    println("ID 3 -> " + users.byID(3).first)
 
     assertEquals(
       Set(User(Some(1), "Homer", "Simpson"), User(Some(2), "Marge", "Simpson")),
@@ -58,7 +59,7 @@ class MapperTest extends TestkitTest[JdbcTestDB] {
     )
     assertEquals(
       User(Some(3), "Carl", "Carlson"),
-      usersByID(3).first
+      users.byID(3).first
     )
 
     val q1 = for {

--- a/src/main/scala/scala/slick/lifted/AbstractTable.scala
+++ b/src/main/scala/scala/slick/lifted/AbstractTable.scala
@@ -60,7 +60,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     * @param onDelete A `ForeignKeyAction`, default being `NoAction`.
     */
   def foreignKey[P, PU, TT <: AbstractTable[_], U]
-      (name: String, sourceColumns: P, targetTableQuery: TableQuery[TT, _])
+      (name: String, sourceColumns: P, targetTableQuery: TableQuery[TT])
       (targetColumns: TT => P, onUpdate: ForeignKeyAction = ForeignKeyAction.NoAction,
        onDelete: ForeignKeyAction = ForeignKeyAction.NoAction)(implicit unpack: Shape[_ <: ShapeLevel.Flat, TT, U, _], unpackp: Shape[_ <: ShapeLevel.Flat, P, PU, _]): ForeignKeyQuery[TT, U] = {
     val targetTable: TT = targetTableQuery.unpackable.value

--- a/src/main/scala/scala/slick/lifted/Aliases.scala
+++ b/src/main/scala/scala/slick/lifted/Aliases.scala
@@ -8,7 +8,7 @@ package lifted
 trait Aliases {
   type Query[+E, U] = lifted.Query[E, U]
   val Query = lifted.Query
-  type TableQuery[+E <: AbstractTable[_], U] = lifted.TableQuery[E, U]
+  type TableQuery[E <: AbstractTable[_]] = lifted.TableQuery[E]
   val TableQuery = lifted.TableQuery
   type Compiled[T] = lifted.Compiled[T]
   val Compiled = lifted.Compiled

--- a/src/main/scala/scala/slick/profile/RelationalProfile.scala
+++ b/src/main/scala/scala/slick/profile/RelationalProfile.scala
@@ -23,7 +23,7 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
     implicit def columnToOptionColumn[T : BaseTypedType](c: Column[T]): Column[Option[T]] = c.?
     implicit def valueToConstColumn[T : TypedType](v: T) = new LiteralColumn[T](v)
     implicit def columnToOrdered[T](c: Column[T]): ColumnOrdered[T] = c.asc
-    implicit def tableQueryToTableQueryExtensionMethods[T <: Table[_], U](q: TableQuery[T, U]) =
+    implicit def tableQueryToTableQueryExtensionMethods[T <: Table[_], U](q: Query[T, U] with TableQuery[T]) =
       new TableQueryExtensionMethods[T, U](q)
   }
 
@@ -35,14 +35,14 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
     type BaseColumnType[T] = driver.BaseColumnType[T]
   }
 
-  class TableQueryExtensionMethods[T <: Table[_], U](val q: TableQuery[T, U]) {
-    def ddl: SchemaDescription = buildTableSchemaDescription(q.unpackable.value)
+  class TableQueryExtensionMethods[T <: Table[_], U](val q: Query[T, U] with TableQuery[T]) {
+    def ddl: SchemaDescription = buildTableSchemaDescription(q.baseTableRow)
 
     /** Create a `Compiled` query which selects all rows where the specified
       * key matches the parameter value. */
     def findBy[P](f: (T => Column[P]))(implicit tm: TypedType[P]): CompiledFunction[Column[P] => Query[T, U], Column[P], P, Query[T, U], Seq[U]] = {
       import driver.Implicit._
-      Compiled { (p: Column[P]) => q.filter(table => Library.==.column[Boolean](f(table).toNode, p.toNode)) }
+      Compiled { (p: Column[P]) => (q: Query[T, U]).filter(table => Library.==.column[Boolean](f(table).toNode, p.toNode)) }
     }
   }
 }


### PR DESCRIPTION
This allows you to subclass it in an object instead of instantiating
a val, thus giving you a useful namespace for table-related static
features.

Coaxing type inference to do the right thing in the absence of the 2nd
(unpacked) type parameter of TableQuery required some refactoring but
in the end it looks good.

Test in MapperTest.testMappedEntity. Review by @cvogt 
