### PR TITLE
Allow UnshapedQueryExecutor to be extended by profiles.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -192,6 +192,10 @@ class MainTest extends TestkitTest[JdbcTestDB] { mainTest =>
     println("Updated "+updated2+" row(s)")
     assertEquals(1, updated2)
 
+    val q9 = users.length
+    assertEquals(4, q9.run)
+    println("Count statement: " + q9.selectStatement)
+
     for(t <- q1) println("User tuple: "+t)
   }
 }

--- a/src/main/scala/scala/slick/driver/JdbcExecutorComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcExecutorComponent.scala
@@ -5,12 +5,15 @@ import scala.slick.ast.Util._
 import scala.slick.ast.TypeUtil._
 import scala.slick.util.SQLBuilder
 import scala.slick.profile.SqlExecutorComponent
+import scala.slick.lifted.{Shape, ShapeLevel}
 
 trait JdbcExecutorComponent extends SqlExecutorComponent { driver: JdbcDriver =>
 
   type QueryExecutor[T] = QueryExecutorDef[T]
+  type UnshapedQueryExecutor[T] = UnshapedQueryExecutorDef[T]
 
   def createQueryExecutor[R](tree: Node, param: Any): QueryExecutor[R] = new QueryExecutorDef[R](tree, param)
+  def createUnshapedQueryExecutor[M](value: M): UnshapedQueryExecutor[M] = new UnshapedQueryExecutorDef[M](value)
 
   class QueryExecutorDef[R](tree: Node, param: Any) extends super.QueryExecutorDef[R] {
 
@@ -24,5 +27,10 @@ trait JdbcExecutorComponent extends SqlExecutorComponent { driver: JdbcDriver =>
       case First(rsm: ResultSetMapping) =>
         createQueryInvoker[Any, Any](rsm).first(param)
     }).asInstanceOf[R]
+  }
+
+  class UnshapedQueryExecutorDef[M](value: M) extends super.UnshapedQueryExecutorDef[M](value) {
+    @inline final def selectStatement[U](implicit shape: Shape[_ <: ShapeLevel.Flat, M, U, _], session: Backend#Session): String =
+      executor[U].selectStatement
   }
 }

--- a/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
@@ -13,8 +13,11 @@ trait MemoryQueryingProfile extends RelationalProfile { driver: MemoryQueryingDr
 
   type ColumnType[T] = ScalaType[T]
   type BaseColumnType[T] = ScalaType[T] with BaseTypedType[T]
+  type UnshapedQueryExecutor[R] = UnshapedQueryExecutorDef[R]
 
   val MappedColumnType = new MappedColumnTypeFactory
+
+  def createUnshapedQueryExecutor[M](value: M): UnshapedQueryExecutor[M] = new UnshapedQueryExecutorDef[M](value)
 
   class MappedColumnTypeFactory extends super.MappedColumnTypeFactory {
     def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T] =


### PR DESCRIPTION
We already allow this for the standard QueryExecutor. We need the same
for UnshapedQueryExecutor in order to add the "selectStatement"
method at the JdbcProfile level.

We also add an "executor" method that will compute the real (shaped)
executor for caching it in user code (analogous to the existing
"executor" field in QueryExecutor).

Test in MainTest. Fixes issue #548.

Review by @cvogt 
