### PR TITLE
add pg aggregate functions support

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PgFeatureTests.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PgFeatureTests.scala
@@ -1,0 +1,61 @@
+package com.typesafe.slick.testkit.tests
+
+import com.typesafe.slick.testkit.util.{JdbcTestDB, TestkitTest}
+import scala.slick.driver.PostgresDriver
+import scala.slick.ast.Library.SqlFunction
+import scala.slick.ast.LiteralNode
+import org.junit.Assert._
+
+class PgFeatureTests extends TestkitTest[JdbcTestDB] {
+
+  def testAggregates {
+    if (List("postgres").contains(tdb.confName)) {
+
+      val driver = tdb.driver.asInstanceOf[PostgresDriver]
+      import driver.simple._
+
+      ///
+      case class Tab(name: String, count: Int, x: Double, y: Double)
+
+      class Tabs(tag: Tag) extends Table[Tab](tag, "test1_tab1") {
+        def name = column[String]("COL2")
+        def count = column[Int]("count")
+        def x = column[Double]("x")
+        def y = column[Double]("y")
+
+        def * = (name, count, x, y) <> (Tab.tupled, Tab.unapply)
+      }
+      val tabs = TableQuery(new Tabs(_))
+
+      (tabs.ddl).create
+
+      ///
+      tabs ++= Seq(
+        Tab("foo", 1, 103.05, 179.17),
+        Tab("quux", 3, 57.39, 99.07),
+        Tab("bar", 2, 35.89, 101.33),
+        Tab("bar", 11, 73.75, 28.57)
+      )
+
+      println("============== testing pg aggregate function support =============")
+
+      object AggLibrary {
+        val Avg = new SqlFunction("avg")
+        val StringAgg = new SqlFunction("string_agg")
+        val Corr = new SqlFunction("corr")
+      }
+
+      case class Avg[T]() extends UnaryAggFuncPartsBasic[T, T](AggLibrary.Avg)
+      case class StringAgg(delimiter: String) extends UnaryAggFuncPartsBasic[String, String](AggLibrary.StringAgg, List(LiteralNode(delimiter)))
+      case class Corr() extends BinaryAggFuncPartsBasic[Double, Double](AggLibrary.Corr)
+
+      val q = tabs.map(t => (t.name ^: StringAgg(",").forDistinct().orderBy(t.name), t.count ^: Avg[Int]))
+      println(s"q = ${q.selectStatement}")
+      assertEquals(("bar,foo,quux", 4), q.first)
+
+      val q1 = tabs.map(t => (t.y, t.x) ^: Corr())
+      println(s"q = ${q1.selectStatement}")
+      assertEquals(0.45, q1.first, 0.01)
+    }
+  }
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -44,6 +44,7 @@ object Testkit {
     classOf[tk.TemplateTest] ::
     classOf[tk.TransactionTest] ::
     classOf[tk.UnionTest] ::
+    classOf[tk.PgFeatureTests] ::
     (Nil: List[Class[_ <: TestkitTest[_ >: Null <: TestDB]]])
 }
 

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -3,7 +3,7 @@ package scala.slick.driver
 import java.util.UUID
 import java.sql.{PreparedStatement, ResultSet}
 import scala.slick.lifted._
-import scala.slick.ast.{SequenceNode, Library, FieldSymbol, Node}
+import scala.slick.ast._
 import scala.slick.util.MacroSupport.macroSupportInterpolation
 import scala.slick.compiler.CompilerState
 import scala.slick.jdbc.meta.MTable
@@ -28,6 +28,7 @@ trait PostgresDriver extends JdbcDriver { driver =>
   override def getTables: Invoker[MTable] = MTable.getTables(None, None, None, Some(Seq("TABLE")))
 
   override val columnTypes = new JdbcTypes
+  override val simple: SimpleQL with Implicits = new SimpleQL with Implicits {}
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
   override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new TableDDLBuilder(table)
   override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder = new ColumnDDLBuilder(column)
@@ -38,6 +39,12 @@ trait PostgresDriver extends JdbcDriver { driver =>
     /* PostgreSQL does not have a TINYINT type, so we use SMALLINT instead. */
     case java.sql.Types.TINYINT => "SMALLINT"
     case _ => super.defaultSqlTypeName(tmd)
+  }
+
+  trait SimpleQL extends super.SimpleQL {
+    type UnaryAggFuncPartsBasic[T,R] = driver.UnaryAggFuncPartsBasic[T,R]
+    type BinaryAggFuncPartsBasic[T,R] = driver.BinaryAggFuncPartsBasic[T,R]
+    type TernaryAggFuncPartsBasic[T,R] = driver.TernaryAggFuncPartsBasic[T,R]
   }
 
   class QueryBuilder(tree: Node, state: CompilerState) extends super.QueryBuilder(tree, state) {
@@ -112,6 +119,104 @@ trait PostgresDriver extends JdbcDriver { driver =>
       override def valueToSQLLiteral(value: UUID) = "'" + value + "'"
       override def hasLiteralForm = true
     }
+  }
+
+  /*****************************************************************************************
+    *                        additional feature support related
+    *****************************************************************************************/
+  /**
+   * pg inherits support, for usage pls see [[com.typesafe.slick.testkit.tests.PgFeatureTests]]
+   */
+  trait InheritingTable { sub: Table[_] =>
+    val inherited: Table[_]
+  }
+
+  /**
+   * pg aggregate function support, usage:
+   * {{{
+   *  object AggregateLibrary {
+   *    val StringAgg = new SqlFunction("string_agg")
+   *  }
+   *  case class StringAgg(delimiter: String) extends UnaryAggFuncPartsBasic[String, String](AggregateLibrary.StringAgg, List(LiteralNode(delimiter)))
+   *  ...
+   *  col1 ^: StringAgg(",").forDistinct().orderBy(col1 desc)
+   * }}}
+   */
+  final case class AggFuncInputs(aggParams: Seq[Node], modifier: Option[String] = None, orderBy: Seq[(Node, Ordering)] = Nil) extends SimplyTypedNode {
+    type Self = AggFuncInputs
+    val nodeChildren = aggParams ++ orderBy.map(_._1)
+    protected[this] def nodeRebuild(ch: IndexedSeq[Node]): Self = {
+      val newAggParams = ch.slice(0, aggParams.length)
+      val orderByOffset = aggParams.length
+      val newOrderBy = ch.slice(orderByOffset, orderByOffset + orderBy.length)
+      copy(aggParams = newAggParams,
+        orderBy = (orderBy, newOrderBy).zipped.map { case ((_, o), n) => (n, o) })
+    }
+    protected def buildType = aggParams(0).nodeType
+    override def toString = "AggFuncInputs"
+  }
+
+  ///
+  trait AggFuncParts {
+    def aggFunc: FunctionSymbol
+    def params: Seq[Node]
+    def modifier: Option[String]
+    def ordered: Option[Ordered]
+  }
+  protected sealed class AggFuncPartsImpl(
+    val aggFunc: FunctionSymbol,
+    val params: Seq[Node] = Nil,
+    val modifier: Option[String] = None,
+    val ordered: Option[Ordered] = None
+    ) extends AggFuncParts
+
+  ///
+  trait UnaryAggFunction[T,R] { parts: AggFuncParts =>
+    def ^:[P1,PR](expr: Column[P1])(implicit tm: JdbcType[R], om: OptionMapperDSL.arg[T,P1]#to[R,PR]): Column[PR] = {
+      val aggParams = expr.toNode +: params
+      om.column(aggFunc, AggFuncInputs(aggParams, modifier, ordered.map(_.columns).getOrElse(Nil)))
+    }
+  }
+  class UnaryAggFuncPartsBasic[T,R](aggFunc: FunctionSymbol, params: Seq[Node] = Nil) extends AggFuncPartsImpl(aggFunc, params) with UnaryAggFunction[T,R] {
+    def forDistinct() = new UnaryAggFuncPartsWithModifier[T,R](aggFunc, params, Some("DISTINCT"))
+    def orderBy(ordered: Ordered) = new AggFuncPartsImpl(aggFunc, params, None, Some(ordered)) with UnaryAggFunction[T,R]
+  }
+  class UnaryAggFuncPartsWithModifier[T,R](aggFunc: FunctionSymbol, params: Seq[Node] = Nil, modifier: Option[String] = None)
+    extends AggFuncPartsImpl(aggFunc, params, modifier) with UnaryAggFunction[T,R] {
+    def orderBy(ordered: Ordered) = new AggFuncPartsImpl(aggFunc, params, modifier, Some(ordered)) with UnaryAggFunction[T,R]
+  }
+
+  ///
+  trait BinaryAggFunction[T,R] { parts: AggFuncParts =>
+    def ^:[P1,P2,PR](expr: (Column[P1], Column[P2]))(implicit tm: JdbcType[R], om: OptionMapperDSL.arg[T,P1]#arg[T,P2]#to[R,PR]): Column[PR] = {
+      val aggParams = expr._1.toNode +: expr._2.toNode +: params
+      om.column(aggFunc, AggFuncInputs(aggParams, modifier, ordered.map(_.columns).getOrElse(Nil)))
+    }
+  }
+  class BinaryAggFuncPartsBasic[T,R](aggFunc: FunctionSymbol, params: Seq[Node] = Nil) extends AggFuncPartsImpl(aggFunc, params) with BinaryAggFunction[T,R] {
+    def forDistinct() = new BinaryAggFuncPartsWithModifier[T,R](aggFunc, params, Some("DISTINCT"))
+    def orderBy(ordered: Ordered) = new AggFuncPartsImpl(aggFunc, params, None, Some(ordered)) with BinaryAggFunction[T,R]
+  }
+  class BinaryAggFuncPartsWithModifier[T,R](aggFunc: FunctionSymbol, params: Seq[Node] = Nil, modifier: Option[String] = None)
+    extends AggFuncPartsImpl(aggFunc, params, modifier) with BinaryAggFunction[T,R] {
+    def orderBy(ordered: Ordered) = new AggFuncPartsImpl(aggFunc, params, modifier, Some(ordered)) with BinaryAggFunction[T,R]
+  }
+
+  ///
+  trait TernaryAggFunction[T,R] { parts: AggFuncParts =>
+    def ^:[P1,P2,P3,PR](expr: (Column[P1], Column[P2], Column[P3]))(
+      implicit tm: JdbcType[R], om: OptionMapperDSL.arg[T,P1]#arg[T,P2]#arg[T,P3]#to[R,PR]): Column[PR] = {
+      val aggParams = expr._1.toNode +: expr._2.toNode +: expr._3.toNode +: params
+      om.column(aggFunc, AggFuncInputs(aggParams, modifier, ordered.map(_.columns).getOrElse(Nil)))
+    }
+  }
+  class TernaryAggFuncPartsBasic[T,R](aggFunc: FunctionSymbol, params: Seq[Node] = Nil) extends AggFuncPartsImpl(aggFunc, params) with TernaryAggFunction[T,R] {
+    def forDistinct() = new TernaryAggFuncPartsWithModifier[T,R](aggFunc, params, Some("DISTINCT"))
+    def orderBy(ordered: Ordered) = new AggFuncPartsImpl(aggFunc, params, None, Some(ordered)) with TernaryAggFunction[T,R]
+  }
+  class TernaryAggFuncPartsWithModifier[T,R](aggFunc: FunctionSymbol, params: Seq[Node] = Nil, modifier: Option[String] = None)
+    extends AggFuncPartsImpl(aggFunc, params, modifier) with TernaryAggFunction[T,R] {
+    def orderBy(ordered: Ordered) = new AggFuncPartsImpl(aggFunc, params, modifier, Some(ordered)) with TernaryAggFunction[T,R]
   }
 }
 


### PR DESCRIPTION
This patch is adding **postgres aggregate function**  support to `slick`.  

Sample codes for postgres aggregate function:
```scala
// prepare/define aggregate function
object AggregateLibrary {
  val StringAgg = new SqlFunction("string_agg")
}
case class StringAgg(delimiter: String) extends UnaryAggFuncPartsBasic[String,String](AggregateLibrary.StringAgg, List(LiteralNode(delimiter)))

// now, use it...
col1 ^: StringAgg(",").forDistinct().orderBy(col1 desc)
```

Pls help review and give your suggestions.