### PR TITLE
Fix some bugs in comprehension fusion.

### DIFF
--- a/src/main/scala/scala/slick/ast/Library.scala
+++ b/src/main/scala/scala/slick/ast/Library.scala
@@ -63,7 +63,14 @@ object Library {
 
   val Exists = new SqlFunction("exists")
 
+  /** A standard cast operation which usually requires code to be generated */
   val Cast = new FunctionSymbol("Cast")
+
+  /** A type assignment describing an inherent type change that does not require any code to be
+    * generated. It is used in SQL-like ASTs for assigning the proper scalar type to aggregating
+    * subqueries which are used in a scalar context. */
+  val SilentCast = new FunctionSymbol("SilentCast")
+
   val IfNull = new JdbcFunction("ifnull")
 
   // Values

--- a/src/main/scala/scala/slick/compiler/Relational.scala
+++ b/src/main/scala/scala/slick/compiler/Relational.scala
@@ -130,7 +130,14 @@ class ConvertToComprehensions extends Phase {
       val newGroupBy = Some(ProductNode(Seq(newBy)).flatten.withComputedTypeNoRec)
       Comprehension(Seq(gen -> from), groupBy = newGroupBy,
         select = Some(Pure(newSel).withComputedTypeNoRec)).nodeTyped(b.nodeType)
-    // Bind to Comprehension
+    // Inline Pure(StructNode)) generators into Bind. It may be too late to recognize this pattern
+    // in fuseComprehensions after lifting aggregates
+    case b @ Bind(gen, Pure(StructNode(ch), _), select) =>
+      val defs = ch.toMap
+      Comprehension(select = Some(select.replace({
+        case Select(Ref(gen2), fs) if gen2 == gen => defs(fs)
+      }, keepType = true))).nodeTyped(b.nodeType)
+    // Other Bind to Comprehension
     case b @ Bind(gen, from, select) =>
       Comprehension(from = mkFrom(gen, from), select = Some(select)).nodeTyped(b.nodeType)
     // Filter to Comprehension
@@ -329,7 +336,8 @@ class FuseComprehensions extends Phase {
     * (if they would refer to unreachable symbols when used in 'from'
     * position). */
   def liftAggregates(c: Comprehension): Comprehension = {
-    val lift = ArrayBuffer[(AnonSymbol, AnonSymbol, Library.AggregateFunctionSymbol, Comprehension)]()
+    logger.debug("Checking for liftable aggregates in: ", c)
+    val lift = ArrayBuffer[(AnonSymbol, AnonSymbol, Library.AggregateFunctionSymbol, Comprehension, Type)]()
     val seenGens = HashMap[Symbol, Node]()
     def tr(n: Node): Node = n match {
       //TODO Once we can recognize structurally equivalent sub-queries and merge them, c2 could be a Ref
@@ -341,7 +349,7 @@ class FuseComprehensions extends Phase {
           s match {
             case Library.CountAll =>
               if(c2.from.isEmpty) Library.Cast.typed(ap.nodeType, LiteralNode(1))
-              else c2.copy(select = Some(Pure(ProductNode(Seq(Library.Count.typed(ap.nodeType, LiteralNode(1)))))))
+              else Library.SilentCast.typed(ap.nodeType, c2.copy(select = Some(Pure(ProductNode(Seq(Library.Count.typed(ap.nodeType, LiteralNode(1))))))))
             case s =>
               val c3 = ensureStruct(c2).nodeWithComputedType(SymbolScope.empty, false, true)
               // All standard aggregate functions operate on a single column
@@ -352,7 +360,7 @@ class FuseComprehensions extends Phase {
         } else {
           val a = new AnonSymbol
           val f = new AnonSymbol
-          lift += ((a, f, s, c2))
+          lift += ((a, f, s, c2, ap.nodeType))
           Select(Ref(a), f)
         }
       case c: Comprehension => c // don't recurse into sub-queries
@@ -364,19 +372,18 @@ class FuseComprehensions extends Phase {
         ch
       case (None, ch) => tr(ch)
     }
-    if(lift.isEmpty) c2
+    val c3 = if(lift.isEmpty) c2
     else {
-      val newFrom = lift.map { case (a, f, s, c2) =>
+      val newFrom = lift.map { case (a, f, s, c2, tpe) =>
         val c3 = ensureStruct(c2).nodeWithComputedType(SymbolScope.empty, false, true)
         val a2 = new AnonSymbol
         val (c2b, call) = s match {
           case Library.CountAll =>
-            (c3, Library.Count.typed(c3.nodeType.asCollectionType.elementType, LiteralNode(1)))
+            (c3, Library.Count.typed(tpe, LiteralNode(1)))
           case s =>
             // All standard aggregate functions operate on a single column
             val Some(Pure(StructNode(Seq((f2, _))), _)) = c3.select
-            val elType = c3.nodeType.asCollectionType.elementType
-            (c3, Apply(s, Seq(Select(Ref(a2), f2)))(elType))
+            (c3, Apply(s, Seq(Select(Ref(a2), f2)))(tpe))
         }
         a -> Comprehension(from = Seq(a2 -> c2b),
           select = Some(Pure(StructNode(IndexedSeq(f -> call)))))
@@ -384,6 +391,8 @@ class FuseComprehensions extends Phase {
       logger.debug("Introducing new generator(s) "+newFrom.map(_._1).mkString(", ")+" for aggregations")
       c2.copy(from = c.from ++ newFrom)
     }
+    if(c3 ne c) logger.debug("After lifting aggregates: ", c3)
+    c3
   }
 
   /** Rewrite a Comprehension to always return a StructNode */

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -250,6 +250,7 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
         b"\($n like ${quote("%"+likeEncode(s))(ScalaBaseType.stringType)} escape '^'\)"
       case Library.Trim(n) =>
         expr(Library.LTrim.typed[String](Library.RTrim.typed[String](n)), skipParens)
+      case Library.SilentCast(ch) => b"$ch"
       case a @ Library.Cast(ch @ _*) =>
         val tn =
           if(ch.length == 2) ch(1).asInstanceOf[LiteralNode].value.asInstanceOf[String]


### PR DESCRIPTION
- Inline single-row generators of shape Pure(StructNode(_)) into the
  projections of Bind nodes in convertToComprehensions. If we rely on
  doing it in fuseComprehensions it may be too late: If that generator
  returns an aggregate, it will have already been lifted into the parent
  comprehension, making the single-row character unrecognizable.
- Assign correct types to lifted aggregates and inlined aggregates.

Fixes issue #753. Test in CountTest.testJoinCount. Review by @cvogt 
