### PR TITLE
User uppercase identifiers in InsertTest.testInsertOrUpdateAutoInc.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -133,9 +133,9 @@ class InsertTest extends TestkitTest[JdbcTestDB] {
   }
 
   def testInsertOrUpdateAutoInc {
-    class T(tag: Tag) extends Table[(Int, String)](tag, "t_merge2") {
-      def id = column[Int]("id", O.AutoInc, O.PrimaryKey)
-      def name = column[String]("name")
+    class T(tag: Tag) extends Table[(Int, String)](tag, "T_MERGE2") {
+      def id = column[Int]("ID", O.AutoInc, O.PrimaryKey)
+      def name = column[String]("NAME")
       def * = (id, name)
       def ins = (id, name)
     }


### PR DESCRIPTION
Oracle and DB2 require non-quoted identifiers for auto-generated
columns that are returned from INSERTs. testReturning already uses
uppercase names for the same reason.

Review by @cvogt 
