### PR TITLE
Support Unit values in Query return types.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalTypeTest.scala
@@ -59,4 +59,17 @@ class RelationalTypeTest extends TestkitTest[RelationalTestDB] {
     roundtrip[Boolean]("boolean_true", true)
     roundtrip[Boolean]("boolean_false", false)
   }
+
+  def testUnit {
+    class T(tag: Tag) extends Table[Int](tag, "unit_t") {
+      def id = column[Int]("id")
+      def * = id
+    }
+    val ts = TableQuery[T]
+    ts.ddl.create
+    ts += 42
+    assertEquals(Seq(()), ts.map(_ => ()).run)
+    assertEquals(Seq(((), 42)), ts.map(a => ((), a)).run)
+    assertEquals(Seq((42, ())), ts.map(a => (a, ())).run)
+  }
 }

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -109,8 +109,10 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
             buildSelectPart(n)
             b" as `$sym"
           }
+          if(ch.isEmpty) b"1"
         case Some(Pure(ProductNode(ch), _)) =>
           b.sep(ch, ", ")(buildSelectPart)
+          if(ch.isEmpty) b"1"
         case Some(Pure(n, _)) => buildSelectPart(n)
         case None =>
           if(c.from.length <= 1) b"*"

--- a/src/main/scala/scala/slick/relational/ResultConverter.scala
+++ b/src/main/scala/scala/slick/relational/ResultConverter.scala
@@ -103,6 +103,14 @@ final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product
   }
 }
 
+final class UnitResultConverter[M <: ResultConverterDomain] extends ResultConverter[M, Unit] {
+  def fullWidth = 0
+  def skippingWidth = 0
+  def read(pr: Reader) = ()
+  def update(value: Unit, pr: Updater) = ()
+  def set(value: Unit, pp: Writer, forced: Boolean) = ()
+}
+
 final class GetOrElseResultConverter[M <: ResultConverterDomain, T](child: ResultConverter[M, Option[T]], default: () => T) extends ResultConverter[M, T] {
   def read(pr: Reader) = child.read(pr).getOrElse(default())
   def update(value: T, pr: Updater) = child.update(Some(value), pr)

--- a/src/main/scala/scala/slick/relational/ResultConverterCompiler.scala
+++ b/src/main/scala/scala/slick/relational/ResultConverterCompiler.scala
@@ -16,7 +16,8 @@ trait ResultConverterCompiler[Domain <: ResultConverterDomain] {
     case p @ Path(_) => createColumnConverter(n, p, None)
     case OptionApply(p @ Path(_)) => createColumnConverter(n, p, None)
     case ProductNode(ch) =>
-      new ProductResultConverter(ch.map(n => compile(n))(collection.breakOut): _*)
+      if(ch.isEmpty) new UnitResultConverter
+      else new ProductResultConverter(ch.map(n => compile(n))(collection.breakOut): _*)
     case GetOrElse(ch, default) =>
       createGetOrElseResultConverter(compile(ch).asInstanceOf[ResultConverter[Domain, Option[Any]]], default)
     case TypeMapping(ch, mapper, _) =>

--- a/src/main/scala/scala/slick/util/TupleSupport.fm
+++ b/src/main/scala/scala/slick/util/TupleSupport.fm
@@ -21,7 +21,8 @@ object TupleSupport {
     case p => p.productIterator.toIndexedSeq
   }
 
-  private[this] val tupleClassTags = Vector[ClassTag[_ <: Product]](
+  private[this] val tupleClassTags = Vector[ClassTag[_]](
+    classTag[Unit],
 <#list 1..22 as i>
     classTag[Tuple${i}[<#list 1..i as j>_<#if i != j>, </#if></#list>]]<#if i != 22>,</#if>
 </#list>
@@ -29,8 +30,8 @@ object TupleSupport {
   private[this] val productWrapperTag = classTag[ProductWrapper]
 
   /** Return a ClassTag for a tuple of the given arity */
-  def classTagForArity(i: Int): ClassTag[_ <: Product] =
-    if(i <= tupleClassTags.length) tupleClassTags(i-1) else productWrapperTag
+  def classTagForArity(i: Int): ClassTag[_] =
+    if(i < tupleClassTags.length) tupleClassTags(i) else productWrapperTag
 }
 
 /** Extension methods for prepending and appending values to tuples */


### PR DESCRIPTION
- Emit a dummy value ("select 1 from ...") in
  JdbcStatementBuilderComponent for a query which returns an empty
  ProductNode or StructNode.
- Add a UnitResultConverter of width 0 and create this instead of a
  ProductResultConverter for empty ProductNodes.
- Return classTag[Unit] for arity 0 in TupleSupport.classTagForArity.

Tests in RelationalTypeTest.testUnit. Fixes issue #742. Review by @cvogt.
