### PR TITLE
Use INTEGER for all integral types on SQLite.

### DIFF
--- a/src/main/scala/scala/slick/driver/SQLiteDriver.scala
+++ b/src/main/scala/scala/slick/driver/SQLiteDriver.scala
@@ -8,7 +8,7 @@ import scala.slick.util.MacroSupport.macroSupportInterpolation
 import scala.slick.profile.{RelationalProfile, SqlProfile, Capability}
 import scala.slick.compiler.CompilerState
 import scala.slick.model.Model
-import scala.slick.jdbc.Invoker
+import scala.slick.jdbc.{Invoker, JdbcType}
 import scala.slick.jdbc.meta.MTable
 
 /** Slick driver for SQLite.
@@ -181,6 +181,11 @@ trait SQLiteDriver extends JdbcDriver { driver =>
     // the same in ReturningInsertInvoker because SQLite does not allow returning non-AutoInc keys anyway.
     override protected val useServerSideUpsert = compiled.upsert.fields.forall(fs => !fs.options.contains(ColumnOption.AutoInc))
     override protected def useTransactionForUpsert = !useServerSideUpsert
+  }
+
+  override def defaultSqlTypeName(tmd: JdbcType[_]): String = tmd.sqlType match {
+    case java.sql.Types.TINYINT | java.sql.Types.SMALLINT | java.sql.Types.BIGINT => "INTEGER"
+    case _ => super.defaultSqlTypeName(tmd)
   }
 
   class JdbcTypes extends super.JdbcTypes {


### PR DESCRIPTION
From http://www.sqlite.org/datatype3.html it seems that SQLite does not
distinguish at all between the different types, so in general it does
not matter which one you use (and all the standard names are understood
by SQLite), except for Auto-Increment columns where you must specify
INTEGER as the type.

Replaces #908. Review by @cvogt 
