### PR TITLE
Rename Invoker.to to Invoker.buildColl and deprecate the old name.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
@@ -26,23 +26,23 @@ class InvokerTest extends TestkitTest[JdbcTestDB] {
     val r1t: List[Int] = r1
     assertEquals(List(1, 2, 3, 4, 5), r1)
 
-    val r2 = q.to[List]
+    val r2 = q.buildColl[List]
     val r2t: List[Int] = r2
     assertEquals(List(1, 2, 3, 4, 5), r2)
 
-    val r3 = q.to[Set]
+    val r3 = q.buildColl[Set]
     val r3t: Set[Int] = r3
     assertEquals(Set(3, 4, 2, 1, 5), r3)
 
-    val r4 = q.to[IndexedSeq]
+    val r4 = q.buildColl[IndexedSeq]
     val r4t: IndexedSeq[Int] = r4
     assertEquals(IndexedSeq(1, 2, 3, 4, 5), r4)
 
-    val r5 = q.to[ArrayBuffer]
+    val r5 = q.buildColl[ArrayBuffer]
     val r5t: ArrayBuffer[Int] = r5
     assertEquals(ArrayBuffer(1, 2, 3, 4, 5), r5)
 
-    val r6 = q.to[Array]
+    val r6 = q.buildColl[Array]
     val r6t: Array[Int] = r6
     assertEquals(Array(1, 2, 3, 4, 5).toList, r6.toList)
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -64,7 +64,7 @@ class JdbcTypeTest extends TestkitTest[JdbcTestDB] {
       ts insert (2, new SerialBlob(Array[Byte](4,5)))
 
       assertEquals(Set((1,"123"), (2,"45")),
-        ts.mapResult{ case (id, data) => (id, data.getBytes(1, data.length.toInt).mkString) }.to[Set])
+        ts.mapResult{ case (id, data) => (id, data.getBytes(1, data.length.toInt).mkString) }.buildColl[Set])
     }
   }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MutateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MutateTest.scala
@@ -61,6 +61,6 @@ class MutateTest extends TestkitTest[JdbcTestDB] {
 
     tsByA(1).mutate(_.delete)
 
-    assertEquals(Set((2,5), (2,6), (2,7), (2,8)), ts.to[Set])
+    assertEquals(Set((2,5), (2,6), (2,7), (2,8)), ts.buildColl[Set])
   }
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -102,7 +102,7 @@ class PlainSQLTest extends TestkitTest[JdbcTestDB] {
     } yield sqlu"insert into USERS values ($id, $name)".first).sum
     assertEquals(4, total)
 
-    assertEquals(Set(0,1,2,3), sql"select id from users".as[Int].to[Set])
+    assertEquals(Set(0,1,2,3), sql"select id from users".as[Int].buildColl[Set])
 
     val res = userForID(2).first
     println("User for ID 2: "+res)

--- a/src/main/scala/scala/slick/driver/JdbcExecutorComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcExecutorComponent.scala
@@ -20,7 +20,7 @@ trait JdbcExecutorComponent extends SqlExecutorComponent { driver: JdbcDriver =>
 
     def run(implicit session: Backend#Session): R = (tree match {
       case rsm: ResultSetMapping =>
-        createQueryInvoker[Any, Any](rsm).to(param)(session, rsm.nodeType.asCollectionType.cons.canBuildFrom)
+        createQueryInvoker[Any, Any](rsm).buildColl(param)(session, rsm.nodeType.asCollectionType.cons.canBuildFrom)
       case First(rsm: ResultSetMapping) =>
         createQueryInvoker[Any, Any](rsm).first(param)
     }).asInstanceOf[R]

--- a/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
@@ -233,12 +233,12 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
 
     protected def retManyBatch(st: Statement, values: Seq[U], updateCounts: Array[Int]) = {
       implicit val session: Backend#Session = null
-      buildKeysResult(st).to[Vector]
+      buildKeysResult(st).buildColl[Vector]
     }
 
     protected def retQuery(st: Statement, updateCount: Int) = {
       implicit val session: Backend#Session = null
-      buildKeysResult(st).to[Vector]
+      buildKeysResult(st).buildColl[Vector]
     }
 
     def into[R](f: (U, RU) => R) = createMappedKeysInsertInvoker[U, RU, R](tree, keys, f)
@@ -260,7 +260,7 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
 
     protected def retManyBatch(st: Statement, values: Seq[U], updateCounts: Array[Int]) = {
       implicit val session: Backend#Session = null
-      val ru = buildKeysResult(st).to[Vector]
+      val ru = buildKeysResult(st).buildColl[Vector]
       (values, ru).zipped.map(tr)
     }
   }

--- a/src/main/scala/scala/slick/jdbc/Invoker.scala
+++ b/src/main/scala/scala/slick/jdbc/Invoker.scala
@@ -73,8 +73,12 @@ trait Invoker[-P, +R] extends Function1[P, UnitInvoker[R]] { self =>
   /**
    * Execute the statement and return a fully materialized collection.
    */
-  final def to[C[_]](param: P)(implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] =
+  final def buildColl[C[_]](param: P)(implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] =
     build[C[R]](param)(session, canBuildFrom)
+
+  @deprecated("Use .buildColl instead of .to", "2.0.0")
+  final def to[C[_]](param: P)(implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] =
+    buildColl[C](param)
 
   /**
    * Execute the statement and call f for each converted row of the result set.
@@ -151,6 +155,9 @@ trait UnitInvoker[+R] extends Invoker[Unit, R] {
   final def firstOption(implicit session: JdbcBackend#Session): Option[R] = delegate.firstOption(appliedParameter)
   final def first()(implicit session: JdbcBackend#Session): R = delegate.first(appliedParameter)
   final def list()(implicit session: JdbcBackend#Session): List[R] = delegate.list(appliedParameter)
+  final def buildColl[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] =
+    delegate.buildColl(appliedParameter)
+  @deprecated("Use .buildColl instead of .to", "2.0.0")
   final def to[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] =
     delegate.to(appliedParameter)
   final def toMap[T, U](implicit session: JdbcBackend#Session, ev: R <:< (T, U)): Map[T, U] = delegate.toMap(appliedParameter)

--- a/src/sphinx/code/LiftedEmbedding.scala
+++ b/src/sphinx/code/LiftedEmbedding.scala
@@ -152,7 +152,7 @@ object LiftedEmbedding extends App{
     {
       //#invoker
       val l = q.list
-      val v = q.to[Vector]
+      val v = q.buildColl[Vector]
       val invoker = q.invoker
       val statement = q.selectStatement
       //#invoker


### PR DESCRIPTION
This will free up "to" for use in the new encoding of type constructors
into Query for Slick 2.1. We should be able to get rid of Invokers in
2.1 and do everything with the simple Executor.

Review by @cvogt 
