### PR TITLE
add window functions support

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/WindowFuncTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/WindowFuncTest.scala
@@ -1,0 +1,68 @@
+package com.typesafe.slick.testkit.tests
+
+import scala.slick.ast.Library.SqlFunction
+import com.typesafe.slick.testkit.util.{JdbcTestDB, TestkitTest}
+import org.junit.Assert._
+
+class WindowFuncTest extends TestkitTest[JdbcTestDB] {
+  import tdb.profile.simple._
+
+  def testWindowFunctions {
+    if (List("postgres").contains(tdb.confName)) {
+      import scala.slick.lifted.FunctionSymbolExtensionMethods._
+
+      case class Tab(col1: String, col2: String, col3: String, col4: Int)
+
+      class Tabs(tag: Tag) extends Table[Tab](tag, "TAB_Window_func") {
+        def col1 = column[String]("COL1")
+        def col2 = column[String]("COL2")
+        def col3 = column[String]("COL3")
+        def col4 = column[Int]("COL4")
+
+        def * = (col1, col2, col3, col4) <> (Tab.tupled, Tab.unapply)
+      }
+      val Tabs = TableQuery[Tabs]
+
+      Tabs.ddl.create
+      Tabs ++= Seq(
+        Tab("foo", "bar",  "bat", 1),
+        Tab("foo", "bar",  "bat", 2),
+        Tab("foo", "quux", "bat", 3),
+        Tab("baz", "quux", "bat", 4),
+        Tab("az", "quux", "bat", 5)
+      )
+
+      println("============== testing window function support =============")
+      val Avg = new SqlFunction("avg")
+
+      val q = Tabs.map(r => {
+        val avg4 = Avg.column[Int](r.col4.toNode)
+        val w = Over.partitionBy(r.col1).orderBy(r.col1, r.col4)
+        (r.col1, r.col2, r.col4, avg4 :: w)
+      })
+      println(q.selectStatement)
+      val expected = List(
+        ("az","quux",5,5),
+        ("baz","quux",4,4),
+        ("foo","bar",1,1),
+        ("foo","bar",2,1),
+        ("foo","quux",3,2)
+      )
+      assertEquals(expected, q.list)
+
+      val q1 = Tabs.filter(r => r.col4 < 5).map(r => {
+        val avg4 = Avg.column[Int](r.col4.toNode)
+        val w = Over.partitionBy(r.col1).orderBy(r.col1, r.col4.desc).rowsFrame(RowCursor.BoundPreceding(3), Some(RowCursor.CurrentRow))
+        (r.col1, r.col2, r.col4, avg4 :: w)
+      })
+      println(q1.selectStatement)
+      val expected1 = List(
+        ("baz","quux",4,4),
+        ("foo","quux",3,3),
+        ("foo","bar",2,2),
+        ("foo","bar",1,2)
+      )
+      assertEquals(expected1, q1.list)
+    }
+  }
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -44,6 +44,7 @@ object Testkit {
     classOf[tk.TemplateTest] ::
     classOf[tk.TransactionTest] ::
     classOf[tk.UnionTest] ::
+    classOf[tk.WindowFuncTest] ::
     (Nil: List[Class[_ <: TestkitTest[_ >: Null <: TestDB]]])
 }
 

--- a/src/main/scala/scala/slick/ast/Node.scala
+++ b/src/main/scala/scala/slick/ast/Node.scala
@@ -564,6 +564,24 @@ final case class ConditionalExpr(val clauses: IndexedSeq[Node], val elseClause: 
   override def toString = "ConditionalExpr"
 }
 
+/** A window function expression; clauses should be: aggExpr [partition by ...] [order by ...] [rows between .. and ..] */
+final case class WindowExpr(aggExpr: Node, partitionBy: Seq[Node], orderBy: Seq[(Node, Ordering)],
+                            frameDef: Option[(String, String, Option[String])] = None) extends SimplyTypedNode {
+  type Self = WindowExpr
+  val nodeChildren = aggExpr +: (partitionBy ++ orderBy.map(_._1))
+  protected[this] def nodeRebuild(ch: IndexedSeq[Node]): Self = {
+    val newAggExpr = ch(0)
+    val partitionByOffset = 1
+    val newPartitionBy = ch.slice(partitionByOffset, partitionByOffset + partitionBy.length)
+    val orderByOffset = partitionByOffset + partitionBy.length
+    val newOrderBy = ch.slice(orderByOffset, orderByOffset + orderBy.length)
+    copy(aggExpr = newAggExpr, partitionBy = newPartitionBy,
+      orderBy = (orderBy, newOrderBy).zipped.map { case ((_, o), n) => (n, o) })
+  }
+  protected def buildType = aggExpr.nodeType
+  override def toString = "WindowExpr"
+}
+
 final case class OptionApply(val child: Node) extends UnaryNode with SimplyTypedNode {
   type Self = OptionApply
   protected[this] def nodeRebuild(ch: Node) = copy(child = ch)

--- a/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcStatementBuilderComponent.scala
@@ -297,6 +297,16 @@ trait JdbcStatementBuilderComponent { driver: JdbcDriver =>
           case n => b" else $n"
         }
         b" end)"
+      case c: WindowExpr =>
+        expr(c.aggExpr)
+        b" over("
+        if(c.partitionBy.nonEmpty) { b" partition by "; b.sep(c.partitionBy, ",")(expr(_, true)) }
+        if(c.orderBy.nonEmpty) buildOrderByClause(c.orderBy)
+        c.frameDef.map {
+          case (mode, start, Some(end)) => b" $mode between $start and $end"
+          case (mode, start, None)      => b" $mode $start"
+        }
+        b") "
       case RowNumber(by) =>
         b"row_number() over("
         if(by.isEmpty) b"order by (select 1)"

--- a/src/main/scala/scala/slick/lifted/Aliases.scala
+++ b/src/main/scala/scala/slick/lifted/Aliases.scala
@@ -17,6 +17,8 @@ trait Aliases {
   type LiteralColumn[T] = lifted.LiteralColumn[T]
   val LiteralColumn = lifted.LiteralColumn
   val Case = lifted.Case
+  val Over = lifted.Over
+  val RowCursor = lifted.Over.RowCursor
   type Rep[T] = lifted.Rep[T]
   val Functions = lifted.Functions
   type Parameters[PU, PP] = lifted.Parameters[PU, PP]

--- a/src/main/scala/scala/slick/lifted/Over.scala
+++ b/src/main/scala/scala/slick/lifted/Over.scala
@@ -1,0 +1,69 @@
+package scala.slick.lifted
+
+import scala.slick.ast._
+
+/** `Over` provides a DSL for `OVER clause` of window function in the query language.
+  * An optional series of `partitionBy`/`OrderBy`/`rowsFrame`/`rangeFrame` expressions
+  * can be chained, e.g.:
+  * {{{
+  *   salary.avg :: Over.partitionBy(dept).orderBy(dept,salary)
+  *                   .rowsFrame(RowCursor.UnboundPreceding, RowCursor.CurrentRow)
+  * }}}
+  * NOTE: to cooperate with it, you maybe need some aggregate related column extension
+  * methods, like [[scala.slick.lifted.ExtensionMethods]] did.
+  * */
+object Over {
+  sealed class RowCursor(val desc: String)
+
+  object RowCursor {
+    case object CurrentRow extends RowCursor("current row")
+    case class BoundPreceding[T <: AnyVal](value: T) extends RowCursor(s"$value preceding")
+    case object UnboundPreceding extends RowCursor("unbounded preceding")
+    case class BoundFollowing[T <: AnyVal](value: T) extends RowCursor(s"$value following")
+    case object UnboundFollowing extends RowCursor("unbounded following")
+  }
+
+  private val ROWS_MODE  = "rows"
+  private val RANGE_MODE = "range"
+
+  ///
+  def apply(): OverClause = new OverClause(IndexedSeq())
+
+  def partitionBy(columns: Column[_]*): OverWithPartitionBy = new OverWithPartitionBy(columns.map(_.toNode))
+
+  def orderBy(ordered: Ordered): OverWithOrderBy = new OverWithOrderBy(ordered.columns)
+
+  def rowsFrame(start: RowCursor, end: Option[RowCursor] = None): OverWithFrameDef = new OverWithFrameDef((ROWS_MODE, start.desc, end.map(_.desc)))
+  
+  def rangeFrame(start: RowCursor, end: Option[RowCursor] = None): OverWithFrameDef = new OverWithFrameDef((RANGE_MODE, start.desc, end.map(_.desc)))
+
+  //
+  sealed class OverClause(partitionBy: Seq[Node] = Nil, orderBy: Seq[(Node, Ordering)] = Nil,
+                          frameDef: Option[(String, String, Option[String])] = None) {
+    def ::[T: TypedType](aggExpr: Column[T]): Column[T] = Column.forNode[T](WindowExpr(aggExpr.toNode, partitionBy, orderBy, frameDef))
+  }
+
+  final class OverWithPartitionBy(partitionBy: Seq[Node]) extends OverClause(partitionBy) {
+    
+    def orderBy(ordered: Ordered): OverWithOrderBy = new OverWithOrderBy(ordered.columns, partitionBy)
+    
+    def rowsFrame(start: RowCursor, end: Option[RowCursor] = None): OverWithFrameDef =
+      new OverWithFrameDef((ROWS_MODE, start.desc, end.map(_.desc)), partitionBy = partitionBy)
+    
+    def rangeFrame(start: RowCursor, end: Option[RowCursor] = None): OverWithFrameDef =
+      new OverWithFrameDef((RANGE_MODE, start.desc, end.map(_.desc)), partitionBy = partitionBy)
+  }
+  
+  final class OverWithOrderBy(orderBy: Seq[(Node, Ordering)],
+                              partitionBy: Seq[Node] = Nil) extends OverClause(partitionBy, orderBy) {
+    def rowsFrame(start: RowCursor, end: Option[RowCursor] = None): OverWithFrameDef =
+      new OverWithFrameDef((ROWS_MODE, start.desc, end.map(_.desc)), orderBy, partitionBy)
+    
+    def rangeFrame(start: RowCursor, end: Option[RowCursor] = None): OverWithFrameDef =
+      new OverWithFrameDef((RANGE_MODE, start.desc, end.map(_.desc)), orderBy, partitionBy)
+  }
+  
+  final class OverWithFrameDef(frameDef: (String, String, Option[String]),
+                               orderBy: Seq[(Node, Ordering)] = Nil,
+                               partitionBy: Seq[Node] = Nil) extends OverClause(partitionBy, orderBy, Some(frameDef))
+}


### PR DESCRIPTION
This patch is adding **window function** support to `slick`. 

A usage example of window function is as below:
```scala
salary.avg :: Over.partitionBy(dept).orderBy(dept,salary)
                     .rowsFrame(RowCursor.UnboundPreceding, RowCursor.CurrentRow)
```

Pls help review and give your suggestions.