### PR TITLE
Add Float support to ModelBuilder / Fix MetaModelTest for jtds

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MetaModelTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MetaModelTest.scala
@@ -60,7 +60,10 @@ class MetaModelTest extends TestkitTest[JdbcTestDB] {
       case _:AssertionError => 
     }
 
-    val DBTypePattern = "^[a-zA-Z][a-zA-Z0-9]*$".r // postgres uses lower case and things like int4
+    // postgres uses lower case and things like int4
+    // seen in jtds: int identity
+    // seen in oracle: VARCHAR2
+    val DBTypePattern = "^[a-zA-Z][a-zA-Z0-9 ]*$".r
 
     // check that the model matches the table classes
     val model = tdb.profile.createModel(ignoreInvalidDefaults=false)
@@ -101,8 +104,9 @@ class MetaModelTest extends TestkitTest[JdbcTestDB] {
       assert(
         Seq(
           "CHAR","CHARACTER",
-          "bpchar" // postgres
-        ) contains tpe("title"),
+          "BPCHAR" // bpchar: postgres
+          //"char" // jtds
+        ) contains tpe("title").toUpperCase,
         tpe("title")
       )
       assert(

--- a/src/main/scala/scala/slick/driver/JdbcModelComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcModelComponent.scala
@@ -193,6 +193,7 @@ trait JdbcModelComponent{ driver: JdbcDriver =>
                 case (v,"Int")    => v.toInt
                 case (v,"Long")   => v.toLong
                 case (v,"Double") => v.toDouble
+                case (v,"Float") => v.toFloat
                 case (v,"Char")   => v.head // FIXME: check length
                 case (v,"String") if meta.typeName == "CHAR" => v.head // FIXME: check length
                 case (v,"scala.math.BigDecimal") => v // FIXME: probably we shouldn't use a string here


### PR DESCRIPTION
This should do the trick for passing the tests with jtds. The db type assertions in the tests need to be re-written to be more stable eventually.

review by @szeiger 
