### PR TITLE
Scala 2.11 compatibility

### DIFF
--- a/src/main/scala/scala/slick/direct/SlickBackend.scala
+++ b/src/main/scala/scala/slick/direct/SlickBackend.scala
@@ -364,8 +364,7 @@ class SlickBackend( val driver: JdbcDriver, mapper:Mapper ) extends QueryableBac
             op,
             components
         )
-        if definitions
-            .TupleClass
+        if (1 to 22).map(definitions.TupleClass)
             .filter(_ != NoSymbol)
             .map( _.companionSymbol.typeSignature.member( newTermName("apply") ) )
             .contains( op.symbol )


### PR DESCRIPTION
`Definitions#TupleClass` is no longer an `Array[Symbol]` in
Scala 2.11. But it does have a `.seq` method that returns
an `IndexedSeq[Symbol]`.

This change is compatible with 2.10 and 2.11.
