### PR TITLE
Add breaking test case for Query(this) and join

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -20,6 +20,7 @@ class JoinTest extends TestkitTest[RelationalTestDB] {
       def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
       def title = column[String]("title")
       def category = column[Int]("category")
+      def withCategory = Query(this) join categories
       def * = (id, title, category)
     }
     val posts = TableQuery[Posts]
@@ -82,6 +83,8 @@ class JoinTest extends TestkitTest[RelationalTestDB] {
       q4.run.foreach(x => println("  "+x))
       assertEquals(List((1,0), (2,1), (3,2), (4,3), (5,2)), q4.map(p => (p._1, p._2)).run)
     }
+
+    posts.flatMap(_.withCategory).run
   }
 
   def testZip = ifCap(rcap.zip) {


### PR DESCRIPTION
This produces invalid SQL

```
select s4.s19, s4.s20, s4.s21, s5."id", s5."name" from "posts_j" s38,
(select s38."id" as s19, s38."title" as s20, s38."category" as s21) s4
inner join (select s40."id" as "id", s40."name" as "name" from "cat_j" s40) s5
```

and leads to

```
[error] Test com.typesafe.slick.testkit.tests.JoinTest.testJoin[h2mem] failed: org.h2.jdbc.JdbcSQLException: Column "X7.id" not found; SQL statement:
[error] CREATE FORCE VIEW PUBLIC._16 AS
[error] SELECT
[error]     X7."id" AS X3,
[error]     X7."title" AS X4,
[error]     X7."category" AS X5
[error] FROM SYSTEM_RANGE(1, 1) [42122-170]
[error]     at org.h2.message.DbException.getJdbcSQLException(DbException.java:329)
[error]     at org.h2.message.DbException.get(DbException.java:169)
[error]     at org.h2.message.DbException.get(DbException.java:146)
[error]     at org.h2.expression.ExpressionColumn.optimize(ExpressionColumn.java:141)
[error]     at org.h2.expression.Alias.optimize(Alias.java:47)
[error]     at org.h2.command.dml.Select.prepare(Select.java:799)
[error]     at org.h2.command.Parser.prepare(Parser.java:202)
[error]     at org.h2.engine.Session.prepare(Session.java:387)
[error]     at org.h2.engine.Session.prepare(Session.java:374)
[error]     at org.h2.table.TableView.compileViewQuery(TableView.java:100)
[error]     at org.h2.table.TableView.initColumnsAndTables(TableView.java:145)
[error]     at org.h2.table.TableView.init(TableView.java:96)
[error]     at org.h2.table.TableView.this(TableView.java:62)
[error]     at org.h2.table.TableView.createTempView(TableView.java:421)
[error]     at org.h2.command.Parser.readTableFilter(Parser.java:1036)
[error]     at org.h2.command.Parser.parseSelectSimpleFromPart(Parser.java:1689)
[error]     at org.h2.command.Parser.parseSelectSimple(Parser.java:1796)
[error]     at org.h2.command.Parser.parseSelectSub(Parser.java:1683)
[error]     at org.h2.command.Parser.parseSelectUnion(Parser.java:1526)
[error]     at org.h2.command.Parser.parseSelect(Parser.java:1514)
[error]     at org.h2.command.Parser.parsePrepared(Parser.java:404)
[error]     at org.h2.command.Parser.parse(Parser.java:278)
[error]     at org.h2.command.Parser.parse(Parser.java:250)
[error]     at org.h2.command.Parser.prepareCommand(Parser.java:217)
[error]     at org.h2.engine.Session.prepareLocal(Session.java:414)
[error]     at org.h2.engine.Session.prepareCommand(Session.java:363)
[error]     at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1116)
[error]     at org.h2.jdbc.JdbcPreparedStatement.this(JdbcPreparedStatement.java:74)
[error]     at org.h2.jdbc.JdbcConnection.prepareStatement(JdbcConnection.java:629)
[error]     at scala.slick.jdbc.JdbcBackend$SessionDef$class.prepareStatement(JdbcBackend.scala:123)
[error]     at scala.slick.jdbc.JdbcBackend$BaseSession.prepareStatement(JdbcBackend.scala:297)
[error]     at scala.slick.jdbc.StatementInvoker.results(StatementInvoker.scala:28)
[error]     at scala.slick.jdbc.StatementInvoker.iteratorTo(StatementInvoker.scala:16)
[error]     at scala.slick.jdbc.Invoker$class.foreach(Invoker.scala:89)
[error]     at scala.slick.jdbc.StatementInvoker.foreach(StatementInvoker.scala:9)
[error]     at scala.slick.jdbc.Invoker$class.build(Invoker.scala:65)
[error]     at scala.slick.jdbc.StatementInvoker.build(StatementInvoker.scala:9)
[error]     at scala.slick.jdbc.Invoker$class.buildColl(Invoker.scala:73)
[error]     at scala.slick.jdbc.StatementInvoker.buildColl(StatementInvoker.scala:9)
[error]     at scala.slick.driver.JdbcExecutorComponent$QueryExecutorDef.run(JdbcExecutorComponent.scala:26)
[error]     at scala.slick.driver.JdbcExecutorComponent$QueryExecutorDef.run(JdbcExecutorComponent.scala:18)
[error]     at com.typesafe.slick.testkit.tests.JoinTest.testJoin(JoinTest.scala:87)
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
[error]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
[error]     at java.lang.reflect.Method.invoke(Method.java:597)
[error]     at com.typesafe.slick.testkit.util.Testkit$$anonfun$runChildren$2.apply(Testkit.scala:86)
[error]     at com.typesafe.slick.testkit.util.Testkit$$anonfun$runChildren$2.apply(Testkit.scala:77)
[error]     at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:772)
[error]     at scala.collection.Iterator$class.foreach(Iterator.scala:727)
[error]     at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
[error]     at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
[error]     at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
[error]     at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:771)
[error]     at com.typesafe.slick.testkit.util.Testkit.runChildren(Testkit.scala:77)
[error]     at com.typesafe.slick.testkit.util.SimpleParentRunner.run(SimpleParentRunner.scala:56)
[error]     ...
```
