### PR TITLE
Implement casts for more basic data types in QueryInterpreter.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -144,6 +144,14 @@ class AggregateTest extends TestkitTest[RelationalTestDB] {
     assertEquals(res9, q9b.run.toSet)
     val q9c = ts.map(x => x).groupBy(x => x).map(_._1)
     assertEquals(res9, q9c.run.toSet)
+
+    println("=========================================================== q10")
+    val q10 = (for {
+      m <- ts
+    } yield m) groupBy (_.a) map {
+      case (id, data) => (id, data.map(_.b.asColumnOf[Option[Double]]).max)
+    }
+    assertEquals(Set((2,Some(5.0)), (1,Some(3.0)), (3,Some(9.0))), q10.run.toSet)
   }
 
   def testIntLength {

--- a/src/main/scala/scala/slick/memory/QueryInterpreter.scala
+++ b/src/main/scala/scala/slick/memory/QueryInterpreter.scala
@@ -305,6 +305,11 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         case (_, ScalaBaseType.stringType) => v.toString
         case (_, ScalaBaseType.intType) => v.toString.toInt
         case (_, ScalaBaseType.longType) => v.toString.toLong
+        case (_, ScalaBaseType.byteType) => v.toString.toByte
+        case (_, ScalaBaseType.shortType) => v.toString.toShort
+        case (_, ScalaBaseType.doubleType) => v.toString.toDouble
+        case (_, ScalaBaseType.floatType) => v.toString.toFloat
+        case (_, ScalaBaseType.bigDecimalType) => BigDecimal(v.toString)
       }
     case Library.Ceiling =>
       val t = args(0)._1.asInstanceOf[ScalaNumericType[Any]]


### PR DESCRIPTION
Fixes issue #664. Test in AggregateTest.testGroupBy. Review by @cvogt 
