### PR TITLE
Bump version numbers:

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,9 +13,9 @@ import de.johoop.testngplugin.TestNGPlugin._
 
 object SlickBuild extends Build {
 
-  val slickVersion = "2.2.0-SNAPSHOT"
-  val binaryCompatSlickVersion = "2.2.0" // Slick base version for binary compatibility checks
-  val scalaVersions = Seq("2.10.4", "2.11.2")
+  val slickVersion = "3.0.0-M1"
+  val binaryCompatSlickVersion = "3.0.0" // Slick base version for binary compatibility checks
+  val scalaVersions = Seq("2.10.4", "2.11.4")
 
   /** Dependencies for reuse in different parts of the build */
   object Dependencies {

--- a/slick-codegen/src/main/scala/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -25,7 +25,7 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
     ) +
     "\n/** DDL for all tables. Call .create to execute. */"+
     "\nlazy val schema = " + tables.map(_.TableValue.name + ".schema").mkString(" ++ ") +
-    "\n@deprecated(\"Use .schema instead of .ddl\", \"2.2\")"+
+    "\n@deprecated(\"Use .schema instead of .ddl\", \"3.0\")"+
     "\ndef ddl = schema" +
     "\n\n" +
     tables.map(_.code.mkString("\n")).mkString("\n\n")

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ExecutorTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ExecutorTest.scala
@@ -3,7 +3,7 @@ package com.typesafe.slick.testkit.tests
 import org.junit.Assert._
 import com.typesafe.slick.testkit.util.{RelationalTestDB, TestkitTest}
 
-@deprecated("Using deprecated .simple API", "2.2")
+@deprecated("Using deprecated .simple API", "3.0")
 class ExecutorTest extends TestkitTest[RelationalTestDB] {
   import tdb.profile.simple._
   override val reuseInstance = true

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InvokerTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import scala.slick.util.CloseableIterator
 import com.typesafe.slick.testkit.util.{JdbcTestDB, TestkitTest}
 
-@deprecated("Using deprecated .simple API", "2.2")
+@deprecated("Using deprecated .simple API", "3.0")
 class InvokerTest extends TestkitTest[JdbcTestDB] {
   import tdb.profile.simple._
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/IterateeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/IterateeTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import scala.slick.util.iter._
 import com.typesafe.slick.testkit.util.{JdbcTestDB, TestkitTest}
 
-@deprecated("Testing deprecated iteratee API", "2.2")
+@deprecated("Testing deprecated iteratee API", "3.0")
 class IterateeTest extends TestkitTest[JdbcTestDB] {
   import tdb.profile.simple._
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -6,7 +6,7 @@ import com.typesafe.slick.testkit.util.{RelationalTestDB, AsyncTest}
 class JoinTest extends AsyncTest[RelationalTestDB] {
   import tdb.profile.api._
 
-  @deprecated("Using deprecated join operators", "2.2")
+  @deprecated("Using deprecated join operators", "3.0")
   def testJoin = {
     class Categories(tag: Tag) extends Table[(Int, String)](tag, "cat_j") {
       def id = column[Int]("id")

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OldPlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OldPlainSQLTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import scala.slick.jdbc.StaticQuery.interpolation
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 
-@deprecated("Using deprecated old Plain SQL API", "2.2")
+@deprecated("Using deprecated old Plain SQL API", "3.0")
 class OldPlainSQLTest extends TestkitTest[JdbcTestDB] {
 
   implicit val getUserResult = GetResult(r => new User(r.<<, r.<<))

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OldTransactionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OldTransactionTest.scala
@@ -3,7 +3,7 @@ package com.typesafe.slick.testkit.tests
 import com.typesafe.slick.testkit.util.{JdbcTestDB, TestkitTest}
 import org.junit.Assert._
 
-@deprecated("Using deprecated .simple API", "2.2")
+@deprecated("Using deprecated .simple API", "3.0")
 class OldTransactionTest extends TestkitTest[JdbcTestDB] {
   import tdb.profile.simple._
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -150,7 +150,7 @@ sealed abstract class GenericTest[TDB >: Null <: TestDB](implicit TdbClass: Clas
 }
 
 abstract class TestkitTest[TDB >: Null <: TestDB](implicit TdbClass: ClassTag[TDB]) extends GenericTest[TDB] {
-  @deprecated("Use implicitSession instead of sharedSession", "2.2")
+  @deprecated("Use implicitSession instead of sharedSession", "3.0")
   protected final def sharedSession: tdb.profile.Backend#Session = implicitSession
 
   protected implicit def implicitSession: tdb.profile.Backend#Session = {

--- a/src/main/scala/scala/slick/jdbc/Invoker.scala
+++ b/src/main/scala/scala/slick/jdbc/Invoker.scala
@@ -116,7 +116,7 @@ trait ResultSetMutator[T] {
   /** Update the current row. */
   def row_=(value: T)
   /** Insert a new row. */
-  @deprecated("Use `+=` instead of `insert`", "2.2")
+  @deprecated("Use `+=` instead of `insert`", "3.0")
   final def insert(value: T) = += (value)
   /** Insert a new row. */
   def += (value: T): Unit

--- a/src/main/scala/scala/slick/lifted/Aliases.scala
+++ b/src/main/scala/scala/slick/lifted/Aliases.scala
@@ -45,9 +45,9 @@ trait Aliases {
   val ForeignKeyAction = scala.slick.model.ForeignKeyAction
   type ForeignKeyAction = scala.slick.model.ForeignKeyAction
 
-  @deprecated("Use Rep[T : TypedType] instead of Column[T]", "2.2")
+  @deprecated("Use Rep[T : TypedType] instead of Column[T]", "3.0")
   type Column[T] = lifted.Rep[T]
-  @deprecated("Use Rep[T : TypedType] instead of Column[T]", "2.2")
+  @deprecated("Use Rep[T : TypedType] instead of Column[T]", "3.0")
   val Column = lifted.Rep
 
   type Action[-E <: action.Effect, +R, +S <: action.NoStream] = action.Action[E, R, S]

--- a/src/main/scala/scala/slick/lifted/Query.scala
+++ b/src/main/scala/scala/slick/lifted/Query.scala
@@ -122,27 +122,27 @@ sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
 
   /** Join two queries.
     * An optional join predicate can be specified later by calling `on`. */
-  @deprecated("Use join (without explicit JoinType), joinLeft, joinRight or joinOuter instead", "2.2")
+  @deprecated("Use join (without explicit JoinType), joinLeft, joinRight or joinOuter instead", "3.0")
   def join[E2, U2, D[_]](q2: Query[E2, U2, D], jt: JoinType) = standardJoin(q2, jt)
 
   /** Join two queries with a cross / inner join.
     * An optional join predicate can be specified later by calling `on`. */
-  @deprecated("Use join instead of joinInner", "2.2")
+  @deprecated("Use join instead of joinInner", "3.0")
   def innerJoin[E2, U2, D[_]](q2: Query[E2, U2, D]) = standardJoin(q2, JoinType.Inner)
 
   /** Join two queries with a left outer join.
     * An optional join predicate can be specified later by calling `on`. */
-  @deprecated("Use joinLeft (with correct Option types) instead of leftJoin", "2.2")
+  @deprecated("Use joinLeft (with correct Option types) instead of leftJoin", "3.0")
   def leftJoin[E2, U2, D[_]](q2: Query[E2, U2, D]) = standardJoin(q2, JoinType.Left)
 
   /** Join two queries with a right outer join.
     * An optional join predicate can be specified later by calling `on`. */
-  @deprecated("Use joinRight (with correct Option types) instead of rightJoin", "2.2")
+  @deprecated("Use joinRight (with correct Option types) instead of rightJoin", "3.0")
   def rightJoin[E2, U2, D[_]](q2: Query[E2, U2, D]) = standardJoin(q2, JoinType.Right)
 
   /** Join two queries with a full outer join.
     * An optional join predicate can be specified later by calling `on`. */
-  @deprecated("Use joinFull (with correct Option types) instead of outerJoin", "2.2")
+  @deprecated("Use joinFull (with correct Option types) instead of outerJoin", "3.0")
   def outerJoin[E2, U2, D[_]](q2: Query[E2, U2, D]) = standardJoin(q2, JoinType.Outer)
 
   /** Return a query formed from this query and another query by combining

--- a/src/main/scala/scala/slick/memory/DistributedBackend.scala
+++ b/src/main/scala/scala/slick/memory/DistributedBackend.scala
@@ -42,7 +42,7 @@ trait DistributedBackend extends RelationalBackend with Logging {
 
   class DatabaseFactoryDef extends super.DatabaseFactoryDef {
     /** Create a new distributed database instance that uses the global ExecutionContext. */
-    @deprecated("You should explicitly speficy an ExecutionContext in Database.apply()", "2.2")
+    @deprecated("You should explicitly speficy an ExecutionContext in Database.apply()", "3.0")
     def apply(dbs: DatabaseComponent#DatabaseDef*): Database = apply(dbs, ExecutionContext.global)
 
     /** Create a new distributed database instance that uses the supplied ExecutionContext for

--- a/src/main/scala/scala/slick/memory/HeapBackend.scala
+++ b/src/main/scala/scala/slick/memory/HeapBackend.scala
@@ -57,7 +57,7 @@ trait HeapBackend extends RelationalBackend with Logging {
 
   class DatabaseFactoryDef extends super.DatabaseFactoryDef {
     /** Create a new heap database instance that uses the global ExecutionContext. */
-    @deprecated("You should explicitly speficy an ExecutionContext in Database.apply()", "2.2")
+    @deprecated("You should explicitly speficy an ExecutionContext in Database.apply()", "3.0")
     def apply(): Database = new DatabaseDef(ExecutionContext.global)
 
     /** Create a new heap database instance that uses the supplied ExecutionContext for

--- a/src/main/scala/scala/slick/profile/BasicProfile.scala
+++ b/src/main/scala/scala/slick/profile/BasicProfile.scala
@@ -85,13 +85,13 @@ trait BasicProfile extends BasicInvokerComponent with BasicInsertInvokerComponen
     * statement. This provides the driver's implicits, the Database and
     * Session objects for DB connections, and commonly used query language
     * types and objects. */
-  @deprecated("Use 'api' instead of 'simple' or 'Implicit' to import the new API", "2.2")
+  @deprecated("Use 'api' instead of 'simple' or 'Implicit' to import the new API", "3.0")
   val simple: SimpleQL
 
   /** The implicit values and conversions provided by this driver.
     * This is a subset of ``simple``. You usually want to import
     * `simple._` instead of using `Implicit`. */
-  @deprecated("Use 'api' instead of 'simple' or 'Implicit' to import the new API", "2.2")
+  @deprecated("Use 'api' instead of 'simple' or 'Implicit' to import the new API", "3.0")
   val Implicit: Implicits
 
   /** The API for using the query language with a single import

--- a/src/main/scala/scala/slick/profile/RelationalProfile.scala
+++ b/src/main/scala/scala/slick/profile/RelationalProfile.scala
@@ -24,7 +24,7 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
   override protected def computeCapabilities = super.computeCapabilities ++ RelationalProfile.capabilities.all
 
   protected trait CommonImplicits extends super.CommonImplicits with ImplicitColumnTypes {
-    @deprecated("Use an explicit conversion to an Option column with `.?`", "2.2")
+    @deprecated("Use an explicit conversion to an Option column with `.?`", "3.0")
     implicit def columnToOptionColumn[T : BaseTypedType](c: Rep[T]): Rep[Option[T]] = c.?
     implicit def valueToConstColumn[T : TypedType](v: T) = new LiteralColumn[T](v)
     implicit def columnToOrdered[T : TypedType](c: Rep[T]): ColumnOrdered[T] = ColumnOrdered[T](c, Ordering())
@@ -67,7 +67,7 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
   }
 
   class TableQueryExtensionMethods[T <: Table[_], U](val q: Query[T, U, Seq] with TableQuery[T]) {
-    @deprecated("Use .schema instead of .ddl", "2.2")
+    @deprecated("Use .schema instead of .ddl", "3.0")
     final def ddl: SchemaDescription = schema
 
     /** Get the schema description (DDL) for this table. */
@@ -217,7 +217,7 @@ trait RelationalSequenceComponent { driver: RelationalDriver =>
 
     def toNode = SequenceNode(name)(_increment.map(integral.toLong).getOrElse(1))
 
-    @deprecated("Use .schema instead of .ddl", "2.2")
+    @deprecated("Use .schema instead of .ddl", "3.0")
     final def ddl: SchemaDescription = schema
 
     def schema: SchemaDescription = buildSequenceSchemaDescription(this)

--- a/src/sphinx/upgrade.rst
+++ b/src/sphinx/upgrade.rst
@@ -3,7 +3,7 @@
 Upgrade guides
 ##############
 
-Upgrade from 2.1 to 2.2
+Upgrade from 2.1 to 3.0
 =======================
 
 Actions


### PR DESCRIPTION
- Slick 2.2 becomes 3.0
- Use Scala 2.11.4 instead of 2.11.2
