### PR TITLE
Revert the hconsShape workaround.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -269,6 +269,8 @@ class JdbcMapperTest extends TestkitTest[JdbcTestDB] {
     assertEquals("Foo", ares)
     as.update("Foo")
 
+    assertEquals("Foo" :: "Foo" :: HNil, as.map(a => a :: a :: HNil).run.head)
+
     class B(tag: Tag) extends Table[Tuple1[String]](tag, "single_b") {
       def b = column[String]("b")
       def * = Tuple1(b)

--- a/src/main/scala/scala/slick/collection/heterogenous/HList.scala
+++ b/src/main/scala/scala/slick/collection/heterogenous/HList.scala
@@ -132,7 +132,7 @@ final object HList {
     def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new HListShape(shapes)
   }
   implicit def hnilShape[Level <: ShapeLevel] = new HListShape[Level, HNil.type, HNil.type, HNil.type](Nil)
-  implicit def hconsShape[Level <: ShapeLevel, L1 <: Level, L2 <: Level, M1, M2 <: HList, U1, U2 <: HList, P1, P2 <: HList](implicit s1: Shape[L1, M1, U1, P1], s2: HListShape[L2, M2, U2, P2]) =
+  implicit def hconsShape[Level <: ShapeLevel, M1, M2 <: HList, U1, U2 <: HList, P1, P2 <: HList](implicit s1: Shape[_ <: Level, M1, U1, P1], s2: HListShape[_ <: Level, M2, U2, P2]) =
     new HListShape[Level, M1 :: M2, U1 :: U2, P1 :: P2](s1 +: s2.shapes)
 }
 // Separate object for macro impl to avoid dependency of companion class on scala.reflect, see https://github.com/xeno-by/sbt-example-paradise210/issues/1#issuecomment-21021396


### PR DESCRIPTION
It is no longer needed in Scala 2.10.4 and 2.11, and it prevented some
uses of HLists.

Test in JdbcMapperTest.testSingleElement (did not compile with the
workaround in place). Fixes issue #728. Review by @cvogt 
