### PR TITLE
Update Scala version to 2.11.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ object SlickBuild extends Build {
 
   val slickVersion = "2.1.0-SNAPSHOT"
   val binaryCompatSlickVersion = "2.1.0" // Slick base version for binary compatibility checks
-  val scalaVersions = Seq("2.10.4", "2.11.0-RC4")
+  val scalaVersions = Seq("2.10.4", "2.11.1")
 
   /** Dependencies for reuse in different parts of the build */
   object Dependencies {


### PR DESCRIPTION
Hi all, is there a reason why 2.1.0-M1 is only published against 2.11.0-RC4?
