### PR TITLE
Add hackSql Invoker/Executor method

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcExecutorComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcExecutorComponent.scala
@@ -20,6 +20,16 @@ trait JdbcExecutorComponent extends SqlExecutorComponent { driver: JdbcDriver =>
   def createUnshapedQueryExecutor[M](value: M): UnshapedQueryExecutor[M] = new UnshapedQueryExecutorDef[M](value)
 
   class QueryExecutorDef[R](tree: Node, param: Any) extends super.QueryExecutorDef[R] {
+    /** Replace the SQL query used by this invoker.
+      * This can be used as a workaround to replace
+      * non-optimal SQL produced by Slick's query compiler.
+      */
+    def hackSql(sql: String) = new QueryExecutorDef[R](tree, param){
+      override lazy val selectStatement = sql
+      override protected def createQueryInvoker[R](tree: Node, param: Any) = super.createQueryInvoker[R](tree, param).hackSql(sql)
+    }
+
+    protected def createQueryInvoker[R](tree: Node, param: Any) = driver.createQueryInvoker[R](tree, param)
 
     lazy val selectStatement =
       tree.findNode(_.isInstanceOf[CompiledStatement]).get

--- a/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInvokerComponent.scala
@@ -42,6 +42,14 @@ trait JdbcInvokerComponent extends BasicInvokerComponent{ driver: JdbcDriver =>
     protected def extractValue(pr: PositionedResult): R = converter.read(pr.rs)
     protected def updateRowValues(pr: PositionedResult, value: R) = converter.update(value, pr.rs)
     def invoker: this.type = this
+
+    /** Replace the SQL query used by this invoker.
+      * This can be used as a workaround to replace
+      * non-optimal SQL produced by Slick's query compiler.
+      */
+    def hackSql(sql: String) = new QueryInvoker[R](tree, param){
+      override def getStatement = sql
+    }
   }
 
   class DDLInvoker(ddl: DDL) extends super.DDLInvoker {


### PR DESCRIPTION
for replacing the sql generated by Slick's query compiler by hand-written sql

Slick's type-safe API becomes unusable, when the compiler generates queries the optimizer of the targeted db can't efficiently deal with. A known case are nested subqueries, where MySQL <= 5.5 stops may stop using indices and do unnecessary table scans. This implements a viable workaround, which allows to replace the generated SQL by hand-written SQL.

This is also useful for injecting type-preserving features not supported by Slick such as index hints.

Replaces suggested hack in #807.

review by @szeiger 

Two related mailing list threads:
https://groups.google.com/d/msgid/scalaquery/ee4cdbfe-cf2f-4497-afd2-d27bbc3b8949%40googlegroups.com
https://groups.google.com/d/msg/scalaquery/4O1Wr4EK-W4/b7FCudlia2YJ
