### PR TITLE
Prototype for String Aggregation

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -234,6 +234,15 @@ class AggregateTest extends TestkitTest[RelationalTestDB] {
       case (grp, t) => (grp, t.map(x => x.col4 + x.col5).sum)
     }
     assertEquals(Set(("baz",Some(12)), ("foo",Some(24))), q3.run.toSet)
+
+    ifCap(rcap.mkString){
+      assertEquals("bar,bar,quux,quux", Tabs.map(_.col2).mkString(";").run)
+
+      val q4 = Tabs.groupBy(_.col1).map {
+        case (name, group) => (name, group.map(_.col2).mkString(","))
+      }
+      assertEquals(Set(("baz", "quux"), ("foo","bar,bar,quux")), q4.run.toSet)
+    }
   }
 
   def testMultiMapAggregates {

--- a/src/main/scala/scala/slick/ast/Library.scala
+++ b/src/main/scala/scala/slick/ast/Library.scala
@@ -61,6 +61,7 @@ object Library {
   val Max = new SqlAggregateFunction("max")
   val Avg = new SqlAggregateFunction("avg")
   val Sum = new SqlAggregateFunction("sum")
+  val MkString = new SqlAggregateFunction("group_concat")
   val Count = new SqlAggregateFunction("count")
   val CountAll = new AggregateFunction("count(*)")
   val CountDistinct = new AggregateFunction("count distinct")

--- a/src/main/scala/scala/slick/driver/DerbyDriver.scala
+++ b/src/main/scala/scala/slick/driver/DerbyDriver.scala
@@ -62,6 +62,8 @@ import scala.slick.model.Model
   *   <li>[[scala.slick.driver.JdbcProfile.capabilities.supportsByte]]:
   *     Derby doesn't have a corresponding type for Byte.
   *     SMALLINT is used instead and mapped to Short in the Slick model.</li>
+  *   <li>[[scala.slick.driver.JdbcProfile.capabilities.groupConcat]]:
+  *     Derby doesn't have a built-in string aggregation function.</li>
   * </ul>
   */
 trait DerbyDriver extends JdbcDriver { driver =>
@@ -80,6 +82,7 @@ trait DerbyDriver extends JdbcDriver { driver =>
     - RelationalProfile.capabilities.reverse
     - JdbcProfile.capabilities.booleanMetaData
     - JdbcProfile.capabilities.supportsByte
+    - RelationalProfile.capabilities.mkString
   )
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean = true)(implicit session: Backend#Session) extends super.ModelBuilder(mTables, ignoreInvalidDefaults){

--- a/src/main/scala/scala/slick/driver/MySQLDriver.scala
+++ b/src/main/scala/scala/slick/driver/MySQLDriver.scala
@@ -129,6 +129,7 @@ trait MySQLDriver extends JdbcDriver { driver =>
       case RowNum(sym, true) => b"(@`$sym := @`$sym + 1)"
       case RowNum(sym, false) => b"@`$sym"
       case RowNumGen(sym) => b"(select @`$sym := 0)"
+      case Library.MkString(e)/*,separator)*/ => b"group_concat($e)"//" SEPARATOR $separator)"
       case _ => super.expr(n, skipParens)
     }
 

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -118,6 +118,7 @@ trait PostgresDriver extends JdbcDriver { driver =>
     override def expr(n: Node, skipParens: Boolean = false) = n match {
       case Library.NextValue(SequenceNode(name)) => b"nextval('$name')"
       case Library.CurrentValue(SequenceNode(name)) => b"currval('$name')"
+      case Library.MkString(e)/*,separator)*/ => b"string_agg($e, ',')"//$separator)"//" SEPARATOR $separator)"
       case _ => super.expr(n, skipParens)
     }
   }

--- a/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
+++ b/src/main/scala/scala/slick/lifted/ExtensionMethods.scala
@@ -161,6 +161,13 @@ final class SingleColumnQueryExtensionMethods[B1, P1, C[_]](val q: Query[Column[
   def sum(implicit tm: OptionTM) = Library.Sum.column[Option[B1]](q.toNode)
 }
 
+/** Extension methods for Queries of a single String Column */
+final class StringColumnQueryExtensionMethods[B1 <: String, P1, C[_]](val q: Query[Column[P1], _, C]) extends AnyVal {
+  type OptionTM =  TypedType[Option[B1]]
+  def mkString(separator: String)(implicit tm: OptionTM)
+    = Library.MkString.column[String](q.toNode)//, LiteralColumn(separator).toNode)
+}
+
 trait ExtensionMethodConversions {
   implicit def anyColumnExtensionMethods[B1 : BaseTypedType](c: Column[B1]) = new AnyExtensionMethods(c.toNode)
   implicit def anyOptionColumnExtensionMethods[B1](c: Column[Option[B1]]) = new AnyExtensionMethods(c.toNode)
@@ -177,4 +184,6 @@ trait ExtensionMethodConversions {
 
   implicit def singleColumnQueryExtensionMethods[B1 : BaseTypedType, C[_]](q: Query[Column[B1], _, C]) = new SingleColumnQueryExtensionMethods[B1, B1, C](q)
   implicit def singleOptionColumnQueryExtensionMethods[B1, C[_]](q: Query[Column[Option[B1]], _, C]) = new SingleColumnQueryExtensionMethods[B1, Option[B1], C](q)
+  implicit def stringColumnQueryExtensionMethods[B1 <: String : BaseTypedType, C[_]](q: Query[Column[B1], _, C]) = new StringColumnQueryExtensionMethods[B1, B1, C](q)
+  implicit def stringOptionColumnQueryExtensionMethods[B1 <: String, C[_]](q: Query[Column[Option[B1]], _, C]) = new StringColumnQueryExtensionMethods[B1, Option[B1], C](q)
 }

--- a/src/main/scala/scala/slick/memory/MemoryProfile.scala
+++ b/src/main/scala/scala/slick/memory/MemoryProfile.scala
@@ -7,6 +7,7 @@ import scala.slick.compiler._
 import scala.slick.profile.Capability
 import scala.slick.relational.{ResultConverterCompiler, ResultConverter, CompiledMapping}
 import TypeUtil._
+import scala.slick.profile.RelationalProfile
 
 /** A profile and driver for interpreted queries on top of the in-memory database. */
 trait MemoryProfile extends MemoryQueryingProfile { driver: MemoryDriver =>
@@ -24,7 +25,8 @@ trait MemoryProfile extends MemoryQueryingProfile { driver: MemoryDriver =>
   lazy val deleteCompiler = compiler
   lazy val insertCompiler = QueryCompiler(Phase.assignUniqueSymbols, new InsertCompiler(InsertCompiler.NonAutoInc), new MemoryInsertCodeGen)
 
-  override protected def computeCapabilities = super.computeCapabilities ++ MemoryProfile.capabilities.all
+  override protected def computeCapabilities
+    = super.computeCapabilities ++ MemoryProfile.capabilities.all - RelationalProfile.capabilities.mkString
 
   def createQueryExecutor[R](tree: Node, param: Any): QueryExecutor[R] = new QueryExecutorDef[R](tree, param)
   def createInsertInvoker[T](tree: Node): InsertInvoker[T] = new InsertInvokerDef[T](tree)

--- a/src/main/scala/scala/slick/profile/RelationalProfile.scala
+++ b/src/main/scala/scala/slick/profile/RelationalProfile.scala
@@ -104,6 +104,8 @@ object RelationalProfile {
     val typeLong = Capability("relational.typeLong")
     /** Supports zip, zipWith and zipWithIndex */
     val zip = Capability("relational.zip")
+    /** Has a String aggregation function */
+    val mkString = Capability("relational.mkString")
 
     /** Supports all RelationalProfile features which do not have separate capability values */
     val other = Capability("relational.other")
@@ -112,7 +114,7 @@ object RelationalProfile {
     val all = Set(other, columnDefaults, foreignKeyActions, functionDatabase,
       functionUser, joinFull, joinLeft, joinRight, likeEscape, pagingDrop, pagingNested,
       pagingPreciseTake, setByteArrayNull, typeBigDecimal, typeBlob, typeLong,
-      zip, replace, reverse, indexOf)
+      zip, replace, reverse, indexOf, mkString)
   }
 }
 


### PR DESCRIPTION
I gave a generalized version of https://github.com/slick/slick/issues/923 a try.

We still have a problem. Slick pulls our aggregation subqueries but the transformation only matches aggregationfunctions that do not have arguments (besides the collection they aggregate). So no providing a separator works for mkString, but extending the implementation to pass on the separator generates invalid SQL. @szeiger could you take a look at that?

We could add this to 2.1.1, if we finish it.
