### PR TITLE
use fully qualified class-paths for Tag and Table

### DIFF
--- a/slick-codegen/src/main/scala/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -46,7 +46,7 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
     def compoundValue(values: Seq[String]): String = {
       if(hlistEnabled) values.mkString(" :: ") + " :: HNil"
       else if (values.size == 1) values.head
-      else if(values.size <= 22) s"""(${values.mkString(", ")})"""
+      else if (values.size <= 22) s"""(${values.mkString(", ")})"""
       else throw new Exception("Cannot generate tuple for > 22 columns, please set hlistEnable=true or override compound.")
     }
 
@@ -129,7 +129,7 @@ implicit def ${name}(implicit $dependencies): GR[${TableClass.elementType}] = GR
         val prns = parents.map(" with " + _).mkString("")
         val args = model.name.schema.map(n => s"""Some("$n")""") ++ Seq("\""+model.name.table+"\"")
         s"""
-class $name(_tableTag: Tag) extends Table[$elementType](_tableTag, ${args.mkString(", ")})$prns {
+class $name(_tableTag: scala.slick.lifted.Tag) extends profile.simple.Table[$elementType](_tableTag, ${args.mkString(", ")})$prns {
   ${indent(body.map(_.mkString("\n")).mkString("\n\n"))}
 }
         """.trim()
@@ -137,7 +137,7 @@ class $name(_tableTag: Tag) extends Table[$elementType](_tableTag, ${args.mkStri
     }
 
     trait TableValueDef extends super.TableValueDef{
-      def code = s"lazy val $name = new TableQuery(tag => new ${TableClass.name}(tag))"
+      def code = s"lazy val $name = new scala.slick.lifted.TableQuery(tag => new ${TableClass.name}(tag))"
     }
 
     class ColumnDef(model: m.Column) extends super.ColumnDef(model){

--- a/slick-testkit/src/codegen/resources/dbs/h2mem/create-conflict.sql
+++ b/slick-testkit/src/codegen/resources/dbs/h2mem/create-conflict.sql
@@ -1,0 +1,2 @@
+create table "TAG" ("A1" INTEGER NOT NULL,"A2" VARCHAR NOT NULL);
+create table "TABLE" ("A1" INTEGER NOT NULL,"A2" VARCHAR NOT NULL);

--- a/slick-testkit/src/codegen/scala/CodeGeneratorTest.scala
+++ b/slick-testkit/src/codegen/scala/CodeGeneratorTest.scala
@@ -137,6 +137,9 @@ val  SimpleA = CustomTyping.SimpleA
           override def autoIncLastAsOption = true
         }
       }
+    ),
+    new H2Config("CG10", Seq("create-conflict.sql"),
+      config => session => new MySourceCodeGenerator(H2Driver.createModel(ignoreInvalidDefaults=false)(session), config)
     )
   )
   class MySourceCodeGenerator(model:Model, config: Config) extends SourceCodeGenerator(model){


### PR DESCRIPTION
A quick attempt at fixing the bug mentioned here: https://groups.google.com/forum/#!topic/scalaquery/DdB2eHisIKk

Comes with a test that doesn't really test anything, as the whole compilation process crashes if a class with a namespace-conflicting name is generated, but is included for the sake of completeness.
