### PR TITLE
Fix forceInsertAll for single argument

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -112,6 +112,8 @@ class InsertTest extends TestkitTest[JdbcTestDB] {
       ts.forceInsert(104, "A")
       ts.map(_.ins).forceInsertAll((105, "B"), (106, "C"))
       assertEquals(3, ts.filter(_.id > 100).length.run)
+      ts.map(_.ins).forceInsertAll((111, "D"))
+      assertEquals(4, ts.filter(_.id > 100).length.run)
     }
   }
 

--- a/src/main/scala/scala/slick/driver/JdbcInsertInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInsertInvokerComponent.scala
@@ -189,7 +189,8 @@ trait JdbcInsertInvokerComponent extends BasicInsertInvokerComponent{ driver: Jd
     final def forceInsertAll(values: U*)(implicit session: Backend#Session): MultiInsertResult = internalInsertAll(compiled.forceInsert, values: _*)
 
     protected def internalInsertAll(a: compiled.Artifacts, values: U*)(implicit session: Backend#Session): MultiInsertResult = session.withTransaction {
-      if(!useBatchUpdates || (values.isInstanceOf[IndexedSeq[_]] && values.length < 2)) retMany(values, values.map(insert))
+      if(!useBatchUpdates || (values.isInstanceOf[IndexedSeq[_]] && values.length < 2))
+        retMany(values, values.map(v => internalInsert(a, v)))
       else preparedInsert(a.sql) { st =>
         st.clearParameters()
         for(value <- values) {


### PR DESCRIPTION
The current implementation calls standard insertAll despite the compiled.Artifacts being compiled.forceInsert which causes an overwrite of the primary key's value.
