### PR TITLE
First cut at OSGi-fun for slick.

### DIFF
--- a/osgi-tests/src/test/scala/scala/slick/BasicTest.scala
+++ b/osgi-tests/src/test/scala/scala/slick/BasicTest.scala
@@ -1,0 +1,36 @@
+package scala.slick
+
+import org.junit.Assert._
+import org.ops4j.pax.exam.CoreOptions._
+ 
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ops4j.pax.exam
+import org.ops4j.pax.exam.junit.{
+  Configuration,
+  ExamReactorStrategy,
+  JUnit4TestRunner
+}
+import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
+import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.osgi.framework.BundleContext
+import scala.slick.SlickException
+
+@RunWith(classOf[JUnit4TestRunner])
+@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+class BasicTest extends testutil.SlickOsgiHelper {
+
+  @Configuration
+  def config(): Array[exam.Option] = {
+    standardOptions
+  }
+ 
+  @Test
+  def everythingLoads(): Unit = println("Running PAX-Exam test.")
+
+
+  @Test(expected=classOf[SlickException])  
+  def canDoSomethingSlick(): Unit = {
+    throw new SlickException("Test failure")
+  }
+}

--- a/osgi-tests/src/test/scala/scala/slick/testutil/SlickOsgiHelper.scala
+++ b/osgi-tests/src/test/scala/scala/slick/testutil/SlickOsgiHelper.scala
@@ -1,0 +1,25 @@
+package scala.slick
+package testutil
+
+import org.ops4j.pax.exam.CoreOptions._
+import org.ops4j.pax.exam
+import java.io.File
+
+/**
+ * Helper to communicate with promoted bundles from our sbtbuild.
+ */
+trait SlickOsgiHelper {
+  private def makeBundle(file: File): exam.Option = 
+    bundle(file.toURI.toASCIIString)
+
+
+  private def allBundleFiles: Array[File] =
+    Option(sys.props("slick.osgi.bundlepath")).getOrElse("").split(":").map(new File(_))
+
+  def standardOptions: Array[exam.Option] = {
+    val bundles = (allBundleFiles map makeBundle)
+    bundles ++ Array[exam.Option](felix(), equinox(), junitBundles())
+    // to change the local repo used (for some operations, but not all -- which is why I didn't bother):
+    // systemProperty("org.ops4j.pax.url.mvn.localRepository").value(sys.props("maven.repo.local")))
+  }
+}

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,3 +3,5 @@ scalacOptions += "-deprecation"
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")


### PR DESCRIPTION
- Add sbt-osgi plugin
- Create really really stupid defaults for slick OSGi bundle
- Create new project to run slick OSGi tests
  - We have to fork for who knows why
  - We pass bundles to load via a system property (may be windows unfriendly)
- Create the most basic of basic tests, just to ensure we load/link things in the OSGi world.

@szeiger TAG!  You're it.
