### PR TITLE
Workaround for HList compilation problems in Scala 2.10.3, 2.11.0-M7.

### DIFF
--- a/src/main/scala/scala/slick/collection/heterogenous/HList.scala
+++ b/src/main/scala/scala/slick/collection/heterogenous/HList.scala
@@ -131,7 +131,7 @@ final object HList {
     def copy(shapes: Seq[Shape[_, _, _, _]]) = new HListShape(shapes)
   }
   implicit def hnilShape[Level <: ShapeLevel] = new HListShape[Level, HNil.type, HNil.type, HNil.type](Nil)
-  implicit def hconsShape[Level <: ShapeLevel, M1, M2 <: HList, U1, U2 <: HList, P1, P2 <: HList](implicit s1: Shape[_ <: Level, M1, U1, P1], s2: HListShape[_ <: Level, M2, U2, P2]) =
+  implicit def hconsShape[Level <: ShapeLevel, L1 <: Level, L2 <: Level, M1, M2 <: HList, U1, U2 <: HList, P1, P2 <: HList](implicit s1: Shape[L1, M1, U1, P1], s2: HListShape[L2, M2, U2, P2]) =
     new HListShape[Level, M1 :: M2, U1 :: U2, P1 :: P2](s1 +: s2.shapes)
 }
 // Separate object for macro impl to avoid dependency of companion class on scala.reflect, see https://github.com/xeno-by/sbt-example-paradise210/issues/1#issuecomment-21021396


### PR DESCRIPTION
Changing hconsShape as per Paul's suggestion in https://issues.scala-lang.org/browse/SI-8146 avoids the spurious type errors and non-termination issues in the minimized test case:

```
  implicit def hconsShape[Level <: ShapeLevel, L1 <: Level, L2 <: Level, M1, M2 <: HList, U1, U2 <: HList, P1, P2 <: HList](implicit s1: Shape[L1, M1, U1, P1], s2: HListShape[L2, M2, U2, P2]) =
    new HListShape[Level, M1 :: M2, U1 :: U2, P1 :: P2](s1 +: s2.shapes)
```

Slick compiles and tests fine with these changes. I suggest we make this change for 2.0.0 without an additional RC. HList support is pretty much useless without it (so in the worst case it would stay useless for now; it was not present in 1.0 so there can't be any regression) and we cannot fix it in a binary compatible way in 2.0.1. HLists are still not very useful given the compiler performance in 2.10.3 but as Jason suggested there may be a way to fix that in 2.10.x.

Related to issue #577. Review by @cvogt 
