### PR TITLE
Prevent "no-symbol does not have an owner" when using MappedTo.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
@@ -83,6 +83,17 @@ class RelationalMapperTest extends TestkitTest[RelationalTestDB] {
     assertEquals(Set((MyMappedID(1), 2), (MyMappedID(3), 4)), ts.run.toSet)
     assertEquals(Set((MyMappedID(1), 2)), ts.filter(_.id === MyMappedID(1)).run.toSet)
   }
+
+  def mappedToMacroCompilerBug {
+    case class MyId(val value: Int) extends MappedTo[Int]
+
+    class MyTable(tag: Tag) extends Table[MyId](tag, "table") {
+      def * = ???
+    }
+
+    implicitly[Shape[_ <: ShapeLevel.Flat, MyTable, _, _]]
+    TableQuery(new MyTable(_)).map(identity)
+  }
 }
 
 case class MyMappedID(value: Int) extends AnyVal with scala.slick.lifted.MappedTo[Int]

--- a/src/main/scala/scala/slick/lifted/MappedTo.scala
+++ b/src/main/scala/scala/slick/lifted/MappedTo.scala
@@ -18,6 +18,8 @@ object MappedToBase {
 
   def mappedToIsomorphismMacroImpl[E <: MappedToBase](c: Context)(implicit e: c.WeakTypeTag[E]): c.Expr[Isomorphism[E, E#Underlying]] = {
     import c.universe._
+    if(!(e.tpe <:< c.typeOf[MappedToBase]))
+      c.abort(c.enclosingPosition, "Work-around for SI-8351 leading to illegal macro-invocation -- You should not see this message")
     implicit val eutag = c.TypeTag[E#Underlying](e.tpe.member(newTypeName("Underlying")).typeSignatureIn(e.tpe))
     val cons = c.Expr[E#Underlying => E](Function(
       List(ValDef(Modifiers(Flag.PARAM), newTermName("v"), /*Ident(eu.tpe.typeSymbol)*/TypeTree(), EmptyTree)),


### PR DESCRIPTION
Fixes issue #590. Test in RelationalMapperTest.mappedToMacroCompilerBug
(compile-time only; the test is not executed)

Thanks to @xeno-by for narrowing this down. Review by @cvogt 
