### PR TITLE
Add capability for arbitrary casts (which are not supported in Access)

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -145,13 +145,15 @@ class AggregateTest extends TestkitTest[RelationalTestDB] {
     val q9c = ts.map(x => x).groupBy(x => x).map(_._1)
     assertEquals(res9, q9c.run.toSet)
 
-    println("=========================================================== q10")
-    val q10 = (for {
-      m <- ts
-    } yield m) groupBy (_.a) map {
-      case (id, data) => (id, data.map(_.b.asColumnOf[Option[Double]]).max)
+    ifCap(rcap.arbitraryCasts){
+      println("=========================================================== q10")
+      val q10 = (for {
+        m <- ts
+      } yield m) groupBy (_.a) map {
+        case (id, data) => (id, data.map(_.b.asColumnOf[Option[Double]]).max)
+      }
+      assertEquals(Set((2,Some(5.0)), (1,Some(3.0)), (3,Some(9.0))), q10.run.toSet)
     }
-    assertEquals(Set((2,Some(5.0)), (1,Some(3.0)), (3,Some(9.0))), q10.run.toSet)
   }
 
   def testIntLength {

--- a/src/main/scala/scala/slick/driver/AccessDriver.scala
+++ b/src/main/scala/scala/slick/driver/AccessDriver.scala
@@ -65,6 +65,7 @@ import java.sql.{Blob, Clob, Date, Time, Timestamp, SQLException}
 trait AccessDriver extends JdbcDriver { driver =>
 
   override protected def computeCapabilities: Set[Capability] = (super.computeCapabilities
+    - RelationalProfile.capabilities.arbitraryCasts
     - RelationalProfile.capabilities.columnDefaults
     - RelationalProfile.capabilities.foreignKeyActions
     - RelationalProfile.capabilities.functionDatabase

--- a/src/main/scala/scala/slick/profile/RelationalProfile.scala
+++ b/src/main/scala/scala/slick/profile/RelationalProfile.scala
@@ -51,6 +51,8 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
 
 object RelationalProfile {
   object capabilities {
+    /** Supports casts for all supported types (not only integer, long, varchar) */
+    val arbitraryCasts = Capability("relational.arbitraryCasts")
     /** Supports default values in column definitions */
     val columnDefaults = Capability("relational.columnDefaults")
     /** Supports foreignKeyActions */
@@ -90,7 +92,7 @@ object RelationalProfile {
     val other = Capability("relational.other")
 
     /** All relational capabilities */
-    val all = Set(other, columnDefaults, foreignKeyActions, functionDatabase,
+    val all = Set(other, arbitraryCasts, columnDefaults, foreignKeyActions, functionDatabase,
       functionUser, joinFull, joinRight, likeEscape, pagingDrop, pagingNested,
       pagingPreciseTake, setByteArrayNull, typeBigDecimal, typeBlob, typeLong,
       zip)


### PR DESCRIPTION
avoids a `SlickException("Cannot represent cast to type "double" in Access SQL")`
review by @szeiger 
