### PR TITLE
Remove all special handling for products of size 1.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -252,4 +252,42 @@ class JdbcMapperTest extends TestkitTest[JdbcTestDB] {
       .map { case id :: b :: ss :: HNil => id :: ss :: (42 :: HNil) :: HNil }
     assertEquals(Vector(3 :: "bb" :: (42 :: HNil) :: HNil, 2 :: "cc" :: (42 :: HNil) :: HNil), q2.run)
   }
+
+  def testSingleElement {
+    import scala.slick.collection.heterogenous._
+    import scala.slick.collection.heterogenous.syntax._
+
+    class A(tag: Tag) extends Table[String](tag, "single_a") {
+      def b = column[String]("b")
+      def * = b
+    }
+    val as = TableQuery[A]
+    as.ddl.create
+    as += "Foo"
+    val ares: String = as.run.head
+    assertEquals("Foo", ares)
+    as.update("Foo")
+
+    class B(tag: Tag) extends Table[Tuple1[String]](tag, "single_b") {
+      def b = column[String]("b")
+      def * = Tuple1(b)
+    }
+    val bs = TableQuery[B]
+    bs.ddl.create
+    bs += Tuple1("Foo")
+    bs.update(Tuple1("Foo"))
+    val Tuple1(bres) = bs.run.head
+    assertEquals("Foo", bres)
+
+    class C(tag: Tag) extends Table[String :: HNil](tag, "single_c") {
+      def b = column[String]("b")
+      def * = b :: HNil
+    }
+    val cs = TableQuery[C]
+    cs.ddl.create
+    cs += ("Foo" :: HNil)
+    cs.update("Foo" :: HNil)
+    val cres :: HNil = cs.run.head
+    assertEquals("Foo", cres)
+  }
 }

--- a/src/main/scala/scala/slick/ast/Node.scala
+++ b/src/main/scala/scala/slick/ast/Node.scala
@@ -433,10 +433,7 @@ final case class Bind(generator: Symbol, from: Node, select: Node) extends Binar
   }
 }
 
-/** A table expansion. In phase expandTables, all tables are replaced by
-  * TableExpansions to capture the dual nature of tables as as single entity
-  * and a structure of columns. TableExpansions are removed again in phase
-  * rewritePaths. */
+/** A table together with its expansion into columns. */
 final case class TableExpansion(generator: Symbol, table: Node, columns: Node) extends BinaryNode with DefNode {
   type Self = TableExpansion
   def left = table

--- a/src/main/scala/scala/slick/compiler/CreateResultSetMapping.scala
+++ b/src/main/scala/scala/slick/compiler/CreateResultSetMapping.scala
@@ -70,9 +70,9 @@ class CreateResultSetMapping extends Phase {
       logger.debug("Creating mapping from "+tpe)
       tpe match {
         case ProductType(ch) =>
-          if(ch.length == 1) f(ch(0)) else ProductNode(ch.map(f))
+          ProductNode(ch.map(f))
         case StructType(ch) =>
-          if(ch.length == 1) f(ch(0)._2) else ProductNode(ch.map { case (_, t) => f(t) })
+          ProductNode(ch.map { case (_, t) => f(t) })
         case t: MappedScalaType =>
           TypeMapping(f(t.baseType), t.toBase, t.toMapped)
         case n @ NominalType(ts) => tables.get(ts) match {

--- a/src/main/scala/scala/slick/compiler/InsertCompiler.scala
+++ b/src/main/scala/scala/slick/compiler/InsertCompiler.scala
@@ -35,10 +35,7 @@ trait InsertCompiler extends Phase {
       case _: OptionApply | _: GetOrElse | _: ProductNode | _: TypeMapping => n.nodeMapChildren(tr, keepType = true)
       case te @ TableExpansion(_, _, expansion) =>
         setTable(te)
-        tr(expansion match {
-          case ProductNode(Seq(ch)) => ch
-          case n => n
-        })
+        tr(expansion)
       case sel @ Select(Ref(s), fs: FieldSymbol) if s == expansionRef =>
         cols += Select(tref, fs).nodeTyped(sel.nodeType)
         InsertColumn(Select(rref, ElementSymbol(cols.size)).nodeTyped(sel.nodeType), fs).nodeTyped(sel.nodeType)

--- a/src/main/scala/scala/slick/lifted/AbstractTable.scala
+++ b/src/main/scala/scala/slick/lifted/AbstractTable.scala
@@ -40,7 +40,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
   override def toNode = tableTag match {
     case _: BaseTag =>
       val sym = new AnonSymbol
-      TableExpansion(sym, tableNode, ProductNode(Vector(tableTag.taggedAs(List(sym)).*.toNode)).flatten)
+      TableExpansion(sym, tableNode, tableTag.taggedAs(List(sym)).*.toNode)
     case t: RefTag => Path(t.path)
   }
 

--- a/src/main/scala/scala/slick/lifted/Shape.scala
+++ b/src/main/scala/scala/slick/lifted/Shape.scala
@@ -164,15 +164,9 @@ abstract class ProductNodeShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] 
 
 /** Base class for ProductNodeShapes with a type mapping */
 abstract class MappedProductShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] extends ProductNodeShape[Level, C, M, U, P] {
-  lazy val unary = shapes.length == 1
   override def toNode(value: Mixed) = TypeMapping(super.toNode(value), toBase, toMapped)
-  def toBase(v: Any) = {
-    val it = getIterator(v.asInstanceOf[C])
-    if(unary) it.next() else new ProductWrapper(it.toIndexedSeq)
-  }
-  def toMapped(v: Any) = buildValue(
-    if(unary) Vector(v) else TupleSupport.buildIndexedSeq(v.asInstanceOf[Product])
-  )
+  def toBase(v: Any) = new ProductWrapper(getIterator(v.asInstanceOf[C]).toIndexedSeq)
+  def toMapped(v: Any) = buildValue(TupleSupport.buildIndexedSeq(v.asInstanceOf[Product]))
 }
 
 /** Base class for ProductNodeShapes with a type mapping to a type that extends scala.Product */

--- a/src/main/scala/scala/slick/lifted/ShapeLowPriority2.fm
+++ b/src/main/scala/scala/slick/lifted/ShapeLowPriority2.fm
@@ -1,6 +1,9 @@
 package scala.slick.lifted
 
 class ShapeLowPriority2 {
+  @inline
+  implicit final def tuple1Shape[Level <: ShapeLevel, M1, U1, P1](implicit u1: Shape[_ <: Level, M1, U1, P1]): Shape[Level, Tuple1[M1], Tuple1[U1], Tuple1[P1]] =
+    new TupleShape[Level, Tuple1[M1], Tuple1[U1], Tuple1[P1]](u1)
 <#list 2..22 as i>
   @inline
   implicit final def tuple${i}Shape[Level <: ShapeLevel, <#list 1..i as j>M${j}<#if i != j>,</#if></#list>, <#list 1..i as j>U${j}<#if i != j>,</#if></#list>, <#list 1..i as j>P${j}<#if i != j>,</#if></#list>](implicit <#list 1..i as j>u${j}: Shape[_ <: Level, M${j}, U${j}, P${j}]<#if i != j>, </#if></#list>): Shape[Level, (<#list 1..i as j>M${j}<#if i != j>,</#if></#list>), (<#list 1..i as j>U${j}<#if i != j>,</#if></#list>), (<#list 1..i as j>P${j}<#if i != j>,</#if></#list>)] =


### PR DESCRIPTION
The new query compiler can deal perfectly well with nested products,
so there is no more need for ugly hacks that fail for products of
size 1.

We can now also add a Shape for Tuple1 for completeness.

Fixes issue #658. Tests in JdbcMapperTest.testSingleElement. Review by @cvogt 
