### PR TITLE
Binary compatibility fixes for 2.0.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-script: sbt -Dslick.testkit.dbprops=test-dbs/databases.travis.properties test doctest:test
+script: sbt -Dslick.testkit.dbprops=test-dbs/databases.travis.properties test doctest:test mimaReportBinaryIssues
 jdk:
   - openjdk6
 notifications:

--- a/src/main/scala/scala/slick/ast/Type.scala
+++ b/src/main/scala/scala/slick/ast/Type.scala
@@ -108,6 +108,9 @@ final class MappedScalaType(val baseType: Type, _toBase: Any => Any, _toMapped: 
   override def select(sym: Symbol) = baseType.select(sym)
 }
 
+@deprecated("Use UnassignedType or UnassignedStructuralType", "2.0.1")
+final case object NoType extends AtomicType
+
 /** The standard type for freshly constructed nodes without an explicit type. */
 final case object UnassignedType extends AtomicType
 

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -343,7 +343,7 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
     final case class StarAnd(child: Node) extends UnaryNode with SimplyTypedNode {
       type Self = StarAnd
       protected[this] def nodeRebuild(child: Node) = StarAnd(child)
-      protected def buildType = UnassignedType
+      protected def buildType = NoType
     }
 
     override def expr(c: Node, skipParens: Boolean = false): Unit = c match {

--- a/src/main/scala/scala/slick/lifted/Shape.scala
+++ b/src/main/scala/scala/slick/lifted/Shape.scala
@@ -165,7 +165,9 @@ abstract class ProductNodeShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] 
 /** Base class for ProductNodeShapes with a type mapping */
 abstract class MappedProductShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] extends ProductNodeShape[Level, C, M, U, P] {
   override def toNode(value: Mixed) = TypeMapping(super.toNode(value), toBase, toMapped)
-  def toBase(v: Any) = new ProductWrapper(getIterator(v.asInstanceOf[C]).toIndexedSeq)
+  @deprecated("No longer needed", "2.0.1")
+  lazy val unary = shapes.length == 1
+  def toBase(v: Any): AnyRef = new ProductWrapper(getIterator(v.asInstanceOf[C]).toIndexedSeq)
   def toMapped(v: Any) = buildValue(TupleSupport.buildIndexedSeq(v.asInstanceOf[Product]))
 }
 

--- a/src/main/scala/scala/slick/memory/QueryInterpreter.scala
+++ b/src/main/scala/scala/slick/memory/QueryInterpreter.scala
@@ -378,6 +378,15 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
     else Some(it.reduceLeft { (z, b) => f(z, b) })
   }
 
+  @deprecated("Use reduceOptionIt instead", "2.0.1")
+  def foldOptionIt(it: Iterator[Any], opt: Boolean, zero: Any, f: (Any, Any) => Any): Option[Any] = {
+    if(!it.hasNext) None
+    else if(opt) it.foldLeft(Some(zero): Option[Any]) { (z, b) =>
+      for(z <- z; b <- b.asInstanceOf[Option[Any]]) yield f(z, b)
+    }
+    else Some(it.foldLeft(zero) { (z, b) => f(z, b) })
+  }
+
   def createNullRow(tpe: Type): Any = tpe match {
     case t: ScalaType[_] => if(t.nullable) None else null
     case StructType(el) =>


### PR DESCRIPTION
These are the remaining changes on top of 2.0-no-bin-compat to provide
binary compatibility with Slick 2.0.0. We also enable MiMa in the Travis
CI build to check this automatically for the 2.0 branch from now on.

Review by @cvogt 
