### PR TITLE
Enforce maxRows in PositionedResultIterator.

### DIFF
--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/PositionedResultTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/PositionedResultTest.scala
@@ -1,0 +1,34 @@
+package scala.slick.test.jdbc
+
+import scala.slick.jdbc.{PositionedResult, PositionedResultIterator}
+import com.typesafe.slick.testkit.util.DelegateResultSet
+import org.junit.Test
+import org.junit.Assert._
+
+class PositionedResultTest {
+
+  @Test def testMaxRows {
+    assertEquals(5, createFakePR(5, 0).length)
+    assertEquals(1, createFakePR(5, 1).length)
+    assertEquals(4, createFakePR(5, 4).length)
+    assertEquals(5, createFakePR(5, 5).length)
+    assertEquals(5, createFakePR(5, 6).length)
+  }
+
+  def createFakePR(len: Int, limit: Int): PositionedResultIterator[Int] = {
+    val fakeRS = new DelegateResultSet(null) {
+      var count: Int = 0
+      override def next() = {
+        count += 1
+        count <= len
+      }
+      override def getInt(columnIndex: Int): Int = columnIndex
+      override def wasNull(): Boolean = false
+    }
+    val pr = new PositionedResult(fakeRS) { def close() {} }
+    new PositionedResultIterator[Int](pr, limit) {
+      def extractValue(pr: PositionedResult) = pr.nextInt()
+    }
+  }
+
+}

--- a/src/main/scala/scala/slick/jdbc/PositionedResult.scala
+++ b/src/main/scala/scala/slick/jdbc/PositionedResult.scala
@@ -167,11 +167,16 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable { outer =>
 abstract class PositionedResultIterator[+T](val pr: PositionedResult, maxRows: Int) extends ReadAheadIterator[T] with CloseableIterator[T] {
 
   private[this] var closed = false
+  private[this] var readRows = 0
 
   def rs = pr.rs
 
   protected def fetchNext(): T = {
-    if(pr.nextRow) extractValue(pr)
+    if((readRows < maxRows || maxRows <= 0) && pr.nextRow) {
+      val res = extractValue(pr)
+      readRows += 1
+      res
+    }
     else finished()
   }
 


### PR DESCRIPTION
This used to work in 2.0 but got broken during the Invoker refactoring.

Test in PositionedResultTest. Fixes issue #786. Review by @cvogt 
