### PR TITLE
Increase timeout for Reactive Streams TCK tests.

### DIFF
--- a/reactive-streams-tests/src/test/scala/scala/slick/test/stream/HeapPublisherTest.scala
+++ b/reactive-streams-tests/src/test/scala/scala/slick/test/stream/HeapPublisherTest.scala
@@ -5,7 +5,7 @@ import org.testng.annotations.{AfterClass, BeforeClass}
 import scala.concurrent.ExecutionContext
 import scala.slick.memory.MemoryDriver
 
-class HeapPublisherTest extends RelationalPublisherTest[MemoryDriver](MemoryDriver) {
+class HeapPublisherTest extends RelationalPublisherTest[MemoryDriver](MemoryDriver, 300L) {
   import driver.api._
 
   @BeforeClass def setUpDB: Unit =

--- a/reactive-streams-tests/src/test/scala/scala/slick/test/stream/JdbcPublisherTest.scala
+++ b/reactive-streams-tests/src/test/scala/scala/slick/test/stream/JdbcPublisherTest.scala
@@ -2,13 +2,19 @@ package scala.slick.test.stream
 
 import org.testng.annotations.{AfterClass, BeforeClass}
 
+import scala.slick.action.Unsafe
 import scala.slick.driver.{H2Driver, JdbcProfile}
+import scala.util.control.NonFatal
 
-class JdbcPublisherTest extends RelationalPublisherTest[JdbcProfile](H2Driver) {
+class JdbcPublisherTest extends RelationalPublisherTest[JdbcProfile](H2Driver, 500L) {
   import driver.api._
 
-  @BeforeClass def setUpDB: Unit =
+  @BeforeClass def setUpDB: Unit = {
     db = Database.forURL("jdbc:h2:mem:DatabasePublisherTest", driver = "org.h2.Driver")
+    //db = Database.forURL("jdbc:derby:memory:JdbcPublisherTest;create=true", driver = "org.apache.derby.jdbc.EmbeddedDriver")
+    // Wait until the database has been initialized and can process queries:
+    try { Unsafe.runBlocking(db, sql"select 1".as[Int]) } catch { case NonFatal(ex) => }
+  }
 
   @AfterClass def tearDownDB: Unit =
     db.close()

--- a/reactive-streams-tests/src/test/scala/scala/slick/test/stream/RelationalPublisherTest.scala
+++ b/reactive-streams-tests/src/test/scala/scala/slick/test/stream/RelationalPublisherTest.scala
@@ -8,7 +8,7 @@ import org.testng.annotations.{AfterClass, BeforeClass}
 
 import scala.slick.profile.RelationalProfile
 
-abstract class RelationalPublisherTest[P <: RelationalProfile](val driver: P) extends PublisherVerification[Int](new TestEnvironment(300L), 1000L) {
+abstract class RelationalPublisherTest[P <: RelationalProfile](val driver: P, timeout: Long) extends PublisherVerification[Int](new TestEnvironment(timeout), 1000L) {
   import driver.api._
 
   var db: Database = _


### PR DESCRIPTION
This seems to cause the spurious TCK failures on Travis. Under heavy
load, 300ms is not enough for the database to start up initially,
causing the first test to fail. Slightly increasing the timeout plus
waiting for the database to be ready initially should fix this problem.