### PR TITLE
Better scaladoc for extension methods for Column and Query.

### DIFF
--- a/src/main/scala/scala/slick/lifted/ColumnBase.scala
+++ b/src/main/scala/scala/slick/lifted/ColumnBase.scala
@@ -11,7 +11,19 @@ trait Rep[T] {
   def toNode: Node
 }
 
-/** Base class for columns. */
+/** Base class for columns.
+  *
+  * Most operations are added with extension methods that depend on the type inside the `Column`.
+  * These are defined in:
+  * <ul>
+  *   <li>[[scala.slick.lifted.AnyExtensionMethods]] and [[scala.slick.lifted.ColumnExtensionMethods]] for columns of all types</li>
+  *   <li>[[scala.slick.lifted.OptionColumnExtensionMethods]] for columns of all `Option` types</li>
+  *   <li>[[scala.slick.lifted.PlainColumnExtensionMethods]] for columns of all non-`Option` types</li>
+  *   <li>[[scala.slick.lifted.NumericColumnExtensionMethods]] for columns of numeric types (and Options thereof)</li>
+  *   <li>[[scala.slick.lifted.BooleanColumnExtensionMethods]] for columns of `Boolean` / `Option[Boolean]`</li>
+  *   <li>[[scala.slick.lifted.StringColumnExtensionMethods]] for columns of `String` / `Option[String]`</li>
+  * </ul>
+  */
 abstract class Column[T](implicit final val tpe: TypedType[T]) extends Rep[T] { self =>
   /** Order by this column in ascending order */
   def asc = ColumnOrdered[T](this, Ordering())

--- a/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
+++ b/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
@@ -7,18 +7,18 @@ import ScalaBaseType._
 import scala.slick.SlickException
 
 trait ExtensionMethods[B1, P1] extends Any {
-  def c: Column[P1]
-  @inline def n = c.toNode
-  @inline implicit def p1Type = c.tpe
-  implicit def b1Type = (c.tpe match {
+  protected[this] def c: Column[P1]
+  @inline protected[this] def n = c.toNode
+  @inline protected[this] implicit def p1Type = c.tpe
+  implicit protected[this] def b1Type = (c.tpe match {
     case o: OptionTypedType[_] => o.elementType
     case b => b
   }).asInstanceOf[TypedType[B1]]
-  implicit def optionType = (c.tpe match {
+  implicit protected[this] def optionType = (c.tpe match {
     case o: OptionTypedType[_] => o
     case b => b.optionType
   }).asInstanceOf[TypedType[Option[B1]]]
-  type o = OptionMapperDSL.arg[B1, P1]
+  protected[this] type o = OptionMapperDSL.arg[B1, P1]
 }
 
 /** Extension methods for all Columns and all primitive values that can be lifted to Columns */
@@ -30,7 +30,7 @@ final class AnyExtensionMethods(val n: Node) extends AnyVal {
 
 /** Extension methods for all Columns */
 trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
-  def c: Column[P1]
+  protected[this] def c: Column[P1]
 
   @deprecated("Use 'isEmpty' instead of 'isNull'", "2.1")
   def isNull = Library.==.column[Boolean](n, LiteralNode(null))

--- a/src/main/scala/scala/slick/lifted/Query.scala
+++ b/src/main/scala/scala/slick/lifted/Query.scala
@@ -13,7 +13,11 @@ sealed trait QueryBase[T] extends Rep[T]
 /** An instance of Query represents a query or view, i.e. a computation of a
   * collection type (Rep[Seq[T]]). It is parameterized with both, the mixed
   * type (the type of values you see e.g. when you call map()) and the unpacked
-  * type (the type of values that you get back when you run the query).  */
+  * type (the type of values that you get back when you run the query).
+  *
+  * Additional extension methods for queries containing a single column are
+  * defined in [[scala.slick.lifted.SingleColumnQueryExtensionMethods]].
+  */
 sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
   def shaped: ShapedValue[_ <: E, U]
   final lazy val packed = shaped.toNode


### PR DESCRIPTION
- Link to the extension method classes in the scaladocs for `Column` and
  `Query`.
- Mark implementation details of the extension method traits as
  `protected[this]` where applicable to remove them from the generated
  documentation. Unfortunately, this is not possible for the constructor
  parameters of value classes.

Fixes issue #846. Review by @cvogt 
