### PR TITLE
Add documentation for `into` method

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
@@ -239,7 +239,11 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
       implicit val session: Backend#Session = null
       buildKeysResult(st).buildColl[Vector]
     }
-
+    /**
+      * Specifies a mapping from inserted values and generated keys to a desired value.
+      * @param f Function that maps inserted values and generated keys to a desired value.
+      * @tparam R target type of the mapping
+      */
     def into[R](f: (U, RU) => R) = createMappedKeysInsertInvoker[U, RU, R](tree, keys, f)
   }
 

--- a/src/sphinx/code/LiftedEmbedding.scala
+++ b/src/sphinx/code/LiftedEmbedding.scala
@@ -310,6 +310,14 @@ object LiftedEmbedding extends App {
     //#insert3
     println((users returning users.map(_.id)).insertStatement)
 
+    //#insert3b
+    val userWithId =
+      (users returning users.map(_.id)
+             into ((user,id) => user.copy(id=Some(id)))
+      ) += User(None, "Stefan", "Zeiger")
+    //#insert3b
+    println(userWithId)
+
     //#insert4
     class Users2(tag: Tag) extends Table[(Int, String)](tag, "users2") {
       def id = column[Int]("id", O.PrimaryKey)

--- a/src/sphinx/queries.rst
+++ b/src/sphinx/queries.rst
@@ -192,6 +192,12 @@ which must be the table's auto-incrementing primary key. If you ask for
 other columns a ``SlickException`` is thrown at runtime (unless the database
 actually supports it).
 
+You can follow the ``returning`` method with the ``into`` method to map
+the inserted values and the generated keys (specified in returning) to a desired value.
+Here is an example of using this feature to return an object with an updated id:
+
+.. includecode:: code/LiftedEmbedding.scala#insert3b
+
 Instead of inserting data from the client side you can also insert data
 created by a ``Query`` or a scalar expression that is executed in the
 database server:


### PR DESCRIPTION
review by @szeiger 

I suggest we still include this in 2.0.1 final.
