### PR TITLE
Fix identity groupBy with type mappings.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -152,6 +152,35 @@ class AggregateTest extends TestkitTest[RelationalTestDB] {
       case (id, data) => (id, data.map(_.b.asColumnOf[Option[Double]]).max)
     }
     assertEquals(Set((2,Some(5.0)), (1,Some(3.0)), (3,Some(9.0))), q10.run.toSet)
+
+    case class Pair(a:Int,b:Option[Int])
+    class T4(tag: Tag) extends Table[Pair](tag, "t4") {
+      def a = column[Int]("a")
+      def b = column[Option[Int]]("b")
+      def * = (a, b) <> (Pair.tupled,Pair.unapply)
+    }
+    val t4s = TableQuery[T4]
+    t4s.ddl.create
+    t4s ++= Seq(Pair(1, Some(1)), Pair(1, Some(2)))
+    t4s ++= Seq(Pair(1, Some(1)), Pair(1, Some(2)))
+    t4s ++= Seq(Pair(1, Some(1)), Pair(1, Some(2)))
+
+    println("=========================================================== q11")
+    val expected11 = Set(
+      Pair(1, Some(1)), Pair(1, Some(2))
+    )
+    val q12 = t4s
+    val res12 = q12.run
+    assertEquals(6, res12.size)
+    assertEquals(expected11, res12.toSet)
+    val q13 = t4s.map(identity)
+    val res13 = q13.run
+    assertEquals(6, res13.size)
+    assertEquals(expected11, res13.toSet)
+    val q11 = t4s.groupBy(identity).map(_._1)
+    val res11 = q11.run
+    assertEquals(expected11, res11.toSet)
+    assertEquals(2, res11.size)
   }
 
   def testIntLength {

--- a/src/main/scala/scala/slick/ast/Node.scala
+++ b/src/main/scala/scala/slick/ast/Node.scala
@@ -346,7 +346,7 @@ object Ordering {
 }
 
 /** A .groupBy call. */
-final case class GroupBy(fromGen: Symbol, from: Node, by: Node) extends BinaryNode with DefNode {
+final case class GroupBy(fromGen: Symbol, from: Node, by: Node, identity: TypeSymbol = new AnonTypeSymbol) extends BinaryNode with DefNode {
   type Self = GroupBy
   def left = from
   def right = by
@@ -361,7 +361,7 @@ final case class GroupBy(fromGen: Symbol, from: Node, by: Node) extends BinaryNo
     val by2 = by.nodeWithComputedType(scope + (fromGen -> from2Type.elementType), typeChildren, retype)
     nodeRebuildOrThis(Vector(from2, by2)).nodeTypedOrCopy(
       if(!nodeHasType || retype)
-        CollectionType(from2Type.cons, ProductType(IndexedSeq(by2.nodeType.structural, CollectionType(TypedCollectionTypeConstructor.seq, from2Type.elementType))))
+        CollectionType(from2Type.cons, ProductType(IndexedSeq(NominalType(identity)(by2.nodeType), CollectionType(TypedCollectionTypeConstructor.seq, from2Type.elementType))))
       else nodeType)
   }
 }

--- a/src/main/scala/scala/slick/compiler/Columnizer.scala
+++ b/src/main/scala/scala/slick/compiler/Columnizer.scala
@@ -80,10 +80,9 @@ class FlattenProjections extends Phase {
     val translations = new HashMap[TypeSymbol, (Map[List[Symbol], Symbol], StructType)]
     def tr(n: Node): Node = n match {
       case Pure(v, ts) =>
-        val tsym = n.nodeType.asCollectionType.elementType.asInstanceOf[NominalType].sym
-        logger.debug(s"Flattening projection $tsym")
+        logger.debug(s"Flattening projection $ts")
         val (newV, newTranslations) = flattenProjection(tr(v))
-        translations += tsym -> (newTranslations, newV.nodeType.asInstanceOf[StructType])
+        translations += ts -> (newTranslations, newV.nodeType.asInstanceOf[StructType])
         Pure(newV, ts).nodeWithComputedType()
       case Path(path) =>
         logger.debug("Analyzing "+Path.toString(path)+" with symbols "+translations.keySet.mkString(", "))

--- a/src/main/scala/scala/slick/compiler/Relational.scala
+++ b/src/main/scala/scala/slick/compiler/Relational.scala
@@ -107,7 +107,7 @@ class ConvertToComprehensions extends Phase {
         select = Some(Pure(StructNode(rowType.elements.map { case (s, _) => (s, Select(ref, s) ) }.toVector)))
       ).nodeWithComputedType()
     // Simple GroupBy followed by aggregating map operation to Comprehension
-    case b @ Bind(gen, gr @ GroupBy(fromGen, from, by), Pure(sel, _)) =>
+    case b @ Bind(gen, gr @ GroupBy(fromGen, from, by, _), Pure(sel, _)) =>
       val genType = gr.nodeType.asCollectionType.elementType
       val newBy = by.replace({ case r @ Ref(f) if f == fromGen => Ref(gen).nodeTyped(r.nodeType) }, keepType = true)
       logger.debug("Replacing simple groupBy selection in:", sel)

--- a/src/main/scala/scala/slick/jdbc/JdbcMappingCompilerComponent.scala
+++ b/src/main/scala/scala/slick/jdbc/JdbcMappingCompilerComponent.scala
@@ -15,7 +15,7 @@ trait JdbcMappingCompilerComponent extends RelationalMappingCompilerComponent { 
 
   trait MappingCompiler extends super.MappingCompiler {
     def createColumnConverter(n: Node, path: Node, optionApply: Boolean, column: Option[FieldSymbol]): ResultConverter = {
-      val JdbcType(ti, option) = n.nodeType
+      val JdbcType(ti, option) = n.nodeType.structural
       val autoInc = column.fold(false)(_.options.contains(ColumnOption.AutoInc))
       if(option) new OptionResultConverter(ti, autoInc)
       else new BaseResultConverter(ti, autoInc, column.fold(n.toString)(_.name))

--- a/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
@@ -108,9 +108,7 @@ trait MemoryQueryingDriver extends RelationalDriver with MemoryQueryingProfile w
     }
 
     def trType(t: Type): Type = t.structural match {
-      case StructType(el) => StructType(el.map { case (s, t) => (s, trType(t)) })
-      case ProductType(el) => ProductType(el.map(trType))
-      case CollectionType(cons, el) => CollectionType(cons, trType(el))
+      case t @ (_: StructType | _: ProductType | _: CollectionType | _: MappedScalaType) => t.mapChildren(trType)
       case t => typeInfoFor(t)
     }
   }

--- a/src/main/scala/scala/slick/memory/QueryInterpreter.scala
+++ b/src/main/scala/scala/slick/memory/QueryInterpreter.scala
@@ -142,7 +142,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         })
         scope.remove(gen)
         b.result()
-      case GroupBy(gen, from, by) =>
+      case GroupBy(gen, from, by, _) =>
         val fromV = run(from).asInstanceOf[Coll]
         val grouped = new HashMap[Any, ArrayBuffer[Any]]()
         fromV.foreach { v =>


### PR DESCRIPTION
- In #624 we removed NominalTypes of "by" clauses from the inferred type
  of GroupBy nodes. This does not fully address the problem because the
  underlying NominalType is still needed for properly expanding a Table
  to its TableExpansion. Instead, we now generate a _new_ NominalType
  that wraps whatever type the "by" clause has in the result of GroupBy,
  treating this situation the same as Pure (which makes sense because
  the left side of a GroupBy result also generates a new structure).
- Allow NominalTypes of single columns in the JDBC MappingCompiler. Such
  types can arise from the new scheme.
- Treat MappedScalaTypes correctly in MemoryCodeGen (as required by the
  new test cases).

Related to issue #96. Test in AggregateTest.testGroupBy. Review by @cvogt 
