### PR TITLE
Allow non-literal constant values for Query.take and Query.drop

### DIFF
--- a/slick-testkit/src/codegen/resources/logback.xml
+++ b/slick-testkit/src/codegen/resources/logback.xml
@@ -27,6 +27,7 @@
     <logger name="scala.slick.compiler.FixRowNumberOrdering"      level="${log.qcomp.fixRowNumberOrdering:-inherited}" />
     <logger name="scala.slick.compiler.HoistClientOps"            level="${log.qcomp.hoistClientOps:-inherited}" />
     <logger name="scala.slick.compiler.RewriteBooleans"           level="${log.qcomp.rewriteBooleans:-inherited}" />
+    <logger name="scala.slick.compiler.SpecializeParameters"      level="${log.qcomp.specializeParameters:-inherited}" />
     <logger name="scala.slick.compiler.CodeGen"                   level="${log.qcomp.codeGen:-inherited}" />
     <logger name="scala.slick.compiler.InsertCompiler"            level="${log.qcomp.insertCompiler:-inherited}" />
     <logger name="scala.slick.jdbc.JdbcBackend.statement"         level="${log.session:-info}" />

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PagingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PagingTest.scala
@@ -6,41 +6,51 @@ import com.typesafe.slick.testkit.util.{RelationalTestDB, TestkitTest}
 class PagingTest extends TestkitTest[RelationalTestDB] {
   import tdb.profile.simple._
 
-  class IDs(tag: Tag) extends Table[Int](tag, "ids") {
+  override val reuseInstance = true
+
+  class IDs(tag: Tag, name: String) extends Table[Int](tag, name) {
     def id = column[Int]("id", O.PrimaryKey)
     def * = id
   }
-  lazy val ids = TableQuery[IDs]
 
-  def test {
-
+  def testRawPagination {
+    lazy val ids = TableQuery(new IDs(_, "ids_raw"))
     ids.ddl.create;
     ids ++= (1 to 10)
 
     val q1 = ids.sortBy(_.id)
-    println("    "+q1.run)
     assertEquals((1 to 10).toList, q1.run)
 
     val q2 = q1 take 5
-    println("    "+q2.run)
     assertEquals((1 to 5).toList, q2.run)
 
     ifCap(rcap.pagingDrop) {
       val q3 = q1 drop 5
-      println("    "+q3.run)
       assertEquals((6 to 10).toList, q3.run)
 
       val q4 = q1 drop 5 take 3
-      println("    "+q4.run)
       assertEquals((6 to 8).toList, q4.run)
 
       val q5 = q1 take 5 drop 3
-      println("    "+q5.run)
       assertEquals((4 to 5).toList, q5.run)
     }
 
     val q6 = q1 take 0
-    println("    "+q6.run)
     assertEquals(List(), q6.run)
+  }
+
+  def testCompiledPagination {
+    lazy val ids = TableQuery(new IDs(_, "ids_compiled"))
+    ids.ddl.create
+    ids ++= (1 to 10)
+    val q = Compiled { (offset: ConstColumn[Long], fetch: ConstColumn[Long]) =>
+      ids.sortBy(_.id).drop(offset).take(fetch)
+    }
+    assertEquals((1 to 5).toList, q(0, 5).run)
+    ifCap(rcap.pagingDrop) {
+      assertEquals((6 to 10).toList, q(5, 1000).run)
+      assertEquals((6 to 8).toList, q(5, 3).run)
+    }
+    assertEquals(List(), q(0, 0).run)
   }
 }

--- a/src/main/scala/scala/slick/ast/Comprehension.scala
+++ b/src/main/scala/scala/slick/ast/Comprehension.scala
@@ -4,15 +4,17 @@ import TypeUtil.typeToTypeUtil
 import Util._
 
 /** A SQL comprehension */
-final case class Comprehension(from: Seq[(Symbol, Node)] = Seq.empty, where: Seq[Node] = Seq.empty, groupBy: Option[Node] = None, orderBy: Seq[(Node, Ordering)] = Seq.empty, select: Option[Node] = None, fetch: Option[Long] = None, offset: Option[Long] = None) extends DefNode {
+final case class Comprehension(from: Seq[(Symbol, Node)] = Seq.empty, where: Seq[Node] = Seq.empty, groupBy: Option[Node] = None, orderBy: Seq[(Node, Ordering)] = Seq.empty, select: Option[Node] = None, fetch: Option[Node] = None, offset: Option[Node] = None) extends DefNode {
   type Self = Comprehension
-  val nodeChildren = from.map(_._2) ++ where ++ groupBy ++ orderBy.map(_._1) ++ select
+  val nodeChildren = from.map(_._2) ++ where ++ groupBy ++ orderBy.map(_._1) ++ select ++ fetch ++ offset
   override def nodeChildNames =
     from.map("from " + _._1) ++
     where.zipWithIndex.map("where" + _._2) ++
     groupBy.map(_ => "groupBy") ++
     orderBy.map("orderBy " + _._2) ++
-    select.map(_ => "select")
+    select.map(_ => "select") ++
+    fetch.map(_ => "fetch") ++
+    offset.map(_ => "offset")
   protected[this] def nodeRebuild(ch: IndexedSeq[Node]) = {
     val newFrom = ch.slice(0, from.length)
     val whereOffset = newFrom.length
@@ -23,16 +25,22 @@ final case class Comprehension(from: Seq[(Symbol, Node)] = Seq.empty, where: Seq
     val newOrderBy = ch.slice(orderByOffset, orderByOffset + orderBy.length)
     val selectOffset = orderByOffset + newOrderBy.length
     val newSelect = ch.slice(selectOffset, selectOffset + (if(select.isDefined) 1 else 0))
+    val fetchOffset = selectOffset + newSelect.length
+    val newFetch = ch.slice(fetchOffset, fetchOffset + (if(fetch.isDefined) 1 else 0))
+    val offsetOffset = fetchOffset + newFetch.length
+    val newOffset = ch.slice(offsetOffset, offsetOffset + (if(offset.isDefined) 1 else 0))
     copy(
       from = (from, newFrom).zipped.map { case ((s, _), n) => (s, n) },
       where = newWhere,
       groupBy = if(newGroupBy.isEmpty) None else Some(newGroupBy.head),
       orderBy = (orderBy, newOrderBy).zipped.map { case ((_, o), n) => (n, o) },
-      select = if(newSelect.isEmpty) None else Some(newSelect.head)
+      select = if(newSelect.isEmpty) None else Some(newSelect.head),
+      fetch = if(newFetch.isEmpty) None else Some(newFetch.head),
+      offset = if(newOffset.isEmpty) None else Some(newOffset.head)
     )
   }
   def nodeGenerators = from
-  override def toString = "Comprehension(fetch = "+fetch+", offset = "+offset+")"
+  override def toString = "Comprehension"
   protected[this] def nodeRebuildWithGenerators(gen: IndexedSeq[Symbol]) =
     copy(from = (from, gen).zipped.map { case ((_, n), s) => (s, n) })
   def nodeWithComputedType2(scope: SymbolScope, typeChildren: Boolean, retype: Boolean): Self = {
@@ -42,15 +50,17 @@ final case class Comprehension(from: Seq[(Symbol, Node)] = Seq.empty, where: Seq
       val sc2 = sc + (s -> n2.nodeType.asCollectionType.elementType)
       (sc2, n2s :+ n2)
     }
-    // Assign types to "where", "groupBy", "orderBy" and "select" Nodes
+    // Assign types to "where", "groupBy", "orderBy", "select", "fetch" and "offset" Nodes
     val w2 = mapOrNone(where)(_.nodeWithComputedType(genScope, typeChildren, retype))
     val g2 = mapOrNone(groupBy)(_.nodeWithComputedType(genScope, typeChildren, retype))
     val o = orderBy.map(_._1)
     val o2 = mapOrNone(o)(_.nodeWithComputedType(genScope, typeChildren, retype))
     val s2 = mapOrNone(select)(_.nodeWithComputedType(genScope, typeChildren, retype))
+    val fetch2 = mapOrNone(fetch)(_.nodeWithComputedType(genScope, typeChildren, retype))
+    val offset2 = mapOrNone(offset)(_.nodeWithComputedType(genScope, typeChildren, retype))
     // Check if the nodes changed
     val same = (from, f2).zipped.map(_._2 eq _).forall(identity) &&
-      w2.isEmpty && g2.isEmpty && o2.isEmpty && s2.isEmpty
+      w2.isEmpty && g2.isEmpty && o2.isEmpty && s2.isEmpty && fetch2.isEmpty && offset2.isEmpty
     val newSel = s2.map(_.headOption).getOrElse(select)
     val newType =
       if(!nodeHasType || retype) {
@@ -69,7 +79,9 @@ final case class Comprehension(from: Seq[(Symbol, Node)] = Seq.empty, where: Seq
         where = w2.getOrElse(where),
         groupBy = g2.map(_.headOption).getOrElse(groupBy),
         orderBy = o2.map(o2 => (orderBy, o2).zipped.map { case ((_, o), n) => (n, o) }).getOrElse(orderBy),
-        select = s2.map(_.headOption).getOrElse(select)
+        select = s2.map(_.headOption).getOrElse(select),
+        fetch = fetch2.map(_.headOption).getOrElse(fetch),
+        offset = offset2.map(_.headOption).getOrElse(offset)
       ).nodeTyped(newType)
     }
   }

--- a/src/main/scala/scala/slick/ast/Util.scala
+++ b/src/main/scala/scala/slick/ast/Util.scala
@@ -36,9 +36,9 @@ object Scope {
 final class NodeOps(val tree: Node) extends AnyVal {
   import Util._
 
-  @inline def collect[T](pf: PartialFunction[Node, T]): Iterable[T] = NodeOps.collect(tree, pf)
+  @inline def collect[T](pf: PartialFunction[Node, T]): Seq[T] = NodeOps.collect(tree, pf)
 
-  def collectAll[T](pf: PartialFunction[Node, Seq[T]]): Iterable[T] = collect[Seq[T]](pf).flatten
+  def collectAll[T](pf: PartialFunction[Node, Seq[T]]): Seq[T] = collect[Seq[T]](pf).flatten
 
   def replace(f: PartialFunction[Node, Node], keepType: Boolean = false): Node = NodeOps.replace(tree, f, keepType)
 
@@ -82,7 +82,7 @@ object NodeOps {
   // These methods should be in the class but 2.10.0-RC1 took away the ability
   // to use closures in value classes
 
-  def collect[T](tree: Node, pf: PartialFunction[Node, T]): Iterable[T] = {
+  def collect[T](tree: Node, pf: PartialFunction[Node, T]): Seq[T] = {
     val b = new ArrayBuffer[T]
     tree.foreach(pf.andThen[Unit]{ case t => b += t }.orElse[Node, Unit]{ case _ => () })
     b

--- a/src/main/scala/scala/slick/compiler/QueryCompiler.scala
+++ b/src/main/scala/scala/slick/compiler/QueryCompiler.scala
@@ -151,6 +151,7 @@ object Phase {
 
   /* Extra phases that are not enabled by default */
   val rewriteBooleans = new RewriteBooleans
+  val specializeParameters = new SpecializeParameters
 }
 
 /** The current state of a compiler run, consisting of the current AST and

--- a/src/main/scala/scala/slick/compiler/SpecializeParameters.scala
+++ b/src/main/scala/scala/slick/compiler/SpecializeParameters.scala
@@ -1,0 +1,31 @@
+package scala.slick.compiler
+
+import scala.slick.SlickException
+import scala.slick.ast._
+import Util._
+
+/** Specialize the AST for edge cases of query parameters. This is required for
+  * compiling `take(0)` for some databases which do not allow `LIMIT 0`. */
+class SpecializeParameters extends Phase {
+  val name = "specializeParameters"
+
+  def apply(state: CompilerState): CompilerState =
+    state.map(ClientSideOp.mapServerSide(_, keepType = true)(transformServerSide))
+
+  def transformServerSide(n: Node): Node = {
+    val cs = n.collect { case c @ Comprehension(_, _, _, _, _, Some(_: QueryParameter), _) => c }
+    logger.debug("Affected fetch clauses in: "+cs.mkString(", "))
+    cs.foldLeft(n) { case (n, c @ Comprehension(_, _, _, _, _, Some(fetch: QueryParameter), _)) =>
+      val compiledFetchParam = QueryParameter(fetch.extractor, ScalaBaseType.longType)
+      val guarded = n.replace({ case c2: Comprehension if c2 == c => c2.copy(fetch = Some(LiteralNode(0L))) }, keepType = true)
+      val fallback = n.replace({ case c2: Comprehension if c2 == c => c2.copy(fetch = Some(compiledFetchParam)) }, keepType = true)
+      ParameterSwitch(Vector(compare(fetch.extractor, 0L) -> guarded), fallback).nodeTyped(n.nodeType)
+    }
+  }
+
+  /** Create a function that calls an extractor for a value and compares the result with a fixed value. */
+  def compare(f: (Any => Any), v: Any) = new (Any => Boolean) {
+    def apply(param: Any) = v == f(param)
+    override def toString = s"$f(...) == $v"
+  }
+}

--- a/src/main/scala/scala/slick/direct/SlickBackend.scala
+++ b/src/main/scala/scala/slick/direct/SlickBackend.scala
@@ -357,13 +357,13 @@ class SlickBackend( val driver: JdbcDriver, mapper:Mapper ) extends QueryableBac
                   if( !i.isInstanceOf[Int] ){
                     throw new Exception("drop expects Int, found "+i.getClass)
                   }
-                  sq.Drop( sq_lhs, i.asInstanceOf[Int] ) 
+                  sq.Drop( sq_lhs, sq.LiteralNode[Long](i.asInstanceOf[Int].toLong) )
                 case "take"       =>
                   val i = eval(rhs)
                   if( !i.isInstanceOf[Int] ){
                     throw new Exception("take expects Int, found "+i.getClass)
                   }
-                  sq.Take( sq_lhs, i.asInstanceOf[Int] ) 
+                  sq.Take( sq_lhs, sq.LiteralNode[Long](i.asInstanceOf[Int].toLong) )
                 case e => throw new UnsupportedMethodException( scala_lhs.tpe.erasure+"."+term.decoded )
               },
               scope

--- a/src/main/scala/scala/slick/driver/AccessDriver.scala
+++ b/src/main/scala/scala/slick/driver/AccessDriver.scala
@@ -206,7 +206,7 @@ trait AccessDriver extends JdbcDriver { driver =>
       if(o.direction.desc) b" desc"
     }
 
-    override protected def buildFetchOffsetClause(fetch: Option[Long], offset: Option[Long]) = ()
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = ()
   }
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {

--- a/src/main/scala/scala/slick/driver/DerbyDriver.scala
+++ b/src/main/scala/scala/slick/driver/DerbyDriver.scala
@@ -62,7 +62,7 @@ trait DerbyDriver extends JdbcDriver { driver =>
 
   override def getTables: Invoker[MTable] = MTable.getTables(None, None, None, Some(Seq("TABLE")))
 
-  override protected def computeQueryCompiler = super.computeQueryCompiler + Phase.rewriteBooleans
+  override protected def computeQueryCompiler = super.computeQueryCompiler + Phase.rewriteBooleans + Phase.specializeParameters
   override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
   override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new TableDDLBuilder(table)

--- a/src/main/scala/scala/slick/driver/H2Driver.scala
+++ b/src/main/scala/scala/slick/driver/H2Driver.scala
@@ -50,7 +50,7 @@ trait H2Driver extends JdbcDriver { driver =>
       case _ => super.expr(n, skipParens)
     }
 
-    override protected def buildFetchOffsetClause(fetch: Option[Long], offset: Option[Long]) = (fetch, offset) match {
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {
       case (Some(t), Some(d)) => b" limit $t offset $d"
       case (Some(t), None   ) => b" limit $t"
       case (None, Some(d)   ) => b" limit -1 offset $d"

--- a/src/main/scala/scala/slick/driver/HsqldbDriver.scala
+++ b/src/main/scala/scala/slick/driver/HsqldbDriver.scala
@@ -6,7 +6,7 @@ import scala.slick.lifted._
 import scala.slick.ast._
 import scala.slick.util.MacroSupport.macroSupportInterpolation
 import scala.slick.profile.{SqlProfile, Capability}
-import scala.slick.compiler.CompilerState
+import scala.slick.compiler.{Phase, CompilerState}
 import scala.slick.jdbc.meta.MTable
 import scala.slick.jdbc.Invoker
 
@@ -31,6 +31,7 @@ trait HsqldbDriver extends JdbcDriver { driver =>
 
   override def getTables: Invoker[MTable] = MTable.getTables(None, None, None, Some(Seq("TABLE")))
 
+  override protected def computeQueryCompiler = super.computeQueryCompiler + Phase.specializeParameters
   override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
   override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new TableDDLBuilder(table)
@@ -58,7 +59,7 @@ trait HsqldbDriver extends JdbcDriver { driver =>
       case _ => super.expr(c, skipParens)
     }
 
-    override protected def buildFetchOffsetClause(fetch: Option[Long], offset: Option[Long]) = (fetch, offset) match {
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {
       case (Some(t), Some(d)) => b" limit $t offset $d"
       case (Some(t), None   ) => b" limit $t"
       case (None, Some(d)   ) => b" offset $d"

--- a/src/main/scala/scala/slick/driver/MySQLDriver.scala
+++ b/src/main/scala/scala/slick/driver/MySQLDriver.scala
@@ -96,7 +96,7 @@ trait MySQLDriver extends JdbcDriver { driver =>
       case _ => super.expr(n, skipParens)
     }
 
-    override protected def buildFetchOffsetClause(fetch: Option[Long], offset: Option[Long]) = (fetch, offset) match {
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {
       case (Some(t), Some(d)) => b" limit $d,$t"
       case (Some(t), None   ) => b" limit $t"
       case (None,    Some(d)) => b" limit $d,18446744073709551615"

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -44,7 +44,7 @@ trait PostgresDriver extends JdbcDriver { driver =>
     override protected val concatOperator = Some("||")
     override protected val supportsEmptyJoinConditions = false
 
-    override protected def buildFetchOffsetClause(fetch: Option[Long], offset: Option[Long]) = (fetch, offset) match {
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {
       case (Some(t), Some(d)) => b" limit $t offset $d"
       case (Some(t), None   ) => b" limit $t"
       case (None,    Some(d)) => b" offset $d"

--- a/src/main/scala/scala/slick/driver/SQLiteDriver.scala
+++ b/src/main/scala/scala/slick/driver/SQLiteDriver.scala
@@ -84,10 +84,10 @@ trait SQLiteDriver extends JdbcDriver { driver =>
       if(o.direction.desc) b" desc"
     }
 
-    override protected def buildFetchOffsetClause(fetch: Option[Long], offset: Option[Long]) = (fetch, offset) match {
-      case (Some(t), Some(d)) => b" LIMIT $d,$t"
-      case (Some(t), None   ) => b" LIMIT $t"
-      case (None,    Some(d)) => b" LIMIT $d,-1"
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {
+      case (Some(t), Some(d)) => b" limit $d,$t"
+      case (Some(t), None   ) => b" limit $t"
+      case (None,    Some(d)) => b" limit $d,-1"
       case _ =>
     }
 

--- a/src/main/scala/scala/slick/jdbc/JdbcMappingCompilerComponent.scala
+++ b/src/main/scala/scala/slick/jdbc/JdbcMappingCompilerComponent.scala
@@ -61,8 +61,10 @@ trait JdbcMappingCompilerComponent { driver: JdbcDriver =>
 
     def apply(node: Node, state: CompilerState): Node =
       ClientSideOp.mapResultSetMapping(node, keepType = true) { rsm =>
-        val sbr = f(driver.createQueryBuilder(rsm.from, state))
-        val nfrom = CompiledStatement(sbr.sql, sbr, rsm.from.nodeType)
+        val nfrom = ClientSideOp.mapServerSide(rsm.from, keepType = true) { ss =>
+          val sbr = f(driver.createQueryBuilder(ss, state))
+          CompiledStatement(sbr.sql, sbr, ss.nodeType)
+        }
         val nmap = createMappingCompiler.compileMapping(rsm.map)
         rsm.copy(from = nfrom, map = nmap).nodeTyped(rsm.nodeType)
       }

--- a/src/main/scala/scala/slick/lifted/Query.scala
+++ b/src/main/scala/scala/slick/lifted/Query.scala
@@ -152,9 +152,18 @@ sealed abstract class Query[+E, U, C[_]] extends Rep[C[U]] { self =>
     }
 
   /** Select the first `num` elements. */
-  def take(num: Int): Query[E, U, C] = new WrappingQuery[E, U, C](Take(toNode, num), shaped)
+  def take(num: ConstColumn[Long]): Query[E, U, C] = new WrappingQuery[E, U, C](Take(toNode, num.toNode), shaped)
+  /** Select the first `num` elements. */
+  def take(num: Long): Query[E, U, C] = take(LiteralColumn(num))
+  /** Select the first `num` elements. */
+  def take(num: Int): Query[E, U, C] = take(num.toLong)
+
   /** Select all elements except the first `num` ones. */
-  def drop(num: Int): Query[E, U, C] = new WrappingQuery[E, U, C](Drop(toNode, num), shaped)
+  def drop(num: ConstColumn[Long]): Query[E, U, C] = new WrappingQuery[E, U, C](Drop(toNode, num.toNode), shaped)
+  /** Select all elements except the first `num` ones. */
+  def drop(num: Long): Query[E, U, C] = drop(LiteralColumn(num))
+  /** Select all elements except the first `num` ones. */
+  def drop(num: Int): Query[E, U, C] = drop(num.toLong)
 
   def to[D[_]](implicit ctc: TypedCollectionTypeConstructor[D]): Query[E, U, D] = new Query[E, U, D] {
     val shaped = self.shaped

--- a/src/main/scala/scala/slick/memory/QueryInterpreter.scala
+++ b/src/main/scala/scala/slick/memory/QueryInterpreter.scala
@@ -179,13 +179,15 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         b.result()
       case Take(from, num) =>
         val fromV = run(from).asInstanceOf[Coll]
+        val numV = run(num).asInstanceOf[Long]
         val b = from.nodeType.asCollectionType.cons.iterableSubstitute.createBuilder[Any]
-        b ++= fromV.toIterator.take(num)
+        b ++= fromV.toIterator.take(numV.toInt)
         b.result()
       case Drop(from, num) =>
         val fromV = run(from).asInstanceOf[Coll]
+        val numV = run(num).asInstanceOf[Long]
         val b = from.nodeType.asCollectionType.cons.iterableSubstitute.createBuilder[Any]
-        b ++= fromV.toIterator.drop(num)
+        b ++= fromV.toIterator.drop(numV.toInt)
         b.result()
       case Union(left, right, all, _, _) =>
         val leftV = run(left).asInstanceOf[Coll]


### PR DESCRIPTION
- Change Take, Drop, Comprehension, and the TakeDrop extractor to use
  Node instead of Long.
- Add helper method QueryParameter.constOp to perform a computation
  on two Long values inside of LiteralNode or QueryParameter nodes. We
  use it for computations that are necessary for fusing Take and Drop
  operations and computing boundaries for them.
- Add overloads for Query.take and Query.drop which take Long and
  ConstColumn[Long] arguments (in addition to the existing Int versions)
- Add specializeParameters phase which creates a ParameterSwitch node
  for detecting edge cases in parameters that need to be compiled to
  different statements. It is used by DerbyDriver and HsqldbDriver.

Test in PagingTest.testCompiledPagination. Related to #718 .

Review by @cvogt 
