### PR TITLE
Reuse "simple" object for "Implicit" in driver implementations.

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcProfile.scala
+++ b/src/main/scala/scala/slick/driver/JdbcProfile.scala
@@ -21,8 +21,8 @@ trait JdbcProfile extends SqlProfile with JdbcTableComponent
   type Backend = JdbcBackend
   val backend: Backend = JdbcBackend
   val compiler = QueryCompiler.relational
-  val Implicit: Implicits = new Implicits {}
   val simple: SimpleQL with Implicits = new SimpleQL with Implicits {}
+  lazy val Implicit: Implicits = simple
   type ColumnType[T] = JdbcType[T]
   type BaseColumnType[T] = JdbcType[T] with BaseTypedType[T]
   val columnTypes = new JdbcTypes

--- a/src/main/scala/scala/slick/memory/DistributedProfile.scala
+++ b/src/main/scala/scala/slick/memory/DistributedProfile.scala
@@ -15,8 +15,8 @@ trait DistributedProfile extends MemoryQueryingProfile { driver: DistributedDriv
   type Backend = DistributedBackend
   type QueryExecutor[R] = QueryExecutorDef[R]
   val backend: Backend = DistributedBackend
-  val Implicit: Implicits = new Implicits {}
   val simple: SimpleQL = new SimpleQL {}
+  val Implicit: Implicits = simple
 
   lazy val queryCompiler =
     QueryCompiler.standard.addAfter(new Distribute, Phase.assignUniqueSymbols) + new MemoryCodeGen

--- a/src/main/scala/scala/slick/memory/MemoryProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryProfile.scala
@@ -14,9 +14,9 @@ trait MemoryProfile extends MemoryQueryingProfile { driver: MemoryDriver =>
   type InsertInvoker[T] = InsertInvokerDef[T]
   type QueryExecutor[R] = QueryExecutorDef[R]
   type Backend = HeapBackend
-  val Implicit: Implicits = new Implicits {}
   val backend: Backend = HeapBackend
   val simple: SimpleQL = new SimpleQL {}
+  val Implicit: Implicits = simple
 
   val compiler = QueryCompiler.standard
   lazy val queryCompiler = compiler + new MemoryCodeGen

--- a/src/main/scala/scala/slick/profile/BasicProfile.scala
+++ b/src/main/scala/scala/slick/profile/BasicProfile.scala
@@ -29,13 +29,15 @@ trait BasicProfile extends BasicInvokerComponent with BasicExecutorComponent { d
     def ++(other: SchemaDescription): SchemaDescription
   }
 
-  val Implicit: Implicits
-
   /** A collection of values for using the query language with a single import
     * statement. This provides the driver's implicits, the Database and
     * Session objects for DB connections, and commonly used query language
     * types and objects. */
   val simple: SimpleQL
+
+  /** The implicit values and conversions provided by this driver.
+    * This is a subset of ``simple``. */
+  val Implicit: Implicits
 
   trait Implicits extends ExtensionMethodConversions {
     implicit val slickDriver: driver.type = driver


### PR DESCRIPTION
"Implicit" contains a subset of "simple", so we can just cast the
same object to the desired type instead of creating a separate one.

This was suggested in some ticket and fell between the cracks after I implemented it last November. Review by @cvogt 
