### PR TITLE
Enhance null comparisons

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -205,4 +205,32 @@ class MainTest extends TestkitTest[JdbcTestDB] { mainTest =>
 
     for(t <- q1) println("User tuple: "+t)
   }
+  def testNull{
+    class Users(tag: Tag) extends Table[Option[String]](tag, "users") {
+      def name = column[Option[String]]("name")
+      def * = name
+    }
+    lazy val users = TableQuery[Users]
+    users.ddl.create
+    users.insert(Some("chris"))
+    users.insert(Some("stefan"))
+    users.insert(None)
+    println(users.filter(_.name.isNull).length.selectStatement)
+    assertEquals( 1, users.filter(_.name.isNull).length.run )
+    assertEquals( 1, users.filter(_.name.isNull).run.length )
+    assertEquals( 1, users.filter(_.name.isEmpty).length.run )
+    assertEquals( 1, users.filter(_.name.isEmpty).run.length )
+    assertEquals( 2, users.filter(_.name.isNotNull).length.run )
+    assertEquals( 2, users.filter(_.name.isNotNull).run.length )
+    assertEquals( 2, users.filter(_.name.nonEmpty).length.run )
+    assertEquals( 2, users.filter(_.name.nonEmpty).run.length )
+    try{
+      assertEquals( 0, users.filter(_.name === Option[String](null)).length.run )
+      fail()
+    }catch{ case _:SlickException =>  }
+    try{
+      assertEquals( 0, users.filter(_.name === Option[String](null)).run.length )
+      fail()
+    }catch{ case _:SlickException => }
+  }
 }

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -195,6 +195,13 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
       case QueryParameter(extractor, tpe) => b +?= { (p, param) =>
         typeInfoFor(tpe).setValue(extractor(param), p)
       }
+      // Disallow === comparisons with None, as they always return NULL (=false).
+      case Library.Not(Library.==(l, LiteralNode(None))) => {
+        throw new SlickException("Inequality comparison with None not allowed. Please use nonEmpty or isNotNull instead.")
+      }
+      case Library.==(l, LiteralNode(None)) => {
+        throw new SlickException("Equality comparison with None not allowed. Please use isEmpty or isNull instead.")
+      }
       case Library.Not(Library.==(l, LiteralNode(null))) =>
         b"\($l is not null\)"
       case Library.==(l, LiteralNode(null)) =>

--- a/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
+++ b/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
@@ -32,7 +32,9 @@ final class AnyExtensionMethods(val n: Node) extends AnyVal {
 trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
   val c: Column[P1]
 
+  /** Returns true if the column is NULL, false otherwise. */
   def isNull = Library.==.column[Boolean](n, LiteralNode(null))
+  /** Returns false if the column is NULL, true otherwise. */
   def isNotNull = Library.Not.column[Boolean](Library.==.typed[Boolean](n, LiteralNode(null)))
 
   def is[P2, R](e: Column[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
@@ -81,6 +83,10 @@ final class OptionColumnExtensionMethods[B1](val c: Column[Option[B1]]) extends 
     Column.forNode[B1](GetOrElse(c.toNode, () => default))(c.tpe.asInstanceOf[OptionType].elementType.asInstanceOf[TypedType[B1]])
   def get: Column[B1] =
     getOrElse { throw new SlickException("Read NULL value for column "+this) }
+  /** Returns true if the column is NULL, false otherwise. */
+  def isEmpty = this.isNull
+  /** Returns false if the column is NULL, true otherwise. */
+  def nonEmpty = this.isNotNull
 }
 
 /** Extension methods for numeric Columns */


### PR DESCRIPTION
- Collections api conformant aliases isEmpty and nonEmpty for Option columns
- add scaladoc
- disallow === None (in favor of isNull, which is what you want)
- add tests for isNull, isEmpty, isNotNull, nonEmpty, === None

review by @szeiger
