### PR TITLE
Various documentation improvements for 2.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -163,7 +163,9 @@ object SlickBuild extends Build {
         "-doc-source-url", "https://github.com/slick/slick/blob/"+v+"/src/main€{FILE_PATH}.scala",
         "-doc-root-content", "scaladoc-root.txt"
       )),
-      (sphinxEnv in Sphinx) := (sphinxEnv in Sphinx).value + ("version" -> version.value) + ("release" -> version.value),
+      (sphinxEnv in Sphinx) := (sphinxEnv in Sphinx).value +
+        ("version" -> version.value.replaceFirst("""(\d*.\d*).*""", """$1""")) +
+        ("release" -> version.value),
       (sphinxProperties in Sphinx) := Map.empty,
       test := (), // suppress test status output
       testOnly :=  (),

--- a/src/sphinx/conf.py
+++ b/src/sphinx/conf.py
@@ -33,7 +33,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Slick'
-copyright = u'2011-2014 Typesafe, Inc.'
+copyright = u'2011-2014 Typesafe, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -244,29 +244,30 @@ epub_copyright = u'2011-2014 Typesafe, Inc.'
 
 # -- Custom set-up -------------------------------------------------------------
 
-slick_examples_version = version
+slick_template_suffix = '-'+version
 scala_version = '2.10.0'
 
 # e.g. :issue:`36` :ticket:`8`
 extlinks = {
-  'slick': ('https://github.com/slick/slick/blob/'+version+'/%s', ''),
+  'slick': ('https://github.com/slick/slick/blob/'+release+'/%s', ''),
   'issue': ('https://github.com/slick/slick/issues/%s', 'issue #'),
   'ticket': ('https://www.assembla.com/spaces/typesafe-slick/tickets/%s', 'ticket #'),
-  'example-src': ('https://github.com/slick/slick-examples/blob/'+slick_examples_version+'/src/main/scala/com/typesafe/slick/examples/%s', ''),
-  'example': ('https://github.com/slick/slick-examples/blob/'+slick_examples_version+'/%s', ''),
   'wikipedia' : ('http://en.wikipedia.org/wiki/%s',''),
   'javaapi' : ('http://docs.oracle.com/javase/7/docs/api/%s.html', '')
 }
 
 apilinks = {
-  'api': 'http://slick.typesafe.com/doc/'+version+'/api/#%s',
+  'api': 'http://slick.typesafe.com/doc/'+release+'/api/#%s',
   'scalaapi': 'http://www.scala-lang.org/api/'+scala_version+'/#%s'
 }
 
 rst_epilog = '''
 .. include:: /links.txt
-.. _Slick Examples: https://github.com/slick/slick-examples/tree/%(examples-version)s
-.. _Slick TestKit Example: https://github.com/slick/slick-testkit-example/tree/%(examples-version)s
+.. _Hello Slick template: https://typesafe.com/activator/template/hello-slick%(template-suffix)s
+.. _Slick Plain SQL Queries template: https://typesafe.com/activator/template/slick-plainsql%(template-suffix)s
+.. _Slick Multi-DB Patterns template: http://typesafe.com/activator/template/slick-multidb%(template-suffix)s
+.. _Slick Direct Embedding template: http://typesafe.com/activator/template/slick-direct%(template-suffix)s
+.. _Slick TestKit Example template: https://typesafe.com/activator/template/slick-testkit-example%(template-suffix)s
 ''' % {
-  'examples-version': slick_examples_version
+  'template-suffix': slick_template_suffix
 }

--- a/src/sphinx/connection.rst
+++ b/src/sphinx/connection.rst
@@ -4,8 +4,11 @@ Connections / Transactions
 You can write queries anywhere in your program. When you want to execute them
 you need a database connection.
 
+.. index::
+   pair: database; connection
+
 Database connection
-------------------------------------
+-------------------
 
 You can tell Slick how to connect to the JDBC database of your choice by
 creating a :api:`Database <scala.slick.jdbc.JdbcBackend@Database:Database>` object,
@@ -20,10 +23,10 @@ connection data you have available.
 .. :ref:`required dependencies <getting-starget-dependencies>` and imported the
 .. correct :ref:`Slick driver <getting-starget-driver>`.
 
-
+.. index:: URL
 
 Using a JDBC URL
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 You can provide a JDBC URL to
 :api:`forURL <scala.slick.jdbc.JdbcBackend$DatabaseFactoryDef@forURL(String,String,String,Properties,String):DatabaseDef>`.
@@ -37,8 +40,10 @@ specific).
 
 .. TODO: mention that you have to import a matching driver
 
+.. index:: DataSource
+
 Using a DataSource
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 You can provide a :javaapi:`DataSource <javax/sql/DataSource>` object to
 :api:`forDataSource <scala.slick.jdbc.JdbcBackend$DatabaseFactoryDef@forDataSource(DataSource):DatabaseDef>`.
@@ -51,8 +56,10 @@ When you later :ref:`create a Session <session-handling>`, a connection is
 acquired from the pool and when the Session is closed it is returned to the
 pool.
 
+.. index:: JNDI
+
 Using a JNDI Name
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 If you are using :wikipedia:`JNDI` you can provide a JNDI name to
 :api:`forName <scala.slick.jdbc.JdbcBackend$DatabaseFactoryDef@forName(String):DatabaseDef>`
@@ -61,10 +68,11 @@ under which a
 
 .. includecode:: code/Connection.scala#forName
 
+.. index:: session, connection
 .. _session-handling:
 
 Session handling
---------------------------------------------
+----------------
 
 Now you have a :api:`Database <scala.slick.jdbc.JdbcBackend@Database:Database>` object
 and you can use it to open database connections, which Slick encapsulates in
@@ -73,7 +81,7 @@ and you can use it to open database connections, which Slick encapsulates in
 .. _session-scope:
 
 Automatically closing Session scope
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :api:`Database <scala.slick.jdbc.JdbcBackend@Database:Database>` object's
 :api:`withSession <scala.slick.jdbc.JdbcBackend$DatabaseDef@withSession[T]((Session)⇒T):T>`
@@ -109,8 +117,11 @@ inside a :api:`withSession <scala.slick.jdbc.JdbcBackend$DatabaseDef@withSession
 scope for example), by assigning the session to a var, by returning the session
 as the return value of the withSession scope or else.
 
+.. index::
+   pair: session; implicit
+
 Implicit Session
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 By marking the :api:`Session <scala.slick.jdbc.JdbcBackend$SessionDef>` as implicit you can avoid
 having to pass it to the executing methods explicitly.
@@ -119,10 +130,11 @@ having to pass it to the executing methods explicitly.
 
 This is optional of course. Use it if you think it makes your code cleaner.
 
+.. index:: transaction
 .. _transactions:
 
 Transactions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 You can use the :api:`Session <scala.slick.jdbc.JdbcBackend$SessionDef>` object's
 :api:`withTransaction <scala.slick.jdbc.JdbcBackend$SessionDef@withTransaction[T](⇒T):T>`
@@ -142,8 +154,11 @@ method as a shortcut.
 
 .. includecode:: code/Connection.scala#independentTransaction
 
+.. index::
+   single: session; manual
+
 Manual Session handling
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 This is not recommended, but if you have to, you can handle the lifetime of a
 :api:`Session <scala.slick.jdbc.JdbcBackend$SessionDef>` manually.
@@ -151,7 +166,7 @@ This is not recommended, but if you have to, you can handle the lifetime of a
 .. includecode:: code/Connection.scala#manual-session
 
 Passing sessions around
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 You can write re-useable functions to help with Slick queries. They mostly do
 not need a :api:`Session <scala.slick.jdbc.JdbcBackend$SessionDef>` as they just produce query
@@ -163,8 +178,12 @@ reduce boilerplate code:
 
 .. includecode:: code/Connection.scala#helpers
 
+.. index::
+   pair: session; dynamic
+   single: thread-local
+
 Dynamically scoped sessions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You usually do not want to keep sessions open for very long but open and close
 them quickly when needed. As shown above you may use a
@@ -200,6 +219,10 @@ of the consequences regarding static safety and thread safety.
 
 .. TODO: explain how session relates to connection
 
+.. index::
+   single: connection; pool
+   single: pool
+
 Connection Pools
 ----------------
 
@@ -214,7 +237,7 @@ cache them on its own. You should therefore enable prepared statement caching
 in the connection pool's configuration and select a sufficiently large pool
 size.
 
-
+.. index:: JDBC
 .. _jdbc-interop:
 
 JDBC interoperability

--- a/src/sphinx/direct-embedding.rst
+++ b/src/sphinx/direct-embedding.rst
@@ -1,3 +1,5 @@
+.. index:: direct
+
 Direct Embedding (Experimental Feature)
 =======================================
 
@@ -10,6 +12,9 @@ For a user the difference in the code is small, but queries using the direct emb
 which can make error messages easier to understand. 
 
 The following descriptions are anolog to the description of the :doc:`lifted embedding <gettingstarted>`.
+
+.. index::
+   pair: dependency; direct
 
 Dependencies
 ------------

--- a/src/sphinx/extensions.rst
+++ b/src/sphinx/extensions.rst
@@ -1,3 +1,5 @@
+.. index:: extensions, Oracle, DB2, SQL Server
+
 Slick Extensions
 ================
 

--- a/src/sphinx/gettingstarted.rst
+++ b/src/sphinx/gettingstarted.rst
@@ -1,12 +1,34 @@
+.. index:: Activator, template
+
 Getting Started
 ===============
 
-The easiest way to get started is with a working application in `Typesafe Activator <http://typesafe.com/activator>`_.
-To learn the basics of Slick start with the `Hello Slick <http://typesafe.com/activator/template/hello-slick>`_ 
-template.  To learn how to integrate Slick with Play Framework check out the 
-`Play Slick with Typesafe IDs <http://typesafe.com/activator/template/play-slick-advanced>`_ template.
+The easiest way to get started is with a working application in Typesafe Activator_. The following
+templates are created by the Slick team, with updated versions being made for new Slick releases:
 
-To include Slick into an existing project use the library published on Maven Central.  For sbt projects add the 
+* To learn the basics of Slick, start with the `Hello Slick template`_. It contains an extended
+  version of the tutorial and code from this page.
+
+* The `Slick Plain SQL Queries template`_ shows you how to do SQL queries with Slick.
+
+* The `Slick Multi-DB Patterns template`_ shows you how to write Slick applications that can use
+  different database systems and how to use custom database functions in Slick queries.
+
+* The `Slick Direct Embedding template`_ shows you how to use Slick's experimental Direct Embedding
+  query API.
+
+* The `Slick TestKit Example template`_ shows you how to use Slick TestKit to test your own Slick drivers.
+
+There are more Slick templates created by the community, as well as versions of our own templates for other
+Slick releases. You can find `all Slick templates <https://typesafe.com/activator/templates#filter:slick>`_
+on the Typesafe web site.
+
+.. index:: Maven, sbt, artifacts, build, dependency
+
+Adding Slick to Your Project
+============================
+
+To include Slick in an existing project use the library published on Maven Central.  For sbt projects add the
 following to your ``libraryDependencies``:
 
 .. parsed-literal::
@@ -27,19 +49,19 @@ For Maven projects add the following to your ``<dependencies>``:
     <version>1.6.4</version>
   </dependency>
 
+.. index:: logging, SLF4j
+
 Slick uses SLF4J_ for its own debug logging so you also need to add an SLF4J
 implementation. Here we are using ``slf4j-nop`` to disable logging. You have
 to replace this with a real logging framework like Logback_ if you want to see
 log output.
 
-Slick Examples
---------------
-
-Check out the `Slick Examples`_ project for more examples like using multiple databases, using native queries, and advanced invoker usage.
-
-
 Quick Introduction
-------------------
+==================
+
+*Note:* The rest of this chapter is based on the `Hello Slick template`_. The prefered
+way of reading this introduction is in Activator_, where you can edit and run the code
+directly while reading the tutorial.
 
 To use Slick you first need to import the API for the database you will be using, like:
 

--- a/src/sphinx/introduction.rst
+++ b/src/sphinx/introduction.rst
@@ -1,5 +1,7 @@
 :tocdepth: 2
 
+.. index:: introduction
+
 Introduction
 ############
 
@@ -17,8 +19,7 @@ When using Scala instead of raw SQL for your queries you benefit from compile-ti
 and compositionality. Slick can generate queries for different back-end databases including
 your own, using its extensible query compiler.
 
-Get started learning Slick in minutes using the `Hello Slick <http://typesafe.com/activator/template/hello-slick>`_ template in 
-`Typesafe Activator <http://typesafe.com/activator>`_.
+Get started learning Slick in minutes using the `Hello Slick template`_ in Typesafe Activator_.
 
 
 Features
@@ -34,7 +35,7 @@ Scala
 
 .. includecode:: code/GettingStartedOverview.scala#features-scala-collections
 
-Type Safe
+Type-Safe
 ^^^^^^^^^
 * Let your IDE help you write your code
 * Find problems at compile-time instead of at runtime
@@ -55,6 +56,10 @@ Slick requires Scala 2.10. (For Scala 2.9 please use ScalaQuery_, the predecesso
 
 .. _supported-dbs:
 
+.. index::
+   pair: database; supported
+.. index:: Derby, JavaDB, H2, HSQLDB, HyperSQL, Access, MySQL, PostgreSQL, SQLite
+
 Supported database systems
 --------------------------
 
@@ -74,12 +79,42 @@ Writing a fully featured plugin for your own SQL-based backend can be achieved
 with a reasonable amount of work. Support for other backends (like NoSQL) is
 under development but not yet available.
 
+.. index:: license
+
 License
 -------
+
 Slick is released under a BSD-Style free and open source software :slick:`license <LICENSE.txt>`.
 See the chapter on the commercial :doc:`Slick Extensions <extensions>` add-on
 package for details on licensing the Slick drivers for the big commercial
 database systems.
+
+.. index::
+   pair: source; compatibility
+   pair: binary; compatibility
+
+Compatibility Policy
+--------------------
+
+Slick version numbers consist of an epoch, a major and minor version, and possibly a qualifier
+(for milestone, RC and SNAPSHOT versions).
+
+For release versions (i.e. versions without a qualifier), backward binary compatibility is
+guaranteed between releases with the same epoch and major version (e.g. you could use 2.1.2 as a
+drop-in relacement for 2.1.0 but not for 2.0.0). :doc:`Slick Extensions <extensions>` requires at
+least the same minor version of Slick (e.g. Slick Extensions 2.1.2 can be used with Slick 2.1.2 but
+not with Slick 2.1.1).
+
+We do not guarantee source compatibility but we try to preserve it within the same major release.
+Upgrading to a new major release may require some changes to your sources. We generally deprecate
+old features and keep them around for a full major release cycle (i.e. features which become
+deprecated in 2.1.0 will not be removed before 2.2.0) but this is not possible for all kinds of
+changes.
+
+Release candidates have the same compatibility guarantees as the final versions to which they
+lead. There are *no compatibility guarantees* whatsoever for milestones and snapshots.
+
+.. index:: APIs
 
 Query APIs
 ----------
@@ -94,6 +129,7 @@ The experimental :doc:`Direct Embedding <direct-embedding>` is available as an
 alternative to the *Lifted Embedding*.
 
 .. _lifted-embedding:
+.. index:: lifted
 
 Lifted Embedding
 ----------------

--- a/src/sphinx/links.txt
+++ b/src/sphinx/links.txt
@@ -8,3 +8,4 @@
 .. _DBCP: http://commons.apache.org/proper/commons-dbcp/
 .. _c3p0: http://sourceforge.net/projects/c3p0/
 .. _BoneCP: http://jolbox.com/
+.. _Activator: https://typesafe.com/activator

--- a/src/sphinx/migration.rst
+++ b/src/sphinx/migration.rst
@@ -1,3 +1,5 @@
+.. index:: migration, 1.0, upgrading
+
 Migration Guide from Slick 1.0 to 2.0
 =====================================
 
@@ -12,6 +14,8 @@ Instead of writing your table descriptions or plain SQL mappers by hand, in 2.0 
 now automatically generate them from your database schema. The code-generator
 is flexible enough to customize it's output to fit exactly what you need.
 :doc:`More info on code generation <code-generation>`.
+
+.. index:: table object, ~, tuple
 
 Table Descriptions
 ------------------
@@ -89,6 +93,8 @@ function and then call ``.tupled``:
 
 .. includecode:: code/MigrationGuide.scala#mappedprojection2
 
+.. index:: profile, BasicProfile, ExtendedProfile, JdbcProfile
+
 Profile Hierarchy
 -----------------
 
@@ -155,6 +161,9 @@ Pre-compiled Updates
 Slick now supports pre-compilation of updates in the same manner like selects, see
 :ref:`compiled-queries`.
 
+.. index::
+   pair: session; package
+
 Database and Session Handling
 -----------------------------
 
@@ -204,6 +213,8 @@ This is no longer necessary in 2.0:
 Again, the recommended practice is NOT to use dynamic sessions.
 If you are uncertain if you need them the answer is most probably no.
 Static sessions are safer.
+
+.. index:: MappedTypeMapper
 
 Mapped Column Types
 -------------------

--- a/src/sphinx/queries.rst
+++ b/src/sphinx/queries.rst
@@ -1,9 +1,13 @@
+.. index:: Query
+
 Queries
 =======
 
 This chapter describes how to write type-safe queries for selecting,
 inserting, updating and deleting data with the
 :ref:`Lifted Embedding <lifted-embedding>` API.
+
+.. index:: expression, Column, scalar, collection-valued, Rep, Seq, extension method, select, projection, view
 
 Expressions
 -----------
@@ -31,6 +35,8 @@ collections.
 Additional methods for queries of scalar values are added via an
 implicit conversion to ``SingleColumnQueryExtensionMethods``.
 
+.. index:: sort, filter, order by, sortBy, where
+
 Sorting and Filtering
 ---------------------
 
@@ -38,6 +44,8 @@ There are various methods with sorting/filtering semantics (i.e. they take a
 ``Query`` and return a new ``Query`` of the same type), for example:
 
 .. includecode:: code/LiftedEmbedding.scala#filtering
+
+.. index:: join, zip, zipWithIndex
 
 Joining and Zipping
 -------------------
@@ -48,6 +56,11 @@ There are two different ways of writing joins: *Explicit* joins are performed
 by calling a method that joins two queries into a single query of a tuple of
 the individual results. *Implicit* joins arise from a specific shape of a query
 without calling a special method.
+
+.. index::
+   pair: join; implicit
+   pair: join; inner
+   pair: join; cross
 
 An *implicit cross-join* is created with a ``flatMap`` operation on a ``Query``
 (i.e. by introducing more than one generator in a for-comprehension):
@@ -60,6 +73,10 @@ If you add a filter expression, it becomes an *implicit inner join*:
 
 The semantics of these implicit joins are the same as when you are using
 ``flatMap`` on Scala collections.
+
+.. index::
+   pair: join; outer
+   pair: join; explicit
 
 Explicit joins are created by calling one of the available join methods:
 
@@ -86,6 +103,8 @@ so ``zipWithIndex`` is supported as a primitive operator:
 
 .. includecode:: code/JoinsUnions.scala#zipWithIndex
 
+.. index:: union, ++, unionAll
+
 Unions
 ------
 
@@ -96,6 +115,8 @@ operators if they have compatible types:
 
 Unlike ``union`` which filters out duplicate values, ``++`` simply concatenates
 the results of the individual queries, which is usually more efficient.
+
+.. index:: aggregate, min, max, sum, avg, length, count, exists
 
 Aggregation
 -----------
@@ -111,6 +132,8 @@ one column):
 
 .. includecode:: code/LiftedEmbedding.scala#aggregation2
 
+.. index:: group by, groupBy
+
 Grouping is done with the ``groupBy`` method. It has the same semantics as for
 Scala collections:
 
@@ -121,6 +144,11 @@ These would turn into nested collections when executing the query, which is
 not supported at the moment. Therefore it is necessary to flatten the nested
 queries immediately by aggregating their values (or individual columns)
 as done in ``q2``.
+
+.. index:: querying, Invoker, first, buildColl, selectStatement, list
+.. index::
+   pair: query; execute
+   pair: query; run
 
 Querying
 --------
@@ -147,6 +175,8 @@ If you only want a single result value, you can use ``first`` or
 used to iterate over the result set without first copying all data into a
 Scala collection.
 
+.. index:: delete, DeleteInvoker, deleteStatement
+
 Deleting
 --------
 
@@ -161,6 +191,8 @@ the ``delete`` method and a self-reference ``deleteInvoker``:
 A query for deleting must only select from a single table. Any projection is
 ignored (it always deletes full rows).
 
+.. index:: insert, +=, ++=, InsertInvoker, insertStatement
+
 Inserting
 ---------
 
@@ -174,6 +206,8 @@ for inserting are defined in
 :api:`FullInsertInvoker <scala.slick.driver.JdbcInvokerComponent@FullInsertInvoker[U]:JdbcDriver.FullInsertInvoker[U]>`.
 
 .. includecode:: code/LiftedEmbedding.scala#insert1
+
+.. index:: returning, AutoInc, generated key, into
 
 When you include an ``AutoInc`` column in an insert operation, it is silently
 ignored, so that the database can generate the proper value.
@@ -206,6 +240,8 @@ database server:
 
 In these cases, ``AutoInc`` columns are *not* ignored.
 
+.. index:: update, UpdateInvoker, updateStatement
+
 Updating
 --------
 
@@ -220,6 +256,9 @@ updating are defined in
 There is currently no way to use scalar expressions or transformations of
 the existing data in the database for updates.
 
+.. index:: prepared, QueryTemplate, parameter
+.. index::
+   pair: query; compiled
 .. _compiled-queries:
 
 Compiled Queries

--- a/src/sphinx/schemas.rst
+++ b/src/sphinx/schemas.rst
@@ -1,3 +1,5 @@
+.. index:: schema
+
 Schemas
 =======
 
@@ -6,6 +8,8 @@ This chapter describes how to work with database schemas in the
 how you can write schema descriptions by hand. Instead you 
 can also use the :doc:`code generator <code-generation>` to 
 take this work off your hands.
+
+.. index:: table, row
 
 Table Rows
 ----------
@@ -36,22 +40,32 @@ currently using the database's null propagation semantics which may differ
 from Scala's Option semantics. In particular, ``None === None`` evaluates
 to ``None``. This behaviour may change in a future major release of Slick.
 
+.. index:: ColumnOption
+
 After the column name, you can add optional column options to a ``column``
 definition. The applicable options are available through the table's ``O``
 object. The following ones are defined for ``JdbcProfile``:
 
+.. index:: primary key
+
 ``PrimaryKey``
    Mark the column as a (non-compound) primary key when creating the DDL
    statements.
+
+.. index:: default
 
 ``Default[T](defaultValue: T)``
    Specify a default value for inserting data into the table without this column.
    This information is only used for creating DDL statements so that the
    database can fill in the missing information.
 
+.. index:: type
+
 ``DBType(dbType: String)``
    Use a non-standard database-specific type for the DDL statements (e.g.
    ``DBType("VARCHAR(20)")`` for a ``String`` column).
+
+.. index:: AutoInc, generated, identity
 
 ``AutoInc``
    Mark the column as an auto-incrementing key when creating the DDL
@@ -61,11 +75,15 @@ object. The following ones are defined for ``JdbcProfile``:
    Slick will check if the return column is properly marked as AutoInc where
    needed.
 
+.. index:: null, nullable, NotNull
+
 ``NotNull``, ``Nullable``
    Explicitly mark the column as nullable or non-nullable when creating the
    DDL statements for the table. Nullability is otherwise determined from the
    type (Option or non-Option). There is usually no reason to specify these
    options.
+
+.. index:: *, star projection
 
 Every table requires a ``*`` method contatining a default projection.
 This describes what you get back when you return rows (in the form of a
@@ -76,10 +94,15 @@ or omit some columns as you like. The non-lifted type corresponding to the
 non-mapped tables, this will be a single column type or a tuple of column
 types.
 
+.. index::
+   pair: schema; name
+
 If your database layout requires *schema names*, you can specify the schema
 name for a table in front of the table name, wrapped in ``Some()``:
 
 .. includecode:: code/LiftedEmbedding.scala#schemaname
+
+.. index:: TableQuery
 
 Table Query
 -----------
@@ -97,6 +120,10 @@ You can also extend ``TableQuery`` to use it as a convenient namespace for
 additional functionality associated with the table:
 
 .. includecode:: code/LiftedEmbedding.scala#tablequery2
+
+.. index::
+   pair: table; mapped
+.. index:: <>, entity, tupled, unapply
 
 Mapped Tables
 -------------
@@ -117,6 +144,11 @@ For case classes with hand-written companion objects, ``.tupled`` only works
 if you manually extend the correct Scala function type. Alternatively you can use
 ``(User.apply _).tupled``. See `SI-3664 <https://issues.scala-lang.org/browse/SI-3664>`_ and
 `SI-4808 <https://issues.scala-lang.org/browse/SI-4808>`_.
+
+.. index:: constraint, index
+.. index::
+   pair: key; foreign
+   pair: key; primary
 
 Constraints
 -----------
@@ -147,6 +179,8 @@ are non-unique by default unless you set the ``unique`` parameter:
 All constraints are discovered reflectively by searching for methods with
 the appropriate return types which are defined in the table. This behavior
 can be customized by overriding the ``tableConstraints`` method.
+
+.. index:: DDL, create, drop
 
 Data Definition Language
 ------------------------

--- a/src/sphinx/sql.rst
+++ b/src/sphinx/sql.rst
@@ -1,3 +1,5 @@
+.. index:: SQL, Plain SQL
+
 Plain SQL Queries
 =================
 
@@ -6,13 +8,17 @@ not well supported at a higher level of abstraction. Instead of falling back
 to the low level of JDBC_, you can use Slick's *Plain SQL* queries with a much
 nicer Scala-based API.
 
+*Note:* The rest of this chapter is based on the `Slick Plain SQL Queries template`_.
+The prefered way of reading this introduction is in Activator_, where you can edit and
+run the code directly while reading the tutorial.
+
+.. index:: StaticQuery, GetResult
+
 Scaffolding
 -----------
 
-:example-src:`jdbc/PlainSQL.scala` demonstrates some features of the *Plain SQL* support. The
-imports are different from what you're used to for the
-:ref:`lifted embedding <lifted-embedding>` or
-:doc:`direct embedding <direct-embedding>`:
+The imports you need for Plain SQL queries are different from what you're used to for the
+:ref:`lifted embedding <lifted-embedding>` or :doc:`direct embedding <direct-embedding>`:
 
 .. includecode:: code/PlainSQL.scala#imports
 
@@ -30,6 +36,10 @@ The database connection is opened
 some case classes for our data:
 
 .. includecode:: code/PlainSQL.scala#setup
+
+.. index:: updateNA
+.. index::
+   pair: update; Plain SQL
 
 DDL/DML Statements
 ------------------
@@ -51,6 +61,8 @@ to ``StaticQuery.updateNA("")``). We are using it to insert some data into the
 
 .. includecode:: code/PlainSQL.scala#Q.u
 
+.. index:: +?
+
 Embedding literals into SQL code is generally not recommended for security and
 performance reasons, especially if they are to be filled at run-time with
 user-provided data. You can use the special concatenation operator ``+?`` to
@@ -61,6 +73,10 @@ value when the statement gets executed:
 
 The SQL statement is the same for all calls:
 ``insert into coffees values (?,?,?,?,?)``
+
+.. index:: queryNA, PositionedResult
+.. index::
+   pair: query; Plain SQL
 
 Query Statements
 ----------------
@@ -100,6 +116,11 @@ reducing it to a parameterless query. This makes the syntax for parameterized
 queries the same as for normal function application:
 
 .. includecode:: code/PlainSQL.scala#applyQuery
+
+.. index:: interpolation
+.. index::
+   pair: sql; interpolator
+   pair: sqlu; interpolator
 
 String Interpolation
 --------------------

--- a/src/sphinx/testkit.rst
+++ b/src/sphinx/testkit.rst
@@ -1,5 +1,13 @@
+.. index:: TestKit, testing
+.. index::
+   pair: driver; custom
+
 Slick TestKit
 =============
+
+*Note:* This chapter is based on the `Slick TestKit Example template`_.
+The prefered way of reading this introduction is in Activator_, where you can
+edit and run the code directly while reading the tutorial.
 
 When you write your own database driver for Slick, you need a way to run all
 the standard unit tests on it (in addition to any custom tests you may want to
@@ -7,9 +15,9 @@ add) to ensure that it works correctly and does not claim to support any
 capabilities which are not actually implemented. For this purpose the Slick
 unit tests have been factored out into a separate Slick TestKit project.
 
-To get started, you can clone the `Slick TestKit Example`_ project which
-contains a (slightly outdated) version of Slick's standard PostgreSQL driver
-and all the infrastructure required to build and test it.
+To get started, you can clone the `Slick TestKit Example template`_ which
+contains a copy of Slick's standard PostgreSQL driver and all the infrastructure
+required to build and test it.
 
 Scaffolding
 -----------
@@ -43,6 +51,8 @@ Driver
 
 The actual driver implementation can be found under ``src/main/scala``.
 
+.. index:: DriverTest, TestDB
+
 Test Harness
 ------------
 
@@ -73,6 +83,8 @@ default implementations can be used out of the box::
       override lazy val capabilities = driver.capabilities + TestDB.plainSql
     }
   }
+
+.. index:: databases.properties, ExternalTestDB, test-dbs
 
 Database Configuration
 ----------------------

--- a/src/sphinx/theme/layout.html
+++ b/src/sphinx/theme/layout.html
@@ -32,7 +32,7 @@ if(window.location.host == 'slick.typesafe.com'){
           {%- if logo %}
             <span class="logo"><img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Slick"/></span>
           {%- endif %}
-          {{ version|e }} documentation
+          {{ release|e }} manual
         </a></div>
         {%- endblock %}
        </div>
@@ -48,22 +48,19 @@ if(window.location.host == 'slick.typesafe.com'){
           {%- endblock %}
         </div>
         <div class="sidebar">
-          {%- block sidebartoc %}
-          <h3>{{ _('Table Of Contents') }}</h3>
-          {{ toctree() }}
-          {%- endblock %}
           {%- block sidebarsearch %}
-          <h3 style="margin-top: 1.5em;">{{ _('Search') }}</h3>
+          <h3>{{ _('Search') }}</h3>
           <form class="search" action="{{ pathto('search') }}" method="get">
             <input type="text" name="q" />
             <input type="submit" value="{{ _('Go') }}" />
             <input type="hidden" name="check_keywords" value="yes" />
             <input type="hidden" name="area" value="default" />
           </form>
-          <p class="searchtip" style="font-size: 90%">
-            {{ _('Enter search terms or a module, class or function name.') }}
-          </p>
           {%- endblock %}
+            {%- block sidebartoc %}
+            <h3 style="margin-top: 1.5em;">{{ _('Table Of Contents') }}</h3>
+            {{ toctree() }}
+            {%- endblock %}
         </div>
         <div class="clearer"></div>
       </div>

--- a/src/sphinx/userdefined.rst
+++ b/src/sphinx/userdefined.rst
@@ -1,11 +1,16 @@
+.. index:: user-defined
+
 User-Defined Features
 =====================
 
 This chapter describes how to use custom data types and database functions
 in the :ref:`Lifted Embedding <lifted-embedding>` API.
 
-Scala Database functions
---------------------------
+.. index::
+   triple: user-defined; scalar; function
+
+Scalar Database Functions
+-------------------------
 
 If your database system supports a scalar function that is not available as
 a method in Slick you can define it as a
@@ -27,27 +32,35 @@ write your own wrapper function with the proper type-checking:
 flexibility (e.g. function-like expressions with unusual syntax), you can
 use :api:`scala.slick.lifted.SimpleExpression`.
 
-Other Database functions and stored procedures
+Other Database Functions And Stored Procedures
 ----------------------------------------------
 
 For database functions that return complete tables or stored procedures please use :doc:`sql`.
 Stored procedures that return multiple result sets are currently not supported.
+
+.. index:: MappedColumnType, MappedJdbcType
+.. index::
+   triple: user-defined; scalar; type
+   pair: mapped; type
 
 Scalar Types
 -------------
 
 If you need a custom column type you can implement
 :api:`ColumnType <scala.slick.driver.JdbcProfile@ColumnType[T]:JdbcDriver.ColumnType[T]>`. The most
-common scenario is mapping an application-specific type to an already supported
-type in the database. This can be done much simpler by using
-:api:`MappedColumnType <scala.slick.driver.JdbcProfile@MappedColumnType:JdbcDriver.MappedJdbcType.type>` which
-takes care of all the boilerplate. It comes with the usual import from the driver. Do not import it from the :api:`JdbcDriver <scala.slick.driver.JdbcDriver$>` singleton object.
+common scenario is mapping an application-specific type to an already supported type in the database.
+This can be done much simpler by using
+:api:`MappedColumnType <scala.slick.driver.JdbcProfile@MappedColumnType:JdbcDriver.MappedJdbcType.type>`
+which takes care of all the boilerplate. It comes with the usual import from the driver. Do not import
+it from the :api:`JdbcDriver <scala.slick.driver.JdbcDriver$>` singleton object.
 
 .. includecode:: code/LiftedEmbedding.scala#mappedtype1
 
 You can also subclass
 :api:`MappedJdbcType <scala.slick.driver.JdbcProfile@MappedJdbcType>`
 for a bit more flexibility.
+
+.. index:: MappedTo
 
 If you have a wrapper class (which can optionally be a case class and/or value
 class) for an underlying value of some supported type, you can make it extend
@@ -57,6 +70,9 @@ table-specific primary key types:
 
 .. includecode:: code/LiftedEmbedding.scala#mappedtype2
 
+.. index:: Shape
+.. index::
+   triple: user-defined; record; type
 .. _record-types:
 
 Record Types


### PR DESCRIPTION
- Remove all references to slick-examples and point to the Activator
  templates instead.
- To reduce the maintenance burden, external samples are not tied to the
  minor version of qualifier anymore. We now have 4 official Activator
  templates plus slick-testkit-example (still a regular sbt project
  because testing and error reporting does not work properly in
  Activator with our custom TestKit tests) which are all linked from the
  manual. We now link to the major release branches which can be
  updated independently when we release new minor versions. Activator
  templates have to be published separately for different major versions
  (because Activator does not support versioning yet) but multiple
  versions can live in different branches of the same repository.
- Populate the previously empty Index page.
- Add a Compatibility Policy section.
- Move the search box to the top (where people expect it) and remove the
  accompanying text (which refers to Python-specific concepts).
- Change “documentation” to “manual” in the title (short enough to
  prevent overflow with SNAPSHOT versions).

Fixes #603. Review by @cvogt 
