### PR TITLE
Improve reverse engineering to work with slick-extensions

### DIFF
--- a/slick-codegen/src/main/scala/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -161,6 +161,8 @@ class $name(_tableTag: Tag) extends Table[$elementType](_tableTag, ${args.mkStri
         case v:Double  => s"$v"
         case v:Boolean => s"$v"
         case v:Short   => s"$v"
+        case v:Char   => s"'$v'"
+        case v:BigDecimal => s"new scala.math.BigDecimal(new java.math.BigDecimal($v))"
         case v => throw new SlickException( s"Dont' know how to generate code for default value $v of ${v.getClass}" )
       }
       // Explicit type to allow overloading existing Slick method names.


### PR DESCRIPTION
- support for Char and BigDecimal
  caveats:
- Boolean mapping still flawed
- DBType mapping still flawed and non-portable
