### PR TITLE
Improve scaladoc output (src links, start page, pkg docs)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -101,7 +101,17 @@ object SlickBuild extends Build {
     settings = Project.defaultSettings ++ inConfig(config("macro"))(Defaults.configSettings) ++ sharedSettings ++ fmppSettings ++ site.settings ++ site.sphinxSupport() ++ extTarget("slick", None) ++ Seq(
       name := "Slick",
       description := "Scala Language-Integrated Connection Kit",
-      scalacOptions in (Compile, doc) <++= (version).map(v => Seq("-doc-title", "Slick", "-doc-version", v)),
+      scalacOptions in (Compile, doc) <++= (version,sourceDirectory in Compile).map((v,src) => Seq(
+        "-doc-title", "Slick",
+        "-doc-version", v,
+        "-doc-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
+        "-doc-root-content", "scaladoc-root.txt",
+        "-sourcepath", src.getPath, // needed for scaladoc to strip the location of the linked source path
+        "-doc-source-url", "https://github.com/slick/slick/blob/"+v+"/src/main€{FILE_PATH}.scala",
+        "-implicits",
+        "-diagrams", // requires graphviz
+        "-groups"
+      )),
       test := (), // suppress test status output
       testOnly :=  (),
       ivyConfigurations += config("macro").hide.extend(Compile),

--- a/scaladoc-root.txt
+++ b/scaladoc-root.txt
@@ -1,0 +1,66 @@
+<a style="float:right" href="https://github.com/slick/slick/blob/master/scaladoc-root.txt">edit this text on github</a>
+<img src="http://slick.typesafe.com/resources/images/slick-logo.png" alt="Slick logo" />
+<h2>Scala Language-Integrated Connection Kit</h2>
+This is the documentation for the <a href="http://slick.typesafe.com" target="_top">Slick</a> database library.
+Slick is a joint effort by <a href="http://www.typesafe.com" target="_top">Typesafe</a> and
+<a href="http://lamp.epfl.ch/" target="_top">LAMP, EPFL Lausanne</a>.
+
+Further documentation for Slick can be found on the
+<a href="http://slick.typesafe.com/docs/" target="_top">documentation pages</a>.
+
+
+<a href="scala/slick/package.html">To the slick package list...</a>
+
+<h3>Important places</h3>
+
+<h4>Type-safe query operators</h4>
+<ul>
+  <li><a href="scala/slick/lifted/Query.html">Query</a></li>
+  <li><a href="scala/slick/lifted/Column.html">Column</a></li>
+  <li><a href="scala/slick/lifted/NumericColumnExtensionMethods.html">Numeric</a></li>
+  <li><a href="scala/slick/lifted/BooleanColumnExtensionMethods.html">Boolean</a></li>
+  <li><a href="scala/slick/lifted/StringColumnExtensionMethods.html">String</a></li>
+  <li><a href="scala/slick/lifted/PlainColumnExtensionMethods.html">AnyVal / non-nullable</a></li>
+  <li><a href="scala/slick/lifted/OptionColumnExtensionMethods.html">Option / nullable</a></li>
+  <li><a href="scala/slick/lifted/Compiled$.html">Pre-Compiled queries (aka Parameters)</a></li>
+</ul>
+
+</h4>Plain SQL queries</h4>
+<ul>
+  <li><a href="scala/slick/jdbc/GetResult$.html">GetResult mapper</a></li>
+  <li><a href="scala/slick/jdbc/StaticQuery$.html">StaticQuery for raw strings</a></li>
+  <li><a href="scala/slick/jdbc/SQLInterpolation.html">String interpolation</a></li>
+</ul>
+
+<h4>Driver / Connection related</h4>
+<ul>
+  <li><a href="scala/slick/jdbc/JdbcBackend$DatabaseDef.html">Database: withSession / withTransaction</a></li>
+  <li><a href="scala/slick/jdbc/JdbcBackend$SessionDef.html">Session</a></li>
+  <li><a href="scala/slick/driver/package.html">Drivers</a></li>
+  <li><a href="scala/slick/driver/JdbcProfile.html">JdbcProfile</a></li>
+  <li><a href="scala/slick/driver/JdbcExecutorComponent$QueryExecutorDef.html">QueryExecutor</a></li>
+  <li><a href="scala/slick/jdbc/Invoker.html">Invoker</a></li>
+</ul>
+
+<h4>Mapping related</h4>
+<ul>
+  <li><a href="scala/slick/driver/JdbcTypesComponent$ImplicitColumnTypes.html">supported base types</a></li>
+  <li><a href="scala/slick/lifted/SimpleFunction$.html">SimpleFunction</a></li>
+</ul>
+
+<h4>Model / Table class related</h4>
+<ul>
+  <li><a href="scala/slick/lifted/TableQuery$.html">TableQuery</a></li>
+  <li><a href="scala/slick/profile/RelationalTableComponent$Table.html">Table</a></li>
+  <li><a href="scala/slick/ast/ColumnOption.html">ColumnOptions</a></li>
+  <li><a href="scala/slick/model/ForeignKeyAction$.html">ForeignKeyAction</a></li>
+  <li><a href="scala/slick/model/codegen/SourceCodeGenerator.html">Code generator</a></li>
+  <li><a href="scala/slick/model/package.html">Slick model</a></li>
+  <li><a href="scala/slick/jdbc/meta/package.html">JDBC Metadata api (including Slick model converter)</a></li>
+</ul>
+
+<h5>Other</h5>
+<ul>
+  <li><a href="scala/slick/collection/heterogenous/package.html">HLists</a></li>
+  <li><a href="scala/slick/memory/DistributedBackend.html">DistributedBackend</a></li>
+</ul>

--- a/src/main/scala/scala/slick/ast/package.scala
+++ b/src/main/scala/scala/slick/ast/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** Abstract Syntax Tree (AST) for representing queries during compilation */
+package object ast

--- a/src/main/scala/scala/slick/backend/package.scala
+++ b/src/main/scala/scala/slick/backend/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** Generic backend-related code */
+package object backend

--- a/src/main/scala/scala/slick/collection/package.scala
+++ b/src/main/scala/scala/slick/collection/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** HList implementation */
+package object collection

--- a/src/main/scala/scala/slick/compiler/package.scala
+++ b/src/main/scala/scala/slick/compiler/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** Slick AST to database query compiler */
+package object compiler

--- a/src/main/scala/scala/slick/direct/package.scala
+++ b/src/main/scala/scala/slick/direct/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** Direct embedding: limited, experimental query api prototype based on macros */
+package object direct

--- a/src/main/scala/scala/slick/driver/package.scala
+++ b/src/main/scala/scala/slick/driver/package.scala
@@ -1,5 +1,5 @@
 package scala.slick
-
+/** Specific database drivers */
 package object driver {
 
   @deprecated("Use JdbcProfile instead of ExtendedProfile", "1.1")

--- a/src/main/scala/scala/slick/jdbc/meta/package.scala
+++ b/src/main/scala/scala/slick/jdbc/meta/package.scala
@@ -3,6 +3,7 @@ import slick.util.SlickLogger
 import org.slf4j.LoggerFactory
 import scala.reflect.ClassTag
 import scala.slick.SlickException
+/** A wrapper around jdbc's meta data api and logic to create a Slick model from it. */
 package object meta{
   import scala.slick.driver.JdbcProfile
   import scala.slick.jdbc.JdbcBackend

--- a/src/main/scala/scala/slick/jdbc/package.scala
+++ b/src/main/scala/scala/slick/jdbc/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** JDBC related code */
+package object jdbc

--- a/src/main/scala/scala/slick/lifted/package.scala
+++ b/src/main/scala/scala/slick/lifted/package.scala
@@ -1,4 +1,5 @@
 package scala.slick
+/** Lifted embedding: Stable query api based on implicits and overloading lifting Scala code into Slick AST's */
 package object lifted{
   @deprecated("Use scala.slick.model.ForeignKeyAction instead","2.0.0")
   val  ForeignKeyAction = scala.slick.model.ForeignKeyAction

--- a/src/main/scala/scala/slick/memory/package.scala
+++ b/src/main/scala/scala/slick/memory/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** In-memory interpretation of queries and scheduler for distributed queries (i.e. combining several backends). */
+package object memory

--- a/src/main/scala/scala/slick/profile/package.scala
+++ b/src/main/scala/scala/slick/profile/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** Abstract base classes for driver/profile architecture */
+package object profile

--- a/src/main/scala/scala/slick/util/SimpleTypeName.scala
+++ b/src/main/scala/scala/slick/util/SimpleTypeName.scala
@@ -3,7 +3,7 @@ package scala.slick.util
 /**
  * Get a simple type name for a value.
  */
-
+@deprecated("Not needed anymore", "2.0.0")
 object SimpleTypeName {
   def forVal(v: Any) = v match {
     case null => "Null"

--- a/src/main/scala/scala/slick/util/package.scala
+++ b/src/main/scala/scala/slick/util/package.scala
@@ -1,0 +1,3 @@
+package scala.slick
+/** Helper code for various things. Tuples, Logging, SQL, ... */
+package object util


### PR DESCRIPTION
This adds a meaningful start page to our api docs, adds main packages summaries and enables scaladoc features: link to source, groups, diagram (the latter of which require graphviz and will issue warnings if it can't be found when creating api docs)

review by @szeiger  /cc: @jamesward 
