### PR TITLE
Expose “open” and “transaction” flags in BaseSession.

### DIFF
--- a/src/main/scala/scala/slick/jdbc/JdbcBackend.scala
+++ b/src/main/scala/scala/slick/jdbc/JdbcBackend.scala
@@ -391,6 +391,9 @@ trait JdbcBackend extends DatabaseComponent {
     protected var doRollback = false
     protected var inTransaction = false
 
+    def isOpen = open
+    def isInTransaction = inTransaction
+
     lazy val conn = { open = true; database.createConnection() }
     lazy val metaData = conn.getMetaData()
 


### PR DESCRIPTION
You still need to cast down to BaseSession to see them, so they are not
part of the official API, but can be used for integrating other session
management features.

Fixes issue #713. Review by @cvogt 
