### PR TITLE
Fix assertion error for multiple nameless fks or indices

### DIFF
--- a/slick-testkit/src/test/scala/scala/slick/test/model/ModelTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/model/ModelTest.scala
@@ -1,0 +1,31 @@
+package scala.slick.test.lifted
+
+import org.junit.Test
+import org.junit.Assert._
+import scala.slick.model._
+
+/** Test case for the SQL schema support in table definitions */
+class ModelTest {
+
+  @Test def testConsistencyCheck {
+    Model(Seq()).assertConsistency
+
+    val A = QualifiedName("A")
+    val B = QualifiedName("B")
+    val a_id = Column("id",A,"Int",false,Set())
+    val b_id = Column("id",B,"Int",false,Set())
+    val b_a_id = Column("a_id",B,"Int",false,Set())
+
+    // avoid failing on duplicate foreign key None names (e.g. happens on sqlite)
+    Model(Seq(
+      Table(B,Seq(
+        b_id,
+        b_a_id
+      ),None,Seq(
+        ForeignKey(None,B,Seq(b_a_id),A,Seq(a_id),ForeignKeyAction.NoAction,ForeignKeyAction.NoAction),
+        ForeignKey(None,B,Seq(b_a_id),A,Seq(a_id),ForeignKeyAction.NoAction,ForeignKeyAction.NoAction)
+      ),Seq()),
+      Table(A,Seq(a_id),None,Seq(),Seq())
+    )).assertConsistency
+  }
+}

--- a/src/main/scala/scala/slick/model/Model.scala
+++ b/src/main/scala/scala/slick/model/Model.scala
@@ -91,7 +91,7 @@ case class Model(
           assert( table.columns.contains(column), msg("column "+column,"primary key "+pk) )
         }
       }
-      assert(foreignKeys.filter(_.name!="").size == foreignKeys.filter(_.name!="").map(_.name).distinct.size, "duplicate foreign key names detected")
+      assert(foreignKeys.filter(_.name!=None).size == foreignKeys.filter(_.name!=None).map(_.name).distinct.size, "duplicate foreign key names detected")
       foreignKeys.foreach{ fk =>
         assert( tablesByName.isDefinedAt(fk.referencedTable), msg("table "+fk.referencedTable,"foreign key "+fk) )
         assert( tablesByName.isDefinedAt(fk.referencingTable), msg("table "+fk.referencingTable,"foreign key "+fk) )
@@ -105,7 +105,7 @@ case class Model(
           assert( fkTable.columns.contains(fkColumn), msg("column "+fkColumn+" of table "+fkTable,"foreign key "+fk) )
         }
       }
-      assert(indices.filter(_.name!="").size == indices.filter(_.name!="").map(_.name).distinct.size, "duplicate index names detected")
+      assert(indices.filter(_.name!=None).size == indices.filter(_.name!=None).map(_.name).distinct.size, "duplicate index names detected")
       indices.foreach{ idx =>
         assert( tablesByName.isDefinedAt(idx.table), msg("table "+idx.table,"index "+idx) )
         idx.columns.foreach{ column =>


### PR DESCRIPTION
(non type-safe equality caught us)

as reported here: http://stackoverflow.com/questions/22899805/slick-codegenerator-does-not-fill-foreignkey-names-causing-assertion-failed-dup/22900019
