### PR TITLE
Try for Nested List Shape

### DIFF
--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -44,6 +44,7 @@ testkit {
     ${testPackage}.TemplateTest
     ${testPackage}.TransactionTest
     ${testPackage}.UnionTest
+    ${testPackage}.ListShapeTest
   ]
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ListShapeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ListShapeTest.scala
@@ -1,0 +1,97 @@
+package com.typesafe.slick.testkit.tests
+
+import java.util.logging.Logger
+
+import com.typesafe.slick.testkit.util.{JdbcTestDB, TestkitTest}
+import org.junit.Assert._
+
+import scala.collection.mutable.ListBuffer
+import scala.slick.lifted.ListShapeTrait
+
+class ListShapeTest extends TestkitTest[JdbcTestDB] with ListShapeTrait {
+
+  import tdb.profile.simple._
+
+  class Score(tag: Tag, name: String) extends Table[(Int, Int, Int)](tag, name) {
+    def id = column[Int]("id", O.PrimaryKey)
+
+    def group = column[Int]("grp")
+
+    def score = column[Int]("score")
+
+    def * = (id, group, score)
+  }
+
+  def testBasic(): Unit = {
+    def query(n: Column[Int], n2: Column[Int]) = {
+      Query(List(List(List(1, 2).map(_.bind.asColumnOf[Int]) ++ List(n)))).
+        map(x => x.map(x => x.map(x => x.map(x => x + 1).map(x => x + n2))))
+    }
+    val q = Compiled.apply(query _)
+    val resultOne = q.apply(3, 1).run
+    val expectedOne = List(List(List(1, 2) ++ List(3))).map(x => x.map(x => x.map(x => x + 1).map(x => x + 1)))
+    assertEquals(List(expectedOne), resultOne)
+
+    val resultTwo = Query(List(1, 2, 3)).map(t => t.apply(2) :: t.take(2).reverse).list
+    val expectedTwo = List(3, 2, 1)
+    assertEquals(List(expectedTwo), resultTwo)
+  }
+
+  def test {
+    val score = TableQuery(new Score(_, "score_list"))
+    (score.ddl).create
+    def idSeed(i: Int): Stream[Int] = Stream.cons(i, idSeed(i + 1))
+    val seed = idSeed(1).iterator
+    val data = ListBuffer[(Int, Int, Int)]()
+    score.++=(
+      1.to(10).flatMap(x => 1.to(x).map(_ => ((seed.next(), 0, x)))) ++
+        3.to(8).flatMap(x => 1.to(10 - x).map(_ => ((seed.next(), 1, x))))
+    )
+
+    /**
+     * create table score (
+     * id int primary key,
+     * group int,
+     * score int
+     * )
+     *
+     * select b.group,
+     * b.c1, b.c2, b.c3, ... b.c10,
+     * (b.c1 + b.c2 + b.c3, ... b.c10)
+     * from (
+     * select a.group,
+     * (select count(id) from score where group = a.group and score = 1) c1,
+     * (select count(id) from score where group = a.group and score = 2) c2,
+     * (select count(id) from score where group = a.group and score = 3) c3,
+     * ...
+     * (select count(id) from score where group = a.group and score = 10) c10
+     * from (
+     * select distinct group from score
+     * ) a
+     * ) b
+     */
+
+    def col(group: Column[Int]): List[(Int, Column[Int])] = {
+      1.to(10).map(i => (i, score.filter(x => x.group === group && x.score === i).map(_.id).countDistinct)).toList
+    }
+    // below the Distinct is not executed currently. I don't know why.
+    //    val queryOne = score.groupBy(t => t.group).map(t => t._1).
+    //      map(t => (t, col(t))).
+    //      filter(t => LiteralColumn(true) === LiteralColumn(true)).
+    //      map(x => (x._1, x._2, x._2.map(x => x._2).reduceLeft(_ + _))).
+    //      sortBy(t => t._1)
+    val queryOne = Query(0).union(Query(1)).
+      map(t => (t, col(t))).
+      filter(t => LiteralColumn(true) === LiteralColumn(true)). // to introduce sub-query.
+      map(t => (t._1, t._2, t._2.map(x => x._2).reduceLeft(_ + _))).
+      sortBy(t => t._1)
+    val resultOne = queryOne.list
+    val expectedOne = ((0, 1.to(10).map(x => (x, x))) ::
+      (1, 1.to(2).map(x => (x, 0)) ++ 3.to(8).map(x => (x, (10 - x))) ++ 9.to(10).map(x => (x, 0))) :: Nil).map {
+      case (a, b) => (a, b, b.map(_._2).reduceLeft(_ + _))
+    }
+    assertEquals(expectedOne, resultOne)
+    (score.ddl).drop
+  }
+
+}

--- a/src/main/scala/scala/slick/ast/Type.scala
+++ b/src/main/scala/scala/slick/ast/Type.scala
@@ -8,6 +8,7 @@ import scala.reflect.{ClassTag, classTag => mkClassTag}
 import Util._
 import scala.collection.mutable.ArrayBuffer
 import scala.annotation.implicitNotFound
+import scala.slick.relational.ProductNodeResultMappingType
 import scala.slick.util.TupleSupport
 
 /** Super-trait for all types */
@@ -32,8 +33,8 @@ trait AtomicType extends Type {
   def children: Seq[Type] = Seq.empty
 }
 
-final case class StructType(elements: IndexedSeq[(Symbol, Type)]) extends Type {
-  override def toString = "{" + elements.iterator.map{ case (s, t) => s + ": " + t }.mkString(", ") + "}"
+final case class StructType(elements: IndexedSeq[(Symbol, Type)], resultMappingType: Option[(ProductNodeResultMappingType.Value, Int)] = None) extends Type {
+  override def toString = "{" + elements.iterator.map{ case (s, t) => s + ": " + t }.mkString(", ") + "}" + resultMappingType.map(x => f":(${x._1.toString}:${x._2})").getOrElse("")
   lazy val symbolToIndex: Map[Symbol, Int] =
     elements.zipWithIndex.map { case ((sym, _), idx) => (sym, idx) }(collection.breakOut)
   def children: IndexedSeq[Type] = elements.map(_._2)
@@ -68,8 +69,8 @@ object OptionType {
   private val classTag = mkClassTag[Option[_]]
 }
 
-final case class ProductType(elements: IndexedSeq[Type]) extends Type {
-  override def toString = "(" + elements.mkString(", ") + ")"
+final case class ProductType(elements: IndexedSeq[Type], resultMappingType: Option[(ProductNodeResultMappingType.Value, Int)] = None) extends Type {
+  override def toString = "(" + elements.mkString(", ") + ")" + resultMappingType.map(x => f":(${x._1.toString}:${x._2})").getOrElse("")
   def mapChildren(f: Type => Type): ProductType =
     mapOrNone(elements)(f) match {
       case Some(e2) => ProductType(e2)

--- a/src/main/scala/scala/slick/compiler/Columnizer.scala
+++ b/src/main/scala/scala/slick/compiler/Columnizer.scala
@@ -60,7 +60,7 @@ class ExpandRecords extends Phase {
   }}
 
   def expandPath(n: Node): Node = n.nodeType.structural match {
-    case StructType(ch) =>
+    case StructType(ch, _) =>
       StructNode(ch.map { case (s, t) =>
         (s, expandPath(Select(n, s).nodeTyped(t)))
       }(collection.breakOut)).nodeTyped(n.nodeType)

--- a/src/main/scala/scala/slick/compiler/CreateResultSetMapping.scala
+++ b/src/main/scala/scala/slick/compiler/CreateResultSetMapping.scala
@@ -69,10 +69,10 @@ class CreateResultSetMapping extends Phase {
     def f(tpe: Type): Node = {
       logger.debug("Creating mapping from "+tpe)
       tpe match {
-        case ProductType(ch) =>
-          ProductNode(ch.map(f))
-        case StructType(ch) =>
-          ProductNode(ch.map { case (_, t) => f(t) })
+        case ProductType(ch, mappingType) =>
+          ProductNode(ch.map(f), mappingType)
+        case StructType(ch, mappingType) =>
+          ProductNode(ch.map { case (_, t) => f(t) }, mappingType)
         case t: MappedScalaType =>
           TypeMapping(f(t.baseType), t.mapper, t.classTag)
         case n @ NominalType(ts) => tables.get(ts) match {

--- a/src/main/scala/scala/slick/compiler/EmulateOuterJoins.scala
+++ b/src/main/scala/scala/slick/compiler/EmulateOuterJoins.scala
@@ -57,8 +57,8 @@ class EmulateOuterJoins(val useLeftJoin: Boolean, val useRightJoin: Boolean) ext
 
   /** Create a structure of the given type where all columns are NULL. */
   def nullStructFor(t: Type): Node = t.structural match {
-    case ProductType(ts) => ProductNode(ts.map(nullStructFor))
-    case StructType(sts) => StructNode(sts.map { case (s, t) => (s, nullStructFor(t)) })
+    case ProductType(ts, _) => ProductNode(ts.map(nullStructFor))
+    case StructType(sts, _) => StructNode(sts.map { case (s, t) => (s, nullStructFor(t)) })
     case t: OptionType => LiteralNode(t, None)
     case t => LiteralNode(OptionType(t), None)
   }

--- a/src/main/scala/scala/slick/memory/DistributedProfile.scala
+++ b/src/main/scala/scala/slick/memory/DistributedProfile.scala
@@ -68,7 +68,7 @@ trait DistributedProfile extends MemoryQueryingProfile { driver: DistributedDriv
     }
 
     def wrapScalaValue(value: Any, tpe: Type): Any = tpe match {
-      case ProductType(ts) =>
+      case ProductType(ts, _) =>
         val p = value.asInstanceOf[Product]
         new ProductValue((0 until p.productArity).map(i =>
           wrapScalaValue(p.productElement(i), ts(i))


### PR DESCRIPTION
Hi.

This work is for Nested List Shape

You can't use this feature as like below.

```
  List(1, "hi", 1.2)
```

Above is possible using `HList` as like below.

```
  1 :: "hi" :: 1.2 :: HNil
```

But, you can use this feature for basic pivoting like below.

```
    def col(group: Column[Int]): List[(Int, Column[Int])] = {
      1.to(10).map(i => (i, score.filter(x => x.group === group && x.score === i).map(_.id).countDistinct)).toList
    }
    val queryOne = Query(0).union(Query(1)).
      map(t => (t, col(t))).
      filter(t => true.bind === true.bind). // to introduce sub-query.
      map(t => (t._1, t._2, t._2.map(x => x._2).reduceLeft(_ + _))).
      sortBy(t => t._1)
```

As unusual example, below is possible.

```
    def query(n: Column[Int], n2: Column[Int]) = {
      Query(List(List(List(1, 2).map(_.bind.asColumnOf[Int]) ++ List(n)))).
        map(x => x.map(x => x.map(x => x.map(x => x + 1).map(x => x + n2))))
    }
```

I don't think that this feature is useful on usual cases.
But, If there are repeated calculations like above example, I think that this is something useful.

There are a one limitation. You can't use this as `JDBC preparedStatement`'s parameter.
For example, below is not possible.

```
    def query(list:List[Column[Int]]):Query[...] = { ... }
    Compiled(query _).apply(List(1)).run
```

When compiling the query, parameter count is fixed. So, you can't change parameter count after Slick Query Compiling.

By the way, I couldn't find a way to make `ListShape` to default implicit shape.
So, in order to use this feature, you should use `ListShapeTrait`.
If you know how to fix this, please tell me.

Thanks.
