### PR TITLE
Only peek at the node type for logging.

### DIFF
--- a/src/main/scala/scala/slick/ast/Node.scala
+++ b/src/main/scala/scala/slick/ast/Node.scala
@@ -127,7 +127,7 @@ trait SimplyTypedNode extends Node {
 
 object Node extends Logging {
   private def logType(n: Node): Unit =
-    logger.debug("Assigned type "+n.nodeType+" to node "+n)
+    logger.debug("Assigned type "+n.nodePeekType+" to node "+n)
 }
 
 trait TypedNode extends Node with Typed {


### PR DESCRIPTION
This prevents "Trying to reassign node type" exceptions. Logging should
never affect the data being logged.

This is in #242 but we should get it into 2.0. Reviwe by @cvogt 
