### PR TITLE
Prevent some initialization order problems

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcTypesComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcTypesComponent.scala
@@ -36,11 +36,13 @@ trait JdbcTypesComponent extends RelationalTypesComponent { driver: JdbcDriver =
   }
 
   object MappedJdbcType extends MappedColumnTypeFactory {
-    def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T] =
+    def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T] = {
+      assertNonNullType(implicitly[BaseColumnType[U]])
       new MappedJdbcType[T, U] with BaseTypedType[T] {
         def map(t: T) = tmap(t)
         def comap(u: U) = tcomap(u)
       }
+    }
   }
 
   object JdbcType {

--- a/src/main/scala/scala/slick/lifted/Query.scala
+++ b/src/main/scala/scala/slick/lifted/Query.scala
@@ -225,7 +225,7 @@ final class BaseJoinQuery[+E1, +E2, U1, U2, C[_]](leftGen: Symbol, rightGen: Sym
   * for operations that can be performed on tables but not on arbitrary
   * queries, e.g. getting the table DDL. */
 class TableQuery[E <: AbstractTable[_]](cons: Tag => E) extends Query[E, E#TableElementType, Seq] {
-  val shaped = {
+  lazy val shaped = {
     val baseTable = cons(new BaseTag { base =>
       def taggedAs(path: List[Symbol]): AbstractTable[_] = cons(new RefTag(path) {
         def taggedAs(path: List[Symbol]) = base.taggedAs(path)
@@ -234,7 +234,7 @@ class TableQuery[E <: AbstractTable[_]](cons: Tag => E) extends Query[E, E#Table
     ShapedValue(baseTable, Shape.repShape.asInstanceOf[Shape[FlatShapeLevel, E, E#TableElementType, E]])
   }
 
-  val toNode = shaped.toNode
+  lazy val toNode = shaped.toNode
 
   /** Get the "raw" table row that represents the table itself, as opposed to
     * a Path for a variable of the table's type. This method should generally

--- a/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryQueryingProfile.scala
@@ -22,8 +22,10 @@ trait MemoryQueryingProfile extends RelationalProfile { driver: MemoryQueryingDr
   def createUnshapedQueryExecutor[M](value: M): UnshapedQueryExecutor[M] = new UnshapedQueryExecutorDef[M](value)
 
   class MappedColumnTypeFactory extends super.MappedColumnTypeFactory {
-    def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T] =
+    def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T] = {
+      assertNonNullType(implicitly[BaseColumnType[U]])
       new MappedColumnType(implicitly[BaseColumnType[U]], tmap, tcomap)
+    }
   }
 
   class MappedColumnType[T, U](val baseType: ColumnType[U], toBase: T => U, toMapped: U => T)(implicit val classTag: ClassTag[T]) extends ScalaType[T] with BaseTypedType[T] {

--- a/src/main/scala/scala/slick/profile/RelationalProfile.scala
+++ b/src/main/scala/scala/slick/profile/RelationalProfile.scala
@@ -138,6 +138,8 @@ trait RelationalTableComponent { driver: RelationalDriver =>
     val O: driver.columnOptions.type = columnOptions
 
     def column[C](n: String, options: ColumnOption[C]*)(implicit tm: TypedType[C]): Column[C] = new Column[C] {
+      if(tm == null)
+        throw new NullPointerException("implicit TypedType[C] for column[C] is null. This may be an initialization order problem. When using a MappedColumnType, you may want to change it from a val to a lazy val or def.")
       override def toNode =
         Select((tableTag match {
           case r: RefTag => Path(r.path)
@@ -188,8 +190,13 @@ trait RelationalTypesComponent { driver: BasicDriver =>
 
   val MappedColumnType: MappedColumnTypeFactory
 
+
   trait MappedColumnTypeFactory {
     def base[T : ClassTag, U : BaseColumnType](tmap: T => U, tcomap: U => T): BaseColumnType[T]
+
+    protected[this] def assertNonNullType(t: BaseColumnType[_]): Unit =
+      if(t == null)
+        throw new NullPointerException("implicit BaseColumnType[U] for MappedColumnType.base[T, U] is null. This may be an initialization order problem.")
   }
 
   trait ImplicitColumnTypes {


### PR DESCRIPTION
- Make TableQuery.shaped and TableQuery.toNode lazy to prevent them
  from being initialized unnecessarily early, thus avoiding infinite
  recursion loops during initialization.
- Check for null TypedType values in Table.column and
  MappedColumnType.base, failing early with a NPE with a useful error
  message.

Tests in RelationalMiscTest.testInitErrors. Fixes #730.

Review by @cvogt 
