### PR TITLE
Generate table of driver capabilities for the user manual.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target/
 slick-testkit/src/codegen/resources/dbs/hsql/supp.properties
 lib
 *.autosave
+src/sphinx/capabilities.csv

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/BuildCapabilitiesTable.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/BuildCapabilitiesTable.scala
@@ -1,0 +1,50 @@
+package com.typesafe.slick.testkit.util
+
+import scala.slick.profile.{SqlProfile, RelationalProfile, BasicProfile}
+import scala.slick.driver.JdbcProfile
+import java.io.{PrintWriter, OutputStreamWriter, BufferedWriter, FileOutputStream, FileWriter}
+
+/** Build a table of supported capability flags for the user manual. */
+object BuildCapabilitiesTable extends App {
+  // testkit/runMain com.typesafe.slick.testkit.util.BuildCapabilitiesTable ../src/sphinx/capabilities.csv
+  if(args.length < 1 || args.length > 2) {
+    println("Syntax: com.typesafe.slick.testkit.util.BuildCapabilitiesTable OUTPUTFILE [DRIVERLIST]")
+    System.exit(1)
+  }
+
+  val driverNames = if(args.length > 1) args(1).split(",") else Array(
+    "scala.slick.driver.DerbyDriver",
+    "scala.slick.driver.H2Driver",
+    "scala.slick.driver.HsqldbDriver",
+    "scala.slick.driver.AccessDriver",
+    "scala.slick.driver.MySQLDriver",
+    "scala.slick.driver.PostgresDriver",
+    "scala.slick.driver.SQLiteDriver"
+  )
+
+  val drivers = driverNames.map { n =>
+    Class.forName(n + "$").getField("MODULE$").get(null).asInstanceOf[BasicProfile]
+  }
+
+  val profiles = Vector(
+    RelationalProfile.capabilities.all -> "scala.slick.profile.RelationalProfile$$capabilities$@",
+    SqlProfile.capabilities.all -> "scala.slick.profile.SqlProfile$$capabilities$@",
+    JdbcProfile.capabilities.all -> "scala.slick.driver.JdbcProfile$$capabilities$@"
+  )
+
+  val capabilities = for {
+    (caps, linkBase) <- profiles
+    cap <- caps.toVector.sortBy(c => if(c.toString.endsWith(".other")) "" else c.toString)
+  } yield (cap, linkBase + cap.toString.replaceFirst(".*\\.", "") + ":scala.slick.profile.Capability")
+
+  val out = new FileOutputStream(args(0))
+  try {
+    val wr = new PrintWriter(new BufferedWriter(new OutputStreamWriter(out, "UTF-8")))
+    wr.println("Capability," + driverNames.map(n => s":api:`$n`").mkString(","))
+    for((cap, link) <- capabilities) {
+      val flags = drivers.map(d => d.capabilities.contains(cap))
+      wr.println(s":api:`$cap <$link>`," + flags.map(b => if(b) "Yes" else "").mkString(","))
+    }
+    wr.flush()
+  } finally out.close()
+}

--- a/src/sphinx/introduction.rst
+++ b/src/sphinx/introduction.rst
@@ -79,6 +79,14 @@ Writing a fully featured plugin for your own SQL-based backend can be achieved
 with a reasonable amount of work. Support for other backends (like NoSQL) is
 under development but not yet available.
 
+The following capabilities are supported by the drivers. "Yes" means that a
+capability is fully supported. In other cases it may be partially supported or
+not at all. See the individual driver's API documentation for details.
+
+.. csv-table:: Driver Capabilities
+   :header-rows: 1
+   :file: capabilities.csv
+
 .. index:: license
 
 License

--- a/src/sphinx/theme/static/slick.css_t
+++ b/src/sphinx/theme/static/slick.css_t
@@ -91,3 +91,29 @@ pre.literal-block {
   margin-top: 0.8em;
   margin-bottom: 0.8em;
 }
+
+table.docutils {
+  background-color: #e0e0e0;
+  border: 0;
+  padding: 0.2em;
+  border: 1px solid #CCCCCC;
+  margin-left: auto;
+  margin-right: auto;
+  width: 0;
+}
+table.docutils th, table.docutils td {
+  text-align: center;
+  border: 0;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+table.docutils td {
+  background-color: #F8F8F8;
+}
+table.docutils caption {
+  margin: 0.5em;
+  font-family: sans-serif;
+  font-size: 13pt;
+  font-weight: bold;
+  color: rgba(218, 56, 48, 0.9);
+}


### PR DESCRIPTION
A simple command line app `BuildCapabilitiesTable` in TestKit builds the
actual table, which is then included with the `csv-table` directive in
the manual. We can easily link to the scaladocs from the table because
the CSV file has access to the Sphinx extensions as the regular RST
sources.

Fixes issue #435. Review by @cvogt 
