### PR TITLE
Restrict Shape.provenShape to only allow unpacked types in ProvenShape.

### DIFF
--- a/src/main/scala/scala/slick/lifted/Shape.scala
+++ b/src/main/scala/scala/slick/lifted/Shape.scala
@@ -70,7 +70,7 @@ trait ShapeLowPriority extends ShapeLowPriority1 {
     def toNode(value: Mixed): Node = value.toNode
   }
 
-  implicit def provenShape[T, P](implicit shape: Shape[_ <: FlatShapeLevel, T, _, P]): Shape[FlatShapeLevel, ProvenShape[T], T, P] = new Shape[FlatShapeLevel, ProvenShape[T], T, P] {
+  implicit def provenShape[T, P](implicit shape: Shape[_ <: FlatShapeLevel, T, T, P]): Shape[FlatShapeLevel, ProvenShape[T], T, P] = new Shape[FlatShapeLevel, ProvenShape[T], T, P] {
     def pack(value: Mixed): Packed =
       value.shape.pack(value.value.asInstanceOf[value.shape.Mixed]).asInstanceOf[Packed]
     def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] =


### PR DESCRIPTION
This was generally true by construction for actual instances of
ProvenShape, but it was not reflected in the implicit which creates
a Shape for a ProvenShape given a Shape of its contents.

Review by @cvogt 
