### PR TITLE
Fixes for slick-extensions

### DIFF
--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -30,9 +30,8 @@ import scala.slick.model.Model
   *     just as specifying NULL and reports NULL as the default value.
   *     Some other dbms treat queries with no default as NULL default, but
   *     distinguish NULL from no default value in the meta data.</li>
-
   *   <li>[[scala.slick.driver.JdbcProfile.capabilities.supportsByte]]:
-  *     Derby doesn't have a corresponding type for Byte.
+  *     Postgres doesn't have a corresponding type for Byte.
   *     SMALLINT is used instead and mapped to Short in the Slick model.</li>
   * </ul>
   *

--- a/src/main/scala/scala/slick/driver/SQLiteDriver.scala
+++ b/src/main/scala/scala/slick/driver/SQLiteDriver.scala
@@ -55,9 +55,9 @@ import scala.slick.jdbc.meta.MTable
   *     Also see https://code.google.com/p/sqlite-jdbc/issues/detail?id=27
   *     </li>
   *   <li>[[scala.slick.driver.JdbcProfile.capabilities.booleanMetaData]]:
-  *     Derby <= 10.6 doesn't have booleans, so Slick maps to SMALLINT instead.
+  *     SQlite doesn't have booleans, so Slick maps to INTEGER instead.
   *     Other jdbc drivers like MySQL map TINYINT(1) back to a Scala
-  *     Boolean. Derby maps SMALLINT to an Integer and that's how it shows
+  *     Boolean. SQlite maps INTEGER to an Integer and that's how it shows
   *     up in the jdbc meta data, thus the original type is lost.</li>
   *   <li>[[scala.slick.driver.JdbcProfile.capabilities.distinguishesIntTypes]]:
   *     SQLite does not distinguish integer types and maps them all to Int


### PR DESCRIPTION
- shorted column names in tests to <= 30 for Oracle
- remove default schema PUBLIC for H2(?)
- accept integer or char 1 and 0 for mapped non-native booleans
- special case integer and date tests to include oracle (should may be handled via a capability at some later point in time)
- introduces rawDefault method to allow preprocessing the default value meta data (for simplicity in slick-extensions)
