### PR TITLE
Set type when inlining aggregation functions.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/CountTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/CountTest.scala
@@ -90,5 +90,10 @@ class CountTest extends TestkitTest[RelationalTestDB] {
       } yield b).length)
     } yield (a, l)
     assertEquals(Seq((1L, 2)), qJoinLength.run)
+
+    val qOuterJoinLength = (for {
+      (a, b) <- as leftJoin bs on (_.id === _.aId)
+    } yield (a.id, b.data.?)).length
+    assertEquals(3, qOuterJoinLength.run)
   }
 }

--- a/src/main/scala/scala/slick/compiler/Relational.scala
+++ b/src/main/scala/scala/slick/compiler/Relational.scala
@@ -361,7 +361,7 @@ class FuseComprehensions extends Phase {
           val a = new AnonSymbol
           val f = new AnonSymbol
           lift += ((a, f, s, c2, ap.nodeType))
-          Select(Ref(a), f)
+          Select(Ref(a), f).nodeTyped(ap.nodeType)
         }
       case c: Comprehension => c // don't recurse into sub-queries
       case n => n.nodeMapChildren(tr, keepType = true)


### PR DESCRIPTION
Fixes issue #862. Test in CountTest.qOuterJoinLength.

Now targeting the right branch...
