### PR TITLE
Nested Session

### DIFF
--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/DatabaseTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/DatabaseTest.scala
@@ -1,0 +1,73 @@
+package scala.slick.test.jdbc
+
+import org.junit.Test
+import org.junit.Assert._
+import scala.slick.testutil._
+import scala.slick.testutil.TestDBs._
+import com.typesafe.slick.testkit.util.JdbcTestDB
+
+object DatabaseTest extends DBTestObject(H2Mem, SQLiteMem, Postgres, MySQL, DerbyMem, HsqldbMem)
+
+class DatabaseTest(val tdb: JdbcTestDB) extends DBTest {
+  import tdb.profile.simple._
+
+  @Test def testNestedSession() {
+    db withNestedSession { s1:Session =>
+      db withNestedSession{ s2:Session =>
+        assertEquals(s1,s2)
+      }
+      //assert(s1.open) //TODO check if it's opened
+    }
+  }
+
+  @Test def testDynWithNestedSession() {
+    db withDynSession {
+      val s1 = Database.dynamicSession
+      db withNestedSession{ s2:Session =>
+        assertEquals(s1,s2)
+      }
+      //assert(s1.open) //TODO check if it's opened
+    }
+  }
+
+  @Test def testDynNestedSession() {
+    db withDynSession {
+      val s1 = Database.dynamicSession
+      db withNestedSession{
+        val s2 = Database.dynamicSession
+        assertEquals(s1,s2)
+      }
+      //assert(s1.open) //TODO check if it's opened
+    }
+  }
+
+  @Test def testNestedTransaction(){
+    db.withNestedTransaction{s1:Session =>
+      db.withNestedTransaction{s2:Session =>
+        assertEquals(s1, s2)
+      }
+      //assert(s1.open) //TODO check if it's opened
+    }
+  }
+
+  @Test def testDynWithNestedTransaction(){
+    db.withDynTransaction {
+      val s1 = Database.dynamicSession
+      db.withNestedTransaction{ s2:Session =>
+        assertEquals(s1, s2)
+      }
+      //assert(s1.open) //TODO check if it's opened
+    }
+  }
+
+  @Test def testDynNestedTransaction(){
+    db.withDynTransaction {
+      val s1 = Database.dynamicSession
+      db.withNestedTransaction{
+        val s2 = Database.dynamicSession
+        assertEquals(s1, s2)
+      }
+      //assert(s1.open) //TODO check if it's opened
+    }
+  }
+}


### PR DESCRIPTION
It's possible to use a same session without have to pass session in the argument across methods.
But it only works in same thread, because it uses ThreadLocal.

It checks if exists a session in DynamicVariable and give back or if not it creates a new one.

Example

``` scala
case class User(id:Long, email:Option[Email]=None)
case class Email(email:String)
object UserService {

  def getUser(id:Long):Option[User] = Repository.findUserById(id)

  def getEmail(id:Long):Option[Email] = Repository.findEmailByUserId(id)

  def getUserWithEmail(id:Long):Option[User] = {
    val user = Repository.findUserById(id)
    user.map{u =>
      val email = Repository.findEmailByUserId(u.id)
      u.copy(email = email)
  }

}

object Repository {

  def findUserById(id:Long):Option[User] = {
    db.withNestedSession{ implicit s=>
      Users.filter(_.id === id).firstOption
    }
  }

  def findEmailByUserId(userId:Long):Option[Email] = {
    db.withNestedSession{ implicit s=>
      Emails.filter(_.userId === userId).firstOption
    }
  }
}
```
