### PR TITLE
Unforce forcing macro users to recompile by deleting them. Sbt seems to ...

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -168,14 +168,17 @@ object SlickBuild extends Build {
       // Workaround for sbt bug: Without a testGrouping for all test configs,
       // the wrong tests are run
       testGrouping in DocTest <<= definedTests in DocTest map partitionTests,
-      parallelExecution in Test := false,
-      compile in Test ~= { a =>
+      parallelExecution in Test := false
+      /*
+      // enable when working on Shapes
+      ,compile in Test ~= { a =>
         // Delete classes in "compile" packages after compiling. (Currently only scala.slick.test.compile.NestedShapeTest)
         // These are used for compile-time tests and should be recompiled every time.
         val products = a.relations.allProducts.toSeq ** new SimpleFileFilter(_.getParentFile.getName == "compile")
         IO.delete(products.get)
         a
       }
+      */
     ) ++ ifPublished(Seq(
       libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "test")
     ))


### PR DESCRIPTION
...track this correctly now.

review by @szeiger 
