### PR TITLE
Some Column improvements from tmp/remove-column:

### DIFF
--- a/slick-testkit/src/codegen/scala/CodeGeneratorTest.scala
+++ b/slick-testkit/src/codegen/scala/CodeGeneratorTest.scala
@@ -188,7 +188,7 @@ class Tables(val profile: JdbcProfile){
   class SelfRef(tag: Tag) extends Table[(Int,Option[Int])](tag, "SELF_REF") {
     def id = column[Int]("id",O.AutoInc)
     def parent = column[Option[Int]]("parent")
-    def parentFK = foreignKey("parent_fk", parent, SelfRef)(_.id)
+    def parentFK = foreignKey("parent_fk", parent, SelfRef)(_.id.?)
     def * = (id,parent)
   }
   val SelfRef = TableQuery[SelfRef]
@@ -228,7 +228,7 @@ class Tables(val profile: JdbcProfile){
     def idx4 = index("bar",p,unique=true)
     def categoryFK1 = foreignKey("fk1", pk, categories)(_.id) // dup FK collision
     def categoryFK2 = foreignKey("fk2", pk2, categories)(_.id)
-    def postsFK = foreignKey("fk_to_posts", p, posts)(_.id) // fk column name collision
+    def postsFK = foreignKey("fk_to_posts", p, posts)(_.id.?) // fk column name collision
   }
   val X = TableQuery[X]
 
@@ -246,7 +246,7 @@ class Tables(val profile: JdbcProfile){
     def title = column[String]("title")
     def category = column[Option[Int]]("category")
     def * = (id, title, category)
-    def categoryFK = foreignKey("_", category, categories)(_.id)
+    def categoryFK = foreignKey("_", category, categories)(_.id.?)
   }
   val posts = TableQuery[Posts]
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ForeignKeyTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ForeignKeyTest.scala
@@ -25,7 +25,7 @@ class ForeignKeyTest extends TestkitTest[RelationalTestDB] {
       def title = column[String]("title")
       def category = column[Option[Int]]("category")
       def * = (id, title, category)
-      def categoryFK = foreignKey("category_fk", category, categories)(_.id)
+      def categoryFK = foreignKey("category_fk", category, categories)(_.id.?)
       def categoryJoin = categories.filter(_.id === category)
     }
     val posts = TableQuery[Posts]

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MetaModelTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MetaModelTest.scala
@@ -27,7 +27,7 @@ class MetaModelTest extends TestkitTest[JdbcTestDB] {
       def someString = column[String]("some_string",O.Length(111,varying=true)) // tests Length produces valid SQL
       def * = (id, title, category, someBool, someString)
       def pk = primaryKey("posts_pk", (id,title))
-      def categoryFK = foreignKey("category_fk", category, categories)(_.id)
+      def categoryFK = foreignKey("category_fk", category, categories)(_.id.?)
     }
     val posts = TableQuery[Posts]
 

--- a/slick-testkit/src/test/scala/scala/slick/test/codegen/CodeGeneratorAllTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/codegen/CodeGeneratorAllTest.scala
@@ -24,7 +24,7 @@ class CodeGeneratorAllTest(val tdb: JdbcTestDB) extends DBTest {
       def title = column[String]("title")
       def category = column[Option[Int]]("category")
       def * = (id, title, category)
-      def categoryFK = foreignKey("category_fk", category, categories)(_.id)
+      def categoryFK = foreignKey("category_fk", category, categories)(_.id.?)
     }
     val posts = TableQuery[Posts]
 

--- a/slick-testkit/src/test/scala/scala/slick/test/compile/NestedShapesTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/compile/NestedShapesTest.scala
@@ -17,14 +17,14 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, (Column[Int], (Int, Column[String])), _, _]]
 
     // Flat and Nested alike, fully specified
-    implicitly[Shape[FlatShapeLevel, Int, Int, Column[Int]]]
-    implicitly[Shape[FlatShapeLevel, (Int, String), (Int, String), (Column[Int], Column[String])]]
-    implicitly[Shape[FlatShapeLevel, (Column[Int], Int), (Int, Int), (Column[Int], Column[Int])]]
-    implicitly[Shape[FlatShapeLevel, (Column[Int], (Int, Column[String])), (Int, (Int, String)), (Column[Int], (Column[Int], Column[String]))]]
-    implicitly[Shape[NestedShapeLevel, Int, Int, Column[Int]]]
-    implicitly[Shape[NestedShapeLevel, (Int, String), (Int, String), (Column[Int], Column[String])]]
-    implicitly[Shape[NestedShapeLevel, (Column[Int], Int), (Int, Int), (Column[Int], Column[Int])]]
-    implicitly[Shape[NestedShapeLevel, (Column[Int], (Int, Column[String])), (Int, (Int, String)), (Column[Int], (Column[Int], Column[String]))]]
+    implicitly[Shape[FlatShapeLevel, Int, Int, ConstColumn[Int]]]
+    implicitly[Shape[FlatShapeLevel, (Int, String), (Int, String), (ConstColumn[Int], ConstColumn[String])]]
+    implicitly[Shape[FlatShapeLevel, (Column[Int], Int), (Int, Int), (Column[Int], ConstColumn[Int])]]
+    implicitly[Shape[FlatShapeLevel, (Column[Int], (Int, Column[String])), (Int, (Int, String)), (Column[Int], (ConstColumn[Int], Column[String]))]]
+    implicitly[Shape[NestedShapeLevel, Int, Int, ConstColumn[Int]]]
+    implicitly[Shape[NestedShapeLevel, (Int, String), (Int, String), (ConstColumn[Int], ConstColumn[String])]]
+    implicitly[Shape[NestedShapeLevel, (Column[Int], Int), (Int, Int), (Column[Int], ConstColumn[Int])]]
+    implicitly[Shape[NestedShapeLevel, (Column[Int], (Int, Column[String])), (Int, (Int, String)), (Column[Int], (ConstColumn[Int], Column[String]))]]
 
     // Only Nested, only Mixed specified
     implicitly[Shape[NestedShapeLevel, Query[Column[Int], Int, Seq], _, _]] // 1
@@ -36,7 +36,7 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, Query[Column[Int], Int, Seq], Seq[Int], Query[Column[Int], Int, Seq]]] // 5
     implicitly[Shape[NestedShapeLevel, Query[(Column[Int], Column[String]), (Int, String), Seq], Seq[(Int, String)], Query[(Column[Int], Column[String]), (Int, String), Seq]]] // 6
     implicitly[Shape[NestedShapeLevel, (Column[Int], Query[(Column[Int], Column[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Column[Int], Query[(Column[Int], Column[String]), (Int, String), Seq])]] // 7
-    implicitly[Shape[NestedShapeLevel, (Int, Query[(Column[Int], Column[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Column[Int], Query[(Column[Int], Column[String]), (Int, String), Seq])]] // 8
+    implicitly[Shape[NestedShapeLevel, (Int, Query[(Column[Int], Column[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (ConstColumn[Int], Query[(Column[Int], Column[String]), (Int, String), Seq])]] // 8
   }
 
   def illegal1 = ShouldNotTypecheck("""
@@ -68,6 +68,6 @@ class NestedShapesTest {
     """, "No matching Shape.*")
 
   def illegal8 = ShouldNotTypecheck("""
-      implicitly[Shape[FlatShapeLevel, (Int, Query[(Column[Int], Column[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Column[Int], Query[(Column[Int], Column[String]), (Int, String), Seq])]] // 8
+      implicitly[Shape[FlatShapeLevel, (Int, Query[(Column[Int], Column[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (ConstColumn[Int], Query[(Column[Int], Column[String]), (Int, String), Seq])]] // 8
     """, "No matching Shape.*")
 }

--- a/src/main/scala/scala/slick/ast/Type.scala
+++ b/src/main/scala/scala/slick/ast/Type.scala
@@ -198,7 +198,7 @@ final case class NominalType(sym: TypeSymbol, structuralView: Type) extends Type
   def classTag = structuralView.classTag
 }
 
-/** Something that has a type */
+/** Something that has a Type */
 trait Typed {
   def tpe: Type
 }
@@ -207,7 +207,7 @@ object Typed {
   def unapply(t: Typed) = Some(t.tpe)
 }
 
-/* A Type that carries a Scala type argument */
+/** A Type that carries a Scala type argument */
 trait TypedType[T] extends Type { self =>
   def optionType: OptionTypedType[T] = new OptionTypedType[T] {
     val elementType = self

--- a/src/main/scala/scala/slick/lifted/Case.scala
+++ b/src/main/scala/scala/slick/lifted/Case.scala
@@ -17,13 +17,8 @@ object Case {
   def If[C <: Column[_] : CanBeQueryCondition](cond: C) = new UntypedWhen(cond.toNode)
 
   final class UntypedWhen(cond: Node) {
-    def Then[B : BaseTypedType](res: Column[B]) = new TypedCase[B,B](IndexedSeq(new IfThen(cond, res.toNode)))
-
-    def Then[B](res: Column[Option[B]]) = res.tpe match {
-      case tmt: OptionTypedType[_] =>
-        new TypedCase[B,Option[B]](IndexedSeq(new IfThen(cond, res.toNode)))(tmt.elementType, tmt)
-      case tm => throw new SlickException("Unexpected non-Option TypedType "+tm+" for Option type")
-    }
+    def Then[P, B](res: Rep[P])(implicit om: OptionMapperDSL.arg[B, P]#to[B, P], bType: BaseTypedType[B]) =
+      new TypedCase[B, P](IndexedSeq(new IfThen(cond, res.toNode)))(bType, om.liftedType(bType))
   }
 
   final class TypedCase[B : TypedType, T : TypedType](clauses: IndexedSeq[Node])
@@ -32,14 +27,10 @@ object Case {
 
     def If[C <: Column[_] : CanBeQueryCondition](cond: C) = new TypedWhen[B,T](cond.toNode, clauses)
 
-    def Else(res: Column[T]): Column[T] = new TypedCaseWithElse[T](clauses, res.toNode)
+    def Else(res: Column[T]): Column[T] = Column.forNode(ConditionalExpr(clauses, res.toNode))
   }
 
   final class TypedWhen[B : TypedType, T : TypedType](cond: Node, parentClauses: IndexedSeq[Node]) {
     def Then(res: Column[T]) = new TypedCase[B,T](parentClauses :+ new IfThen(cond, res.toNode))
-  }
-
-  final class TypedCaseWithElse[T : TypedType](clauses: IndexedSeq[Node], elseClause: Node) extends Column[T] {
-    def toNode = ConditionalExpr(clauses, elseClause)
   }
 }

--- a/src/main/scala/scala/slick/lifted/OptionMapper.scala
+++ b/src/main/scala/scala/slick/lifted/OptionMapper.scala
@@ -1,7 +1,7 @@
 package scala.slick.lifted
 
 import annotation.implicitNotFound
-import scala.slick.ast.{FunctionSymbol, BaseTypedType, Node, TypedType}
+import scala.slick.ast.{FunctionSymbol, BaseTypedType, Node, OptionApply, TypedType}
 
 trait OptionMapper[BR, R] extends (Column[BR] => Column[R]) {
   def lift: Boolean
@@ -24,7 +24,7 @@ object OptionMapper2 {
     def lift = false
   }
   val option = new OptionMapper2[Any,Any,Any,Any,Any,Option[Any]] {
-    def apply(n: Column[Any]): Column[Option[Any]] = new PlainColumnExtensionMethods[Any](n).?
+    def apply(n: Column[Any]): Column[Option[Any]] = Column.forNode(OptionApply(n.toNode))(n.tpe.optionType)
     def lift = true
   }
 
@@ -43,7 +43,7 @@ object OptionMapper3 {
     def lift = false
   }
   val option = new OptionMapper3[Any,Any,Any,Any,Any,Any,Any,Option[Any]] {
-    def apply(n: Column[Any]): Column[Option[Any]] = new PlainColumnExtensionMethods[Any](n).?
+    def apply(n: Column[Any]): Column[Option[Any]] = Column.forNode(OptionApply(n.toNode))(n.tpe.optionType)
     def lift = true
   }
 

--- a/src/main/scala/scala/slick/lifted/Shape.scala
+++ b/src/main/scala/scala/slick/lifted/Shape.scala
@@ -47,10 +47,10 @@ abstract class Shape[Level <: ShapeLevel, -Mixed_, Unpacked_, Packed_] {
 }
 
 object Shape extends ShapeLowPriority2 {
-  implicit final def primitiveShape[T, Level <: ShapeLevel](implicit tm: TypedType[T]): Shape[Level, T, T, Column[T]] = new Shape[Level, T, T, Column[T]] {
+  implicit final def primitiveShape[T, Level <: ShapeLevel](implicit tm: TypedType[T]): Shape[Level, T, T, ConstColumn[T]] = new Shape[Level, T, T, ConstColumn[T]] {
     def pack(value: Mixed) = LiteralColumn(value)
     def packedShape = RepShape[Level, Packed, Unpacked]
-    def buildParams(extract: Any => Unpacked): Packed = new ParameterColumn[T](new QueryParameter(extract, tm))(tm)
+    def buildParams(extract: Any => Unpacked): Packed = new ConstColumn[T](new QueryParameter(extract, tm))(tm)
     def encodeRef(value: Mixed, path: List[Symbol]) =
       throw new SlickException("Shape does not have the same Mixed and Packed type")
     def toNode(value: Mixed): Node = pack(value).toNode

--- a/src/main/scala/scala/slick/profile/RelationalProfile.scala
+++ b/src/main/scala/scala/slick/profile/RelationalProfile.scala
@@ -32,9 +32,10 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
   }
 
   trait Implicits extends super.Implicits with ImplicitColumnTypes {
+    @deprecated("Use an explicit conversion to an Option column with `.?`", "2.2")
     implicit def columnToOptionColumn[T : BaseTypedType](c: Column[T]): Column[Option[T]] = c.?
     implicit def valueToConstColumn[T : TypedType](v: T) = new LiteralColumn[T](v)
-    implicit def columnToOrdered[T](c: Column[T]): ColumnOrdered[T] = c.asc
+    implicit def columnToOrdered[T](c: Column[T]): ColumnOrdered[T] = ColumnOrdered[T](c, Ordering())
     implicit def tableQueryToTableQueryExtensionMethods[T <: Table[_], U](q: Query[T, U, Seq] with TableQuery[T]) =
       new TableQueryExtensionMethods[T, U](q)
   }
@@ -148,23 +149,22 @@ trait RelationalTableComponent { driver: RelationalDriver =>
       * Note that Slick uses VARCHAR or VARCHAR(254) in DDL for String
       * columns if neither ColumnOption DBType nor Length are given.
       */
-    def column[C](n: String, options: ColumnOption[C]*)(implicit tm: TypedType[C]): Column[C] = new Column[C] {
-      if(tm == null){
-        throw new NullPointerException(
-          "implicit TypedType[C] for column[C] is null. "+
-          "This may be an initialization order problem. "+
-          "When using a MappedColumnType, you may want to change it from a val to a lazy val or def."
-        )
+    def column[C](n: String, options: ColumnOption[C]*)(implicit tt: TypedType[C]): Column[C] = {
+      if(tt == null) throw new NullPointerException(
+        "implicit TypedType[C] for column[C] is null. "+
+        "This may be an initialization order problem. "+
+        "When using a MappedColumnType, you may want to change it from a val to a lazy val or def.")
+      new Column[C] {
+        override def toNode =
+          Select((tableTag match {
+            case r: RefTag => Path(r.path)
+            case _ => tableNode
+          }), FieldSymbol(n)(options, tt)).nodeTyped(tt)
+        override def toString = (tableTag match {
+          case r: RefTag => "(" + _tableName + " " + Path.toString(r.path) + ")"
+          case _ => _tableName
+        }) + "." + n
       }
-      override def toNode =
-        Select((tableTag match {
-          case r: RefTag => Path(r.path)
-          case _ => tableNode
-        }), FieldSymbol(n)(options, tm)).nodeTyped(tm)
-      override def toString = (tableTag match {
-        case r: RefTag => "(" + _tableName + " " + Path.toString(r.path) + ")"
-        case _ => _tableName
-      }) + "." + n
     }
   }
 }

--- a/src/main/scala/scala/slick/util/TupleSupport.fm
+++ b/src/main/scala/scala/slick/util/TupleSupport.fm
@@ -36,23 +36,23 @@ object TupleSupport {
 
 /** Extension methods for prepending and appending values to tuples */
 object TupleMethods {
-  implicit class ColumnTupleExtensionMethods[T](val c: Column[T]) extends AnyVal {
-    def ~ [U](c2: Column[U]): (Column[T], Column[U]) = (c, c2)
-    def ~: [U](c2: Column[U]): (Column[U], Column[T]) = (c2, c)
+  implicit class RepTupleExtensionMethods[T <: Rep[_]](val c: T with Rep[_]) extends AnyVal {
+    def ~ [U <: Rep[_]](c2: U with Rep[_]): (T, U) = (c, c2)
+    def ~: [U <: Rep[_]](c2: U with Rep[_]): (U, T) = (c2, c)
   }
 <#list 2..21 as i>
-  implicit class Tuple${i}ExtensionMethods[<#list 1..i as j>T${j}<#if i != j>, </#if></#list>](val t: (<#list 1..i as j>Column[T${j}]<#if i != j>, </#if></#list>)) extends AnyVal {
-    def ~ [U](c: Column[U]): (<#list 1..i as j>Column[T${j}], </#list>Column[U]) = (<#list 1..i as j>t._${j}, </#list>c)
-    def ~: [U](c: Column[U]): (Column[U]<#list 1..i as j>, Column[T${j}]</#list>) = (c<#list 1..i as j>, t._${j}</#list>)
+  implicit class Tuple${i}ExtensionMethods[<#list 1..i as j>T${j} <: Rep[_]<#if i != j>, </#if></#list>](val t: (<#list 1..i as j>T${j} with Rep[_]<#if i != j>, </#if></#list>)) extends AnyVal {
+    def ~ [U <: Rep[_]](c: U with Rep[_]): (<#list 1..i as j>T${j}, </#list>U) = (<#list 1..i as j>t._${j}, </#list>c)
+    def ~: [U <: Rep[_]](c: U with Rep[_]): (U<#list 1..i as j>, T${j}</#list>) = (c<#list 1..i as j>, t._${j}</#list>)
   }
 </#list>
 
   /** A chained extractor for tuples */
   object ~ {
-    def unapply[T1 <: Column[_], T2 <: Column[_]](p: (T1,T2)) =
+    def unapply[T1 <: Rep[_], T2 <: Rep[_]](p: (T1,T2)) =
       Some(p)
 <#list 3..22 as i>
-    def unapply[<#list 1..i as j>T${j} <: Column[_]<#if i != j>,</#if></#list>](p: (<#list 1..i as j>T${j}<#if i != j>,</#if></#list>)) =
+    def unapply[<#list 1..i as j>T${j} <: Rep[_]<#if i != j>,</#if></#list>](p: (<#list 1..i as j>T${j}<#if i != j>,</#if></#list>)) =
       Some((<#list 1..i-1 as j>p._${j}<#if i-1 != j>,</#if></#list>), p._${i})
 </#list>
   }


### PR DESCRIPTION
- Deprecate the implicit conversion from Column[T] to Column[Option[T]].
  A few unit tests and the code generator relied on this conversion for
  foreign key definitions. These are made explicit now, using `.?` for
  Option-lifting.
- Make primitive types pack to ConstColumn instead of Column.
  A primitive value is always an execution-time constant.
- Remove the unnecessary Column subtypes Case.TypedCaseWithElse and
  ParameterColumn.
- Remove the `asc` and `desc` methods from Column. The implicit
  conversion to ColumnOrdered is sufficient.
- Allow any `Rep` instead of only `Column` in the tuple extension
  methods `~` and `~:`.

Review by @cvogt 
