### PR TITLE
Substitute correct versions numbers from the build into the docs

### DIFF
--- a/src/sphinx/extensions.rst
+++ b/src/sphinx/extensions.rst
@@ -10,9 +10,9 @@ of the `Typesafe Subscription Agreement`_ (PDF).
 
 If you are using sbt_, you can add *slick-extensions* and the Typesafe
 repository (which contains the required artifacts) to your build definition
-like this::
+like this:
 
-  // Use the right Slick version here:
-  libraryDependencies += "com.typesafe.slick" %% "slick-extensions" % "2.0.0"
+.. parsed-literal::
+  libraryDependencies += "com.typesafe.slick" %% "slick-extensions" % "|release|"
 
   resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/maven-releases/"

--- a/src/sphinx/gettingstarted.rst
+++ b/src/sphinx/gettingstarted.rst
@@ -7,17 +7,19 @@ template.  To learn how to integrate Slick with Play Framework check out the
 `Play Slick with Typesafe IDs <http://typesafe.com/activator/template/play-slick-advanced>`_ template.
 
 To include Slick into an existing project use the library published on Maven Central.  For sbt projects add the 
-following to your ``libraryDependencies``::
+following to your ``libraryDependencies``:
 
-  "com.typesafe.slick" %% "slick" % "2.0.0",
+.. parsed-literal::
+  "com.typesafe.slick" %% "slick" % "|release|",
   "org.slf4j" % "slf4j-nop" % "1.6.4"
 
-For Maven projects add the following to your ``<dependencies>``::
+For Maven projects add the following to your ``<dependencies>``:
 
+.. parsed-literal::
   <dependency>
     <groupId>com.typesafe.slick</groupId>
     <artifactId>slick_2.10</artifactId>
-    <version>1.0.1</version>
+    <version>\ |release|\ </version>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>

--- a/src/sphinx/testkit.rst
+++ b/src/sphinx/testkit.rst
@@ -17,11 +17,12 @@ Scaffolding
 Its ``build.sbt`` file is straight-forward. Apart from the usual name and
 version settings, it adds the dependencies for Slick, the TestKit,
 junit-interface, Logback and the PostgreSQL JDBC driver, and it sets some
-options for the test runs::
+options for the test runs:
 
+.. parsed-literal::
   libraryDependencies ++= Seq(
-    "com.typesafe.slick" %% "slick" % "2.0.0-RC1",
-    "com.typesafe.slick" %% "slick-testkit" % "2.0.0-RC1" % "test",
+    "com.typesafe.slick" %% "slick" % "|release|",
+    "com.typesafe.slick" %% "slick-testkit" % "|release|" % "test",
     "com.novocode" % "junit-interface" % "0.10" % "test",
     "ch.qos.logback" % "logback-classic" % "0.9.28" % "test",
     "postgresql" % "postgresql" % "9.1-901.jdbc4" % "test"

--- a/src/sphinx/theme/static/slick.css_t
+++ b/src/sphinx/theme/static/slick.css_t
@@ -79,3 +79,7 @@ div.sidebar input[type="text"] {
   font-style: normal;
   color: #999;
 }
+pre.literal-block {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}


### PR DESCRIPTION
We can use parsed-literal blocks in reST for code blocks that need
to contain the version/release number from the build. Unfortunately,
there is no way to keep syntax highlighting in Sphinx for these blocks
but it is a minor loss compared to the benefit of always building the
docs with the correct version numbers without manual intervention.

Fixes issues #642, #654, #632. Review by @cvogt.
