### PR TITLE
Don't patch type changes from OptionApply in hoistClientOps.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -204,6 +204,7 @@ class MainTest extends TestkitTest[JdbcTestDB] { mainTest =>
     assertEquals(4, q9.run)
     println("Count statement: " + q9.selectStatement)
 
-    for(t <- q1) println("User tuple: "+t)
+    val q10 = users.filter(_.last inSetBind Seq()).map(u => (u.first, u.last))
+    assertEquals(Nil, q10.run)
   }
 }

--- a/src/main/scala/scala/slick/compiler/HoistClientOps.scala
+++ b/src/main/scala/scala/slick/compiler/HoistClientOps.scala
@@ -81,9 +81,6 @@ class HoistClientOps extends Phase {
   }
 
   def rewriteDBSide(tree: Node): Node = tree match {
-    case OptionApply(ch) =>
-      val ch2 = rewriteDBSide(ch)
-      ch2.nodeTypedOrCopy(OptionType(ch2.nodeType))
     case CollectionCast(ch, _) :@ tpe =>
       rewriteDBSide(ch).nodeTypedOrCopy(tpe)
     case GetOrElse(ch, default) =>

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -302,6 +302,7 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
           case (ElementSymbol(idx), z) => joins(z).nodeGenerators(idx-1)._1
         }
         b += symbolName(struct) += '.' += symbolName(field)
+      case OptionApply(ch) => expr(ch, skipParens)
       case n => // try to build a sub-query
         b"\("
         buildComprehension(toComprehension(n))


### PR DESCRIPTION
Patching the types was wrong and only worked for view columns, where the
wrong type is equivalent to the correct one, and for computed values,
where the wrong type is not used at all. It failed for LiteralNodes. The
solution is to leave OptionApply intact in hoistClientOps and ignore it
in QueryBuilder.

Test in MainTest.test. Fixes issue #771. Review by @cvogt, cc @ijuma
