### PR TITLE
Do not escape columns named tag in generated code

### DIFF
--- a/slick-testkit/src/codegen/scala/CodeGeneratorTest.scala
+++ b/slick-testkit/src/codegen/scala/CodeGeneratorTest.scala
@@ -209,7 +209,7 @@ class Tables(val profile: JdbcProfile){
   val all = TableQuery[all]
 
   /** Tests slick term name collision */
-  class X(tag: Tag) extends Table[(Int,Int,Option[Int],Int,Double,String,Option[Int],Option[Int],Option[String])](tag, "X") {
+  class X(tag: Tag) extends Table[(Int,Int,Option[Int],Int,Double,String,Option[Int],Option[Int],Option[String],Option[String],Option[String])](tag, "X") {
     def pk = column[Int]("pk")
     def pk2 = column[Int]("pk2")
     def pkpk = primaryKey( "", (pk,pk2) ) // pk column collision
@@ -220,7 +220,9 @@ class Tables(val profile: JdbcProfile){
     def s = column[Double]("schema_name") // slick Table no-arg method collision
     def sx = column[String]("schema_name_x") // column name collision after disambiguation
     def t_ag = column[Option[String]]("tag") // column name collision after disambiguation
-    def * = (pk,pk2,a,c,s,sx,i1,p,t_ag)
+    def tt = column[Option[String]]("_table_tag") // column name collision after disambiguation
+    def _underscore = column[Option[String]]("_underscore") // column name collision after disambiguation
+    def * = (pk,pk2,a,c,s,sx,i1,p,t_ag,tt,_underscore)
     def idx1 = index("",i1) // idx column collision
     def idx2 = index("i2",i1) // idx column collision
     def categoryFK1 = foreignKey("fk1", pk, categories)(_.id) // dup FK collision

--- a/src/main/scala/scala/slick/model/codegen/AbstractGenerator.scala
+++ b/src/main/scala/scala/slick/model/codegen/AbstractGenerator.scala
@@ -396,7 +396,7 @@ trait GeneratorHelpers[Code,TermName,TypeName]{
       // Table
       Seq("O","tableIdentitySymbol","tableProvider"),
       // generated code
-      Seq("tag")
+      Seq("_tableTag")
     ).flatten
 /* currently disambiguated using overloading
   /** Existing term member names in Table[_] that take parameters */

--- a/src/main/scala/scala/slick/model/codegen/AbstractSourceCodeGenerator.scala
+++ b/src/main/scala/scala/slick/model/codegen/AbstractSourceCodeGenerator.scala
@@ -129,7 +129,7 @@ implicit def ${name}(implicit $dependencies): GR[${TableClass.elementType}] = GR
         val prns = parents.map(" with " + _).mkString("")
         val args = model.name.schema.map(n => s"""Some("$n")""") ++ Seq("\""+model.name.table+"\"")
         s"""
-class $name(tag: Tag) extends Table[$elementType](tag, ${args.mkString(", ")})$prns {
+class $name(_tableTag: Tag) extends Table[$elementType](_tableTag, ${args.mkString(", ")})$prns {
   ${indent(body.map(_.mkString("\n")).mkString("\n\n"))}
 }
         """.trim()


### PR DESCRIPTION
It's probably a better idea using a different name for slick's tag instead of escaping columns named tag. related to #727
