### PR TITLE
Update custom shape docs.

### DIFF
--- a/src/sphinx/code-generation.rst
+++ b/src/sphinx/code-generation.rst
@@ -11,7 +11,8 @@ Overview
 By default, the code generator generates Table classes, corresponding TableQuery values, which
 can be used in a collection-like manner, as well as case classes for holding complete
 rows of values. For Tables with more than 22 columns the generator automatically switches
-to Slick's experimental HList implementation for overcoming Scala's tuple size limit. (If needed use ``HCons`` instead of ``::`` as a type contructor in Scala <= 2.10.3 for now due to performance issues during compilation.)
+to Slick's experimental HList implementation for overcoming Scala's tuple size limit. (In Scala
+<= 2.10.3 use ``HCons`` instead of ``::`` as a type contructor due to performance issues during compilation, which are fixed in 2.10.4 and later.)
 
 The implementation is ready for practical use, but since it is new in
 Slick 2.0 we consider it experimental and reserve the right to remove features

--- a/src/sphinx/userdefined.rst
+++ b/src/sphinx/userdefined.rst
@@ -45,8 +45,8 @@ Stored procedures that return multiple result sets are currently not supported.
    triple: user-defined; scalar; type
    pair: mapped; type
 
-Scalar Types
--------------
+Using Custom Scalar Types in Queries
+------------------------------------
 
 If you need a custom column type you can implement
 :api:`ColumnType <scala.slick.driver.JdbcProfile@ColumnType[T]:JdbcDriver.ColumnType[T]>`. The most
@@ -77,38 +77,62 @@ table-specific primary key types:
    triple: user-defined; record; type
 .. _record-types:
 
-Record Types
--------------
+Using Custom Record Types in Queries
+------------------------------------
 
 Record types are data structures containing a statically known
 number of components with individually declared types.  Out of the box,
 Slick supports Scala tuples (up to arity 22) and Slick's own
-experimental :api:`scala.slick.collection.heterogenous.HList` implementation
-(without any size limit, but currently suffering from long compilation
-times for arities > 25). Record types can be nested and
-mixed arbitrarily in Slick.
+:api:`scala.slick.collection.heterogenous.HList` implementation. Record
+types can be nested and mixed arbitrarily.
 
-If you need more flexibility, you can add support for your own by
-defining an implicit :api:`scala.slick.lifted.Shape`
-definition. Here is an example for a type ``Pair``:
+In order to use custom record types (case classes, custom HLists, tuple-like
+types, etc.) in queries you need to tell Slick how to map them between queries
+and results. You can do that using a :api:`scala.slick.lifted.Shape`
+extending :api:`scala.slick.lifted.MappedScalaProductShape`.
 
-.. includecode:: code/LiftedEmbedding.scala#recordtypepair
+Polymorphic Types (e.g. Custom Tuple Types or HLists)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``Shape`` implementations for record types extend
-:api:`scala.slick.lifted.MappedScalaProductShape`. They are are generally very
-simple but they require some boilerplate for all the types involved. A
-``MappedScalaProductShape`` takes a sequence of Shapes for its elements and
-provides the operations ``buildValue`` (for creating an instance of the record
-type given its elements) and ``copy`` (for creating a copy of this ``Shape``
-with new element Shapes):
+The distinguishing feature of a *polymorphic* record type is that it abstracts
+over its element types, so you can use the same record type for both, lifted
+and plain element types. You can add support for custom polymorphic record
+types using an appropriate implicit :api:`scala.slick.lifted.Shape`.
+
+Here is an example for a type ``Pair``:
 
 .. includecode:: code/LiftedEmbedding.scala#recordtype1
 
 The implicit method ``pairShape`` in this example provides a Shape for a
-``Pair`` of two element types whenever Shapes for the inidividual element
+``Pair`` of two element types whenever Shapes for the individual element
 types are available.
 
 With these definitions in place, we can use the ``Pair`` record type in every
 location in Slick where a tuple or ``HList`` would be acceptable:
 
 .. includecode:: code/LiftedEmbedding.scala#recordtype2
+
+Monomorphic Case Classes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Custom *case classes* are frequently used as monomorphic record types (i.e.
+record types where the element types are fixed). In order to use them in Slick,
+you need to define the case class for a record of plain values (as usual) plus
+an additional case class for a matching record of lifted values.
+
+In order to provide a :api:`scala.slick.lifted.Shape` for a custom case class,
+you can use :api:`scala.slick.lifted.CaseClassShape`:
+
+.. includecode:: code/LiftedEmbedding.scala#case-class-shape
+
+Note that this mechanism can be used as an alternative to client-side mappings
+with the `<>` operator. It requires a bit more boilerplate but allows you to use
+the same field names in both, plain and lifted records.
+
+Combining Mapped Types
+^^^^^^^^^^^^^^^^^^^^^^
+
+In the following example we are combining a mapped case class and the mapped
+``Pair`` type in another mapped case class.
+
+.. includecode:: code/LiftedEmbedding.scala#combining-shapes


### PR DESCRIPTION
Supersedes #692 now that we ship CaseClassShape directly in Slick. Review by @cvogt 
