### PR TITLE
Expand Table refs into columns in "returning" projections.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -57,6 +57,7 @@ class InsertTest extends TestkitTest[JdbcTestDB] {
     def ins1 = as.map(a => (a.s1, a.s2)) returning as.map(_.id)
     def ins2 = as.map(a => (a.s1, a.s2)) returning as.map(a => (a.id, a.s1))
     def ins3 = as.map(a => (a.s1, a.s2)) returning as.map(_.id) into ((v, i) => (i, v._1, v._2))
+    def ins4 = as.map(a => (a.s1, a.s2)) returning as.map(a => a)
 
     as.ddl.create
 
@@ -78,6 +79,11 @@ class InsertTest extends TestkitTest[JdbcTestDB] {
 
       val id4 = ins3.insert("i", "j")
       assertEquals((5, "i", "j"), id4)
+
+      ifCap(jcap.returnInsertOther) {
+        val id5: (Int, String, String) = ins4.insert("k", "l")
+        assertEquals((6, "k", "l"), id5)
+      }
     }
   }
 

--- a/src/main/scala/scala/slick/compiler/InsertCompiler.scala
+++ b/src/main/scala/scala/slick/compiler/InsertCompiler.scala
@@ -19,16 +19,15 @@ trait InsertCompiler extends Phase {
     val tref = Ref(gen)
     val rref = Ref(rgen)
 
-    var table: TableNode = null
+    var tableExpansion: TableExpansion = null
     var expansionRef: Symbol = null
     val cols = new ArrayBuffer[Select]
     def setTable(te: TableExpansion) {
-      val t = te.table.asInstanceOf[TableNode]
-      if(table eq null) {
-        table = t
+      if(tableExpansion eq null) {
+        tableExpansion = te
         expansionRef = te.generator
       }
-      else if(table ne t) throw new SlickException("Cannot insert into more than one table at once")
+      else if(tableExpansion.table ne te.table) throw new SlickException("Cannot insert into more than one table at once")
     }
 
     def tr(n: Node): Node = n match {
@@ -39,14 +38,16 @@ trait InsertCompiler extends Phase {
       case sel @ Select(Ref(s), fs: FieldSymbol) if s == expansionRef =>
         cols += Select(tref, fs).nodeTyped(sel.nodeType)
         InsertColumn(Select(rref, ElementSymbol(cols.size)).nodeTyped(sel.nodeType), fs).nodeTyped(sel.nodeType)
+      case Ref(s) if s == expansionRef =>
+        tr(tableExpansion.columns)
       case Bind(gen, te @ TableExpansion(_, t: TableNode, _), Pure(sel, _)) =>
         setTable(te)
         tr(sel.replace({ case Ref(s) if s == gen => Ref(expansionRef) }, keepType = true))
       case _ => throw new SlickException("Cannot use node "+n+" for inserting data")
     }
     val tree2 = tr(tree)
-    if(table eq null) throw new SlickException("No table to insert into")
-    val ins = Insert(gen, table, tree2, ProductNode(cols)).nodeWithComputedType(SymbolScope.empty, typeChildren = false, retype = true)
+    if(tableExpansion eq null) throw new SlickException("No table to insert into")
+    val ins = Insert(gen, tableExpansion.table, tree2, ProductNode(cols)).nodeWithComputedType(SymbolScope.empty, typeChildren = false, retype = true)
     logger.debug("Insert node:", ins)
 
     ResultSetMapping(rgen, ins, createMapping(ins)).nodeTyped(


### PR DESCRIPTION
Fixes issue #644. Test in InsertTest.testReturning. Review by @cvogt 
