### PR TITLE
[Codegen] - add method to create Hlist type

### DIFF
--- a/src/main/scala/scala/slick/model/codegen/AbstractSourceCodeGenerator.scala
+++ b/src/main/scala/scala/slick/model/codegen/AbstractSourceCodeGenerator.scala
@@ -41,21 +41,26 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
     def extractor = s"${TableClass.elementType}.unapply"
 
     trait EntityTypeDef extends super.EntityTypeDef{
-      def code = 
-        if(classEnabled){
-          val args = columns.map(c=>
+      def code = {
+        val args = columns.map(c=>
             c.default.map( v =>
               s"${c.name}: ${c.exposedType}=$v"
             ).getOrElse(
               s"${c.name}: ${c.exposedType}"
             )
           ).mkString(", ")
+        if(classEnabled){
           val prns = (parents.take(1).map(" extends "+_) ++ parents.drop(1).map(" with "+_)).mkString("")
           s"""case class $name($args)$prns"""
-
         } else {
-          s"type $name = $types"
+          s"""
+type $name = $types
+def $name($args):$name = {
+  ${indent(columns.map(_.name).mkString(" :: "))} :: HNil
+}
+          """.trim
         }
+      }
     }
 
     trait PlainSqlMapperDef extends super.PlainSqlMapperDef{


### PR DESCRIPTION
it creates a method to create a Hlist Row

``` scala
type FooRow = T1 :: T2 :: T3 :: ... :: T22 :: T23 :: HNil
def FooRow(t1:T1, t2:T2, t3:T3, ..., t22:T22, t23:T23):FooRow = {
    t1 :: t2 :: t3 :: ... :: t22 :: t23 :: HNil
}
class Foo(tag:Tag) extends Table[FooRow](tag, "foo") {
    ...
}
lazy val Foo = TableQuer[Foo]
```

so as case class, you can use this method to create new 'FooRow'

``` scala
FooRow(p1, p2, p3, ..., p22, p23)
```

or 

``` scala
FooRow(
t1 = p1,
t2 = p2,
t3 = p3,
...
t22 = p22,
t23 = p23,
)
```
