### PR TITLE
Provide Executable instances for TableQuery and BaseJoinQuery.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
@@ -72,7 +72,8 @@ class TemplateTest extends TestkitTest[RelationalTestDB] {
     }
     def ts = TableQuery[T]
     ts.ddl.create
-    ts ++= Seq((1, "a"), (2, "b"), (3, "c"))
+    ts.map(identity) += (1, "a")
+    ts ++= Seq((2, "b"), (3, "c"))
 
     val byIdAndS = { (id: Column[Int], s: ConstColumn[String]) => ts.filter(t => t.id === id && t.s === s) }
     val byIdAndSC = Compiled(byIdAndS)
@@ -105,5 +106,8 @@ class TemplateTest extends TestkitTest[RelationalTestDB] {
     val r5 = countBelowC(3).run
     val r5t: Int = r5
     assertEquals(2, r5)
+
+    val joinC = Compiled { id: Column[Int] => ts.filter(_.id === id).innerJoin(ts.filter(_.id === id)) }
+    assertEquals(Seq(((1, "a"), (1, "a"))), joinC(1).run)
   }
 }

--- a/src/main/scala/scala/slick/lifted/Compiled.scala
+++ b/src/main/scala/scala/slick/lifted/Compiled.scala
@@ -90,6 +90,8 @@ trait Executable[T, TU]
 
 object Executable {
   @inline implicit def queryIsExecutable[B, BU]: Executable[Query[B, BU], Seq[BU]] = null
+  @inline implicit def tableQueryIsExecutable[B <: AbstractTable[_], BU]: Executable[Query[B, BU] with TableQuery[B], Seq[BU]] = null
+  @inline implicit def baseJoinQueryIsExecutable[B1, B2, BU1, BU2]: Executable[BaseJoinQuery[B1, B2, BU1, BU2], Seq[(BU1, BU2)]] = null
   @inline implicit def scalarIsExecutable[A, AU](implicit shape: Shape[ShapeLevel.Flat, A, AU, A]): Executable[A, AU] = null
 }
 


### PR DESCRIPTION
Backported from #782, fixes #746. Test in TemplateTest.testCompiled.

Review by @cvogt 
