### PR TITLE
join bug

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -87,6 +87,12 @@ class JoinTest extends TestkitTest[RelationalTestDB] {
     println("Full outer join")
     q5.run.foreach(x => println("  "+x))
     assertEquals(Vector((0,4), (1,0), (2,1), (3,2), (4,3), (5,2)), q5.map(p => (p._1, p._2)).run)
+
+    val q6 = (for {
+      ((c1,c2),p) <- (categories innerJoin categories on (_.id === _.id)) outerJoin posts on (_._2.id === _.category)
+    } yield c1.id)
+    println("two joins")
+    println(q6.run)
   }
 
   def testZip = ifCap(rcap.zip) {


### PR DESCRIPTION
@szeiger this is a bug, right?

```
[error] Test com.typesafe.slick.testkit.tests.JoinTest.testJoin[heap] failed: scala.slick.SlickException: Read null value for non-nullable column
[error]     at scala.slick.memory.MemoryQueryingDriver$MemoryCodeGen$QueryResultConverter.read(MemoryQueryingProfile.scala:98)
[error]     at scala.slick.memory.MemoryQueryingDriver$MemoryCodeGen$QueryResultConverter.read(MemoryQueryingProfile.scala:95)
[error]     at scala.slick.memory.MemoryProfile$QueryExecutorDef$$anon$3$$anonfun$run$1.apply(MemoryProfile.scala:48)
[error]     at scala.collection.Iterator$$anon$11.next(Iterator.scala:328)
[error]     at scala.collection.Iterator$class.foreach(Iterator.scala:727)
[error]     at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
[error]     at scala.collection.generic.Growable$class.++=(Growable.scala:48)
[error]     at scala.collection.immutable.VectorBuilder.++=(Vector.scala:716)
[error]     at scala.collection.immutable.VectorBuilder.++=(Vector.scala:692)
[error]     at scala.slick.memory.MemoryProfile$QueryExecutorDef$$anon$3.run(MemoryProfile.scala:48)
[error]     at scala.slick.memory.MemoryProfile$QueryExecutorDef.run(MemoryProfile.scala:53)
[error]     at scala.slick.memory.MemoryProfile$QueryExecutorDef.run(MemoryProfile.scala:41)
[error]     at com.typesafe.slick.testkit.tests.JoinTest.testJoin(JoinTest.scala:95)
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
[error]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:606)
[error]     at com.typesafe.slick.testkit.util.Testkit$$anonfun$runChildren$2.apply(Testkit.scala:49)
[error]     at com.typesafe.slick.testkit.util.Testkit$$anonfun$runChildren$2.apply(Testkit.scala:40)
[error]     at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:772)
join bug
[error]     at scala.collection.Iterator$class.foreach(Iterator.scala:727)
[error]     at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
[error]     at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
[error]     at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
[error]     at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:771)
[error]     at com.typesafe.slick.testkit.util.Testkit.runChildren(Testkit.scala:40)
[error]     at com.typesafe.slick.testkit.util.SimpleParentRunner.run(SimpleParentRunner.scala:56)
[error]     ...
```
