### PR TITLE
Simplify Action Effect handling:

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import de.johoop.testngplugin.TestNGPlugin._
 
 object SlickBuild extends Build {
 
-  val slickVersion = "3.0.0-M1"
+  val slickVersion = "3.0.0-SNAPSHOT"
   val binaryCompatSlickVersion = "3.0.0" // Slick base version for binary compatibility checks
   val scalaVersions = Seq("2.10.4", "2.11.4")
 
@@ -29,7 +29,7 @@ object SlickBuild extends Build {
     val slf4j = "org.slf4j" % "slf4j-api" % "1.6.4"
     val logback = "ch.qos.logback" % "logback-classic" % "0.9.28"
     val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
-    val reactiveStreamsVersion = "1.0.0.M3"
+    val reactiveStreamsVersion = "1.0.0.RC1"
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val pools = Seq(

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
@@ -48,8 +48,6 @@ class TemplateTest extends AsyncTest[RelationalTestDB] {
     val q5a = userNameByIDOrAll(Some(3))
     val q5b = userNameByIDOrAll(None)
 
-    def asAction[E <: Effect, R](a: Action[E, R, NoStream]): Action[E, R, NoStream] = a
-
     for {
       _ <- (users.schema ++ orders.schema).create
       _ <- users.map(_.first) ++= Seq("Homer", "Marge", "Apu", "Carl", "Lenny")

--- a/src/main/scala/scala/slick/action/Action.scala
+++ b/src/main/scala/scala/slick/action/Action.scala
@@ -18,6 +18,12 @@ import scala.util.control.NonFatal
   * unless the session is pinned either explicitly (using `withPinnedSession`) or implicitly (e.g.
   * through a transaction).
   *
+  * The actual implementation base type for all Actions is `EffectfulAction`. `StreamingAction` and
+  * `Action` are type aliases which discard the effect type (and the streaming result type in the
+  * latter case) to make Action types easier to write when these features are not needed. All
+  * primitive Actions and all Actions produced by the standard combinators in Slick have correct
+  * Effect types and are streaming (if possible).
+  *
   * @tparam E The Action's effect type, e.g. `Effect.Read with Effect.Write`. When composing
   *           Actions, the correct combined effect type will be inferred. Effects are used to tie
   *           an Action to a specific back-end type and they can also be used in user code, e.g.
@@ -28,33 +34,33 @@ import scala.util.control.NonFatal
   *           streaming, it is `Streaming[T]` for an element type `T`. For non-streaming
   *           Actions it is `NoStream`.
   */
-sealed trait Action[-E <: Effect, +R, +S <: NoStream] extends Dumpable {
+sealed trait EffectfulAction[-E <: Effect, +R, +S <: NoStream] extends Dumpable {
   /** Transform the result of a successful execution of this action. If this action fails, the
     * resulting action also fails. */
-  def map[R2](f: R => R2)(implicit executor: ExecutionContext): Action[E, R2, NoStream] =
+  def map[R2](f: R => R2)(implicit executor: ExecutionContext): EffectfulAction[E, R2, NoStream] =
     flatMap[E, R2, NoStream](r => SuccessAction[R2](f(r)))
 
   /** Use the result produced by the successful execution of this action to compute and then
     * run the next action in sequence. The resulting action fails if either this action, the
     * computation, or the computed action fails. */
-  def flatMap[E2 <: Effect, R2, S2 <: NoStream](f: R => Action[E2, R2, S2])(implicit executor: ExecutionContext): Action[E with E2, R2, S2] =
+  def flatMap[E2 <: Effect, R2, S2 <: NoStream](f: R => EffectfulAction[E2, R2, S2])(implicit executor: ExecutionContext): EffectfulAction[E with E2, R2, S2] =
     FlatMapAction[E with E2, R2, S2, R](this, f, executor)
 
   /** Run another action after this action, if it completed successfully, and return the result
     * of the second action. If either of the two actions fails, the resulting action also fails. */
-  def andThen[E2 <: Effect, R2, S2 <: NoStream](a: Action[E2, R2, S2]): Action[E with E2, R2, S2] =
+  def andThen[E2 <: Effect, R2, S2 <: NoStream](a: EffectfulAction[E2, R2, S2]): EffectfulAction[E with E2, R2, S2] =
     AndThenAction[E with E2, R2, S2](this, a)
 
   /** Run another action after this action, if it completed successfully, and return the result
     * of both actions. If either of the two actions fails, the resulting action also fails. */
-  def zip[E2 <: Effect, R2](a: Action[E2, R2, NoStream]): Action[E with E2, (R, R2), NoStream] =
+  def zip[E2 <: Effect, R2](a: EffectfulAction[E2, R2, NoStream]): EffectfulAction[E with E2, (R, R2), NoStream] =
     ZipAction[E with E2, R, R2](this, a)
 
   /** Run another action after this action, whether it succeeds or fails, and then return the
     * result of the first action. If the first action fails, its failure is propagated, whether
     * the second action fails or succeeds. If the first action succeeds, a failure of the second
     * action is propagated. */
-  def andFinally[E2 <: Effect](a: Action[E2, _, NoStream]): Action[E with E2, R, S] =
+  def andFinally[E2 <: Effect](a: EffectfulAction[E2, _, NoStream]): EffectfulAction[E with E2, R, S] =
     cleanUp[E2](_ => a)(Action.sameThreadExecutionContext)
 
   /** Run another action after this action, whether it succeeds or fails, in order to clean up or
@@ -67,43 +73,42 @@ sealed trait Action[-E <: Effect, +R, +S <: NoStream] extends Dumpable {
     *                    with the same error, no matter whether the clean-up action succeeds or
     *                    fails. If the clean-up action. If `keepFailure` is set to `false`, an
     *                    error from the clean-up action will override the error from this action. */
-  def cleanUp[E2 <: Effect](f: Option[Throwable] => Action[E2, _, NoStream], keepFailure: Boolean = true)(implicit executor: ExecutionContext): Action[E with E2, R, S] =
+  def cleanUp[E2 <: Effect](f: Option[Throwable] => EffectfulAction[E2, _, NoStream], keepFailure: Boolean = true)(implicit executor: ExecutionContext): EffectfulAction[E with E2, R, S] =
     CleanUpAction[E with E2, R, S](this, f, keepFailure, executor)
 
   /** A shortcut for `andThen`. */
-  final def >> [E2 <: Effect, R2, S2 <: NoStream](a: Action[E2, R2, S2]): Action[E with E2, R2, S2] =
+  final def >> [E2 <: Effect, R2, S2 <: NoStream](a: EffectfulAction[E2, R2, S2]): EffectfulAction[E with E2, R2, S2] =
     andThen[E2, R2, S2](a)
 
   /** Filter the result of this Action with the given predicate. If the predicate matches, the
     * original result is returned, otherwise the resulting Action fails with a
     * NoSuchElementException. */
-  final def filter(p: R => Boolean)(implicit executor: ExecutionContext): Action[E, R, NoStream] =
+  final def filter(p: R => Boolean)(implicit executor: ExecutionContext): EffectfulAction[E, R, NoStream] =
     withFilter(p)
 
-  def withFilter(p: R => Boolean)(implicit executor: ExecutionContext): Action[E, R, NoStream] =
+  def withFilter(p: R => Boolean)(implicit executor: ExecutionContext): EffectfulAction[E, R, NoStream] =
     flatMap(v => if(p(v)) SuccessAction(v) else throw new NoSuchElementException("Action.withFilter failed"))
 
   /** Return an Action which contains the Throwable with which this Action failed as its result.
     * If this Action succeeded, the resulting Action fails with a NoSuchElementException. */
-  def failed: Action[E, Throwable, NoStream] = FailedAction[E](this)
+  def failed: EffectfulAction[E, Throwable, NoStream] = FailedAction[E](this)
 
   /** Convert a successful result `v` of this Action into a successful result `Success(v)` and a
     * failure `t` into a successful result `Failure(t)` */
-  def asTry: Action[E, Try[R], NoStream] = AsTryAction[E, R](this)
+  def asTry: EffectfulAction[E, Try[R], NoStream] = AsTryAction[E, R](this)
 
   /** Run this Action with a pinned database session. If this action is composed of multiple
     * database actions, they will all use the same session, even when sequenced with non-database
     * actions. For non-composite or non-database actions, this has no effect. */
-  def withPinnedSession: Action[E, R, S] =
-    (Action.Pin andThen this andFinally Action.Unpin).asInstanceOf[Action[E, R, S]]
+  def withPinnedSession: EffectfulAction[E, R, S] = Action.Pin andThen this andFinally Action.Unpin
 
   /** Get a wrapping Action which has a name that will be included in log output. */
-  def named(name: String): Action[E, R, S] =
+  def named(name: String): EffectfulAction[E, R, S] =
     NamedAction[E, R, S](this, name)
 
   /** Get the equivalent non-fused Action if this Action has been fused, otherwise this
     * Action is returned. */
-  def nonFusedEquivalentAction: Action[E, R, S] = this
+  def nonFusedEquivalentAction: EffectfulAction[E, R, S] = this
 
   /** Whether or not this Action should be included in log output by default. */
   def isLogged: Boolean = false
@@ -111,32 +116,32 @@ sealed trait Action[-E <: Effect, +R, +S <: NoStream] extends Dumpable {
 
 object Action {
   /** Convert a `Future` to an [[Action]]. */
-  def from[R](f: Future[R]): Action[Effect, R, NoStream] = FutureAction[R](f)
+  def from[R](f: Future[R]): EffectfulAction[Effect, R, NoStream] = FutureAction[R](f)
 
   /** Lift a constant value to an [[Action]]. */
-  def successful[R](v: R): Action[Effect, R, NoStream] = SuccessAction[R](v)
+  def successful[R](v: R): EffectfulAction[Effect, R, NoStream] = SuccessAction[R](v)
 
   /** Create an [[Action]] that always fails. */
-  def failed(t: Throwable): Action[Effect, Nothing, NoStream] = FailureAction(t)
+  def failed(t: Throwable): EffectfulAction[Effect, Nothing, NoStream] = FailureAction(t)
 
-  /** Transform a `TraversableOnce[Action[E, R, NoStream]]` into an `Action[E, TraversableOnce[R], NoStream]`. */
-  def sequence[E <: Effect, R, M[_] <: TraversableOnce[_]](in: M[Action[E, R, NoStream]])(implicit cbf: CanBuildFrom[M[Action[E, R, NoStream]], R, M[R]]): Action[E, M[R], NoStream] = {
+  /** Transform a `TraversableOnce[EffectfulAction[E, R, NoStream]]` into an `EffectfulAction[E, TraversableOnce[R], NoStream]`. */
+  def sequence[E <: Effect, R, M[_] <: TraversableOnce[_]](in: M[EffectfulAction[E, R, NoStream]])(implicit cbf: CanBuildFrom[M[EffectfulAction[E, R, NoStream]], R, M[R]]): EffectfulAction[E, M[R], NoStream] = {
     implicit val ec = Action.sameThreadExecutionContext
-    in.foldLeft(Action.successful(cbf(in)): Action[E, mutable.Builder[R, M[R]], NoStream]) { (ar, ae) =>
-      for (r <- ar; e <- ae.asInstanceOf[Action[E, R, NoStream]]) yield (r += e)
+    in.foldLeft(Action.successful(cbf(in)): EffectfulAction[E, mutable.Builder[R, M[R]], NoStream]) { (ar, ae) =>
+      for (r <- ar; e <- ae.asInstanceOf[EffectfulAction[E, R, NoStream]]) yield (r += e)
     } map (_.result)
   }
 
   /** A simpler version of `sequence` that takes a number of Actions with any return type as
     * varargs and returns an Action that performs the individual Actions in sequence (using
     * `andThen`), returning `()` in the end. */
-  def seq[E <: Effect](actions: Action[E, _, NoStream]*): Action[E, Unit, NoStream] =
-    (actions :+ SuccessAction(())).reduceLeft(_ andThen _).asInstanceOf[Action[E, Unit, NoStream]]
+  def seq[E <: Effect](actions: EffectfulAction[E, _, NoStream]*): EffectfulAction[E, Unit, NoStream] =
+    (actions :+ SuccessAction(())).reduceLeft(_ andThen _).asInstanceOf[EffectfulAction[E, Unit, NoStream]]
 
   /** Create an Action that runs some other actions in sequence and combines their results
     * with the given function. */
-  def fold[E <: Effect, T](actions: Seq[Action[E, T, NoStream]], zero: T)(f: (T, T) => T)(implicit ec: ExecutionContext): Action[E, T, NoStream] =
-    actions.foldLeft[Action[E, T, NoStream]](Action.successful(zero)) { (za, va) => za.flatMap(z => va.map(v => f(z, v))) }
+  def fold[E <: Effect, T](actions: Seq[EffectfulAction[E, T, NoStream]], zero: T)(f: (T, T) => T)(implicit ec: ExecutionContext): EffectfulAction[E, T, NoStream] =
+    actions.foldLeft[EffectfulAction[E, T, NoStream]](Action.successful(zero)) { (za, va) => za.flatMap(z => va.map(v => f(z, v))) }
 
   /** An Action that pins the current session */
   private[slick] object Pin extends SynchronousDatabaseAction[DatabaseComponent, Effect, Unit, NoStream] {
@@ -159,7 +164,7 @@ object Action {
 }
 
 /** An Action that represents a database operation. Concrete implementations are backend-specific. */
-trait DatabaseAction[-E <: Effect, +R, +S <: NoStream] extends Action[E, R, S] {
+trait DatabaseAction[-E <: Effect, +R, +S <: NoStream] extends EffectfulAction[E, R, S] {
   override def isLogged = true
 }
 
@@ -176,43 +181,43 @@ case class FailureAction(t: Throwable) extends SynchronousDatabaseAction[Nothing
 }
 
 /** An asynchronous Action that returns the result of a Future. */
-case class FutureAction[+R](f: Future[R]) extends Action[Effect, R, NoStream] {
+case class FutureAction[+R](f: Future[R]) extends EffectfulAction[Effect, R, NoStream] {
   def getDumpInfo = DumpInfo("future", String.valueOf(f))
   override def isLogged = true
 }
 
 /** An Action that represents a `flatMap` operation for sequencing in the Action monad. */
-case class FlatMapAction[-E <: Effect, +R, +S <: NoStream, P](base: Action[E, P, NoStream], f: P => Action[E, R, S], executor: ExecutionContext) extends Action[E, R, S] {
+case class FlatMapAction[-E <: Effect, +R, +S <: NoStream, P](base: EffectfulAction[E, P, NoStream], f: P => EffectfulAction[E, R, S], executor: ExecutionContext) extends EffectfulAction[E, R, S] {
   def getDumpInfo = DumpInfo("flatMap", String.valueOf(f), children = Vector(("base", base)))
 }
 
 /** An Action that represents an `andThen` operation for sequencing in the Action monad. */
-case class AndThenAction[-E <: Effect, +R, +S <: NoStream](a1: Action[E, _, NoStream], a2: Action[E, R, S]) extends Action[E, R, S] {
+case class AndThenAction[-E <: Effect, +R, +S <: NoStream](a1: EffectfulAction[E, _, NoStream], a2: EffectfulAction[E, R, S]) extends EffectfulAction[E, R, S] {
   def getDumpInfo = DumpInfo("andThen", children = Vector(("1", a1), ("2", a2)))
 }
 
 /** An Action that represents a `zip` operation for sequencing in the Action monad. */
-case class ZipAction[-E <: Effect, +R1, +R2](a1: Action[E, R1, NoStream], a2: Action[E, R2, NoStream]) extends Action[E, (R1, R2), NoStream] {
+case class ZipAction[-E <: Effect, +R1, +R2](a1: EffectfulAction[E, R1, NoStream], a2: EffectfulAction[E, R2, NoStream]) extends EffectfulAction[E, (R1, R2), NoStream] {
   def getDumpInfo = DumpInfo("zip", children = Vector(("1", a1), ("2", a2)))
 }
 
 /** An Action that represents a `cleanUp` operation for sequencing in the Action monad. */
-case class CleanUpAction[-E <: Effect, +R, +S <: NoStream](base: Action[E, R, S], f: Option[Throwable] => Action[E, _, NoStream], keepFailure: Boolean, executor: ExecutionContext) extends Action[E, R, S] {
+case class CleanUpAction[-E <: Effect, +R, +S <: NoStream](base: EffectfulAction[E, R, S], f: Option[Throwable] => EffectfulAction[E, _, NoStream], keepFailure: Boolean, executor: ExecutionContext) extends EffectfulAction[E, R, S] {
   def getDumpInfo = DumpInfo("cleanUp", children = Vector(("try", base)))
 }
 
 /** An Action that represents a `failed` operation. */
-case class FailedAction[-E <: Effect](a: Action[E, _, NoStream]) extends Action[E, Throwable, NoStream] {
+case class FailedAction[-E <: Effect](a: EffectfulAction[E, _, NoStream]) extends EffectfulAction[E, Throwable, NoStream] {
   def getDumpInfo = DumpInfo("failed", children = Vector(("base", a)))
 }
 
 /** An Action that represents an `asTry` operation. */
-case class AsTryAction[-E <: Effect, +R](a: Action[E, R, NoStream]) extends Action[E, Try[R], NoStream] {
+case class AsTryAction[-E <: Effect, +R](a: EffectfulAction[E, R, NoStream]) extends EffectfulAction[E, Try[R], NoStream] {
   def getDumpInfo = DumpInfo("asTry")
 }
 
 /** An Action that attaches a name for logging purposes to another action. */
-case class NamedAction[-E <: Effect, +R, +S <: NoStream](a: Action[E, R, S], name: String) extends Action[E, R, S] {
+case class NamedAction[-E <: Effect, +R, +S <: NoStream](a: EffectfulAction[E, R, S], name: String) extends EffectfulAction[E, R, S] {
   def getDumpInfo = DumpInfo("named", mainInfo = DumpInfo.highlight(name))
   override def isLogged = true
 }
@@ -289,33 +294,33 @@ trait SynchronousDatabaseAction[B <: DatabaseComponent, -E <: Effect, +R, +S <: 
     * supports streaming. This flag is ignored if the Action has a `NoStream` result type. */
   def supportsStreaming: Boolean = true
 
-  private[this] def superAndThen[E2 <: Effect, R2, S2 <: NoStream](a: Action[E2, R2, S2]) = super.andThen[E2, R2, S2](a)
-  override def andThen[E2 <: Effect, R2, S2 <: NoStream](a: Action[E2, R2, S2]): Action[E with E2, R2, S2] = a match {
+  private[this] def superAndThen[E2 <: Effect, R2, S2 <: NoStream](a: EffectfulAction[E2, R2, S2]) = super.andThen[E2, R2, S2](a)
+  override def andThen[E2 <: Effect, R2, S2 <: NoStream](a: EffectfulAction[E2, R2, S2]): EffectfulAction[E with E2, R2, S2] = a match {
     case a: SynchronousDatabaseAction[_, _, _, _] => new SynchronousDatabaseAction.Fused[B, E with E2, R2, S2] {
       def run(context: ActionContext[B]): R2 = {
         self.run(context)
         a.asInstanceOf[SynchronousDatabaseAction[B, E2, R2, S2]].run(context)
       }
-      override def nonFusedEquivalentAction: Action[E with E2, R2, S2] = superAndThen(a)
+      override def nonFusedEquivalentAction: EffectfulAction[E with E2, R2, S2] = superAndThen(a)
     }
     case a => superAndThen(a)
   }
 
-  private[this] def superZip[E2 <: Effect, R2](a: Action[E2, R2, NoStream]) = super.zip[E2, R2](a)
-  override def zip[E2 <: Effect, R2](a: Action[E2, R2, NoStream]): Action[E with E2, (R, R2), NoStream] = a match {
+  private[this] def superZip[E2 <: Effect, R2](a: EffectfulAction[E2, R2, NoStream]) = super.zip[E2, R2](a)
+  override def zip[E2 <: Effect, R2](a: EffectfulAction[E2, R2, NoStream]): EffectfulAction[E with E2, (R, R2), NoStream] = a match {
     case a: SynchronousDatabaseAction[_, _, _, _] => new SynchronousDatabaseAction.Fused[B, E with E2, (R, R2), NoStream] {
       def run(context: ActionContext[B]): (R, R2) = {
         val r1 = self.run(context)
         val r2 = a.asInstanceOf[SynchronousDatabaseAction[B, E2, R2, NoStream]].run(context)
         (r1, r2)
       }
-      override def nonFusedEquivalentAction: Action[E with E2, (R, R2), NoStream] = superZip(a)
+      override def nonFusedEquivalentAction: EffectfulAction[E with E2, (R, R2), NoStream] = superZip(a)
     }
     case a => superZip(a)
   }
 
-  private[this] def superAndFinally[E2 <: Effect](a: Action[E2, _, NoStream]) = super.andFinally[E2](a)
-  override def andFinally[E2 <: Effect](a: Action[E2, _, NoStream]): Action[E with E2, R, S] = a match {
+  private[this] def superAndFinally[E2 <: Effect](a: EffectfulAction[E2, _, NoStream]) = super.andFinally[E2](a)
+  override def andFinally[E2 <: Effect](a: EffectfulAction[E2, _, NoStream]): EffectfulAction[E with E2, R, S] = a match {
     case a: SynchronousDatabaseAction[_, _, _, _] => new SynchronousDatabaseAction.Fused[B, E with E2, R, S] {
       def run(context: ActionContext[B]): R = {
         val res = try self.run(context) catch {
@@ -326,13 +331,13 @@ trait SynchronousDatabaseAction[B <: DatabaseComponent, -E <: Effect, +R, +S <: 
         a.asInstanceOf[SynchronousDatabaseAction[B, E2, Any, S]].run(context)
         res
       }
-      override def nonFusedEquivalentAction: Action[E with E2, R, S] = superAndFinally(a)
+      override def nonFusedEquivalentAction: EffectfulAction[E with E2, R, S] = superAndFinally(a)
     }
     case a => superAndFinally(a)
   }
 
   private[this] def superWithPinnedSession = super.withPinnedSession
-  override def withPinnedSession: Action[E, R, S] = new SynchronousDatabaseAction.Fused[B, E, R, S] {
+  override def withPinnedSession: EffectfulAction[E, R, S] = new SynchronousDatabaseAction.Fused[B, E, R, S] {
     def run(context: ActionContext[B]): R = {
       context.pin
       val res = try self.run(context) catch {
@@ -346,8 +351,8 @@ trait SynchronousDatabaseAction[B <: DatabaseComponent, -E <: Effect, +R, +S <: 
     override def nonFusedEquivalentAction = superWithPinnedSession
   }
 
-  private[this] def superFailed: Action[E, Throwable, NoStream] = super.failed
-  override def failed: Action[E, Throwable, NoStream] = new SynchronousDatabaseAction.Fused[B, E, Throwable, NoStream] {
+  private[this] def superFailed: EffectfulAction[E, Throwable, NoStream] = super.failed
+  override def failed: EffectfulAction[E, Throwable, NoStream] = new SynchronousDatabaseAction.Fused[B, E, Throwable, NoStream] {
     def run(context: ActionContext[B]): Throwable = {
       var ok = false
       try {
@@ -361,8 +366,8 @@ trait SynchronousDatabaseAction[B <: DatabaseComponent, -E <: Effect, +R, +S <: 
     override def nonFusedEquivalentAction = superFailed
   }
 
-  private[this] def superAsTry: Action[E, Try[R], NoStream] = super.asTry
-  override def asTry: Action[E, Try[R], NoStream] = new SynchronousDatabaseAction.Fused[B, E, Try[R], NoStream] {
+  private[this] def superAsTry: EffectfulAction[E, Try[R], NoStream] = super.asTry
+  override def asTry: EffectfulAction[E, Try[R], NoStream] = new SynchronousDatabaseAction.Fused[B, E, Try[R], NoStream] {
     def run(context: ActionContext[B]): Try[R] = {
       try Success(self.run(context)) catch {
         case NonFatal(ex) => Failure(ex)

--- a/src/main/scala/scala/slick/action/Unsafe.scala
+++ b/src/main/scala/scala/slick/action/Unsafe.scala
@@ -11,14 +11,13 @@ object Unsafe {
   /** Run an Action and block the current thread until the result is ready. If the Database uses
     * synchronous, blocking excution, it is performed on the current thread in order to avoid any
     * context switching, otherwise execution happens asynchronously. */
-  def runBlocking[R](db: DatabaseComponent#DatabaseDef, a: Action[Nothing, R, NoStream]): R =
-    db.runInternal(a.asInstanceOf[Action[Effect, R, NoStream]], true).value.get.get
+  def runBlocking[R](db: DatabaseComponent#DatabaseDef, a: Action[R]): R = db.runInternal(a, true).value.get.get
 
   /** Run a streaming Action and return an `Iterator` which performs blocking I/O on the current
     * thread (if supported by the Database) or blocks the current thread while waiting for the
     * next result. */
-  def blockingIterator[S](db: DatabaseComponent#DatabaseDef, a: Action[Nothing, Any, Streaming[S]]): CloseableIterator[S] = new CloseableIterator[S] {
-    val p = db.streamInternal(a.asInstanceOf[Action[Effect, Any, Streaming[S]]], true)
+  def blockingIterator[S](db: DatabaseComponent#DatabaseDef, a: StreamingAction[Any, S]): CloseableIterator[S] = new CloseableIterator[S] {
+    val p = db.streamInternal(a, true)
     var error: Throwable = null
     var sub: Subscription = null
     var value: AnyRef = null

--- a/src/main/scala/scala/slick/action/package.scala
+++ b/src/main/scala/scala/slick/action/package.scala
@@ -1,0 +1,7 @@
+package scala.slick
+
+package object action {
+  type StreamingAction[+R, +T] = EffectfulAction[Nothing, R, Streaming[T]]
+
+  type Action[+R] = EffectfulAction[Nothing, R, NoStream]
+}

--- a/src/main/scala/scala/slick/backend/DatabaseComponent.scala
+++ b/src/main/scala/scala/slick/backend/DatabaseComponent.scala
@@ -30,8 +30,6 @@ trait DatabaseComponent { self =>
   type DatabaseFactory <: DatabaseFactoryDef
   /** The type of session objects used by this backend. */
   type Session >: Null <: SessionDef
-  /** The action effects supported by this backend. */
-  type Effects <: Effect.Read
 
   /** The database factory */
   val Database: DatabaseFactory
@@ -45,9 +43,9 @@ trait DatabaseComponent { self =>
     def close(): Unit
 
     /** Run an Action asynchronously and return the result as a Future. */
-    final def run[R](a: Action[Effects, R, NoStream]): Future[R] = runInternal(a, false)
+    final def run[R](a: Action[R]): Future[R] = runInternal(a, false)
 
-    private[slick] final def runInternal[R](a: Action[Effects, R, NoStream], useSameThread: Boolean): Future[R] =
+    private[slick] final def runInternal[R](a: Action[R], useSameThread: Boolean): Future[R] =
       runInContext(a, new DatabaseActionContext(useSameThread), false)
 
     /** Create a `Publisher` for Reactive Streams which, when subscribed to, will run the specified
@@ -71,13 +69,13 @@ trait DatabaseComponent { self =>
       * from within `onNext`. If streaming is interrupted due to back-pressure signaling, the next
       * row will be prefetched (in order to buffer the next result page from the server when a page
       * boundary has been reached). */
-    final def stream[T](a: Action[Effects, _, Streaming[T]]): DatabasePublisher[T] = streamInternal(a, false)
+    final def stream[T](a: StreamingAction[_, T]): DatabasePublisher[T] = streamInternal(a, false)
 
-    private[slick] final def streamInternal[T](a: Action[Effects, _, Streaming[T]], useSameThread: Boolean): DatabasePublisher[T] =
+    private[slick] final def streamInternal[T](a: StreamingAction[_, T], useSameThread: Boolean): DatabasePublisher[T] =
       createPublisher(a, s => createStreamingDatabaseActionContext(s, useSameThread))
 
     /** Create a Reactive Streams `Publisher` using the given context factory. */
-    protected[this] def createPublisher[T](a: Action[Effects, _, Streaming[T]], createCtx: Subscriber[_ >: T] => StreamingDatabaseActionContext): DatabasePublisher[T] = new DatabasePublisherSupport[T] {
+    protected[this] def createPublisher[T](a: StreamingAction[_, T], createCtx: Subscriber[_ >: T] => StreamingDatabaseActionContext): DatabasePublisher[T] = new DatabasePublisherSupport[T] {
       def subscribe(s: Subscriber[_ >: T]) = if(allowSubscriber(s)) {
         val ctx = createCtx(s)
         if(streamLogger.isDebugEnabled) streamLogger.debug(s"Signaling onSubscribe($ctx)")
@@ -113,7 +111,7 @@ trait DatabaseComponent { self =>
       *                  be a `StreamingDatabaseActionContext` and the Future result should be
       *                  completed with `null` or failed after streaming has finished. This
       *                  method should not call any `Subscriber` method other than `onNext`. */
-    protected[this] def runInContext[R](a: Action[Effects, R, NoStream], ctx: DatabaseActionContext, streaming: Boolean): Future[R] = {
+    protected[this] def runInContext[R](a: Action[R], ctx: DatabaseActionContext, streaming: Boolean): Future[R] = {
       logAction(a, ctx)
       a match {
         case SuccessAction(v) => Future.successful(v)
@@ -275,13 +273,13 @@ trait DatabaseComponent { self =>
       * SynchronousDatabaseActions for asynchronous execution. */
     protected[this] def synchronousExecutionContext: ExecutionContext
 
-    protected[this] def logAction(a: Action[_ <: Effect, _, _ <: NoStream], ctx: DatabaseActionContext): Unit = {
+    protected[this] def logAction(a: Action[_], ctx: DatabaseActionContext): Unit = {
       if(actionLogger.isDebugEnabled && a.isLogged) {
         ctx.sequenceCounter += 1
         val logA = a.nonFusedEquivalentAction
         val aPrefix = if(a eq logA) "" else "[fused] "
         val dump = TreeDump.get(logA, prefix = "    ", firstPrefix = aPrefix, narrow = {
-          case a: Action[_, _, _] => a.nonFusedEquivalentAction
+          case a: Action[_] => a.nonFusedEquivalentAction
           case o => o
         })
         val msg = DumpInfo.highlight("#" + ctx.sequenceCounter) + ": " + dump.substring(0, dump.length-1)

--- a/src/main/scala/scala/slick/backend/RelationalBackend.scala
+++ b/src/main/scala/scala/slick/backend/RelationalBackend.scala
@@ -3,6 +3,4 @@ package scala.slick.backend
 import scala.slick.action.Effect
 
 /** The required backend level for RelationalProfile. */
-trait RelationalBackend extends DatabaseComponent {
-  type Effects <: Effect.Read with Effect.Write with Effect.Schema
-}
+trait RelationalBackend extends DatabaseComponent

--- a/src/main/scala/scala/slick/driver/JdbcProfile.scala
+++ b/src/main/scala/scala/slick/driver/JdbcProfile.scala
@@ -82,7 +82,7 @@ trait JdbcProfile extends SqlProfile with JdbcTableComponent with JdbcActionComp
     implicit def runnableCompiledUpdateActionExtensionMethods[RU, C[_]](c: RunnableCompiled[_ <: Query[_, _, C], C[RU]]): UpdateActionExtensionMethods[RU] =
       createUpdateActionExtensionMethods(c.compiledUpdate, c.param)
 
-    implicit def jdbcActionExtensionMethods[E <: Effect, R, S <: NoStream](a: Action[E, R, S]): JdbcActionExtensionMethods[E, R, S] =
+    implicit def jdbcActionExtensionMethods[E <: Effect, R, S <: NoStream](a: EffectfulAction[E, R, S]): JdbcActionExtensionMethods[E, R, S] =
       new JdbcActionExtensionMethods[E, R, S](a)
 
     implicit def actionBasedSQLInterpolation(s: StringContext) = new ActionBasedSQLInterpolation(s)

--- a/src/main/scala/scala/slick/jdbc/JdbcBackend.scala
+++ b/src/main/scala/scala/slick/jdbc/JdbcBackend.scala
@@ -28,7 +28,6 @@ trait JdbcBackend extends RelationalBackend {
   type Database = DatabaseDef
   type Session = SessionDef
   type DatabaseFactory = DatabaseFactoryDef
-  type Effects = Effect.Read with Effect.Write with Effect.Schema with Effect.Transactional
 
   val Database = new DatabaseFactoryDef {}
   val backend: JdbcBackend = this
@@ -44,12 +43,12 @@ trait JdbcBackend extends RelationalBackend {
 
     def createSession(): Session = new BaseSession(this)
 
-    /** Like `stream(Action)` but you can disable pre-buffering of the next row by setting
+    /** Like `stream(StreamingAction)` but you can disable pre-buffering of the next row by setting
       * `bufferNext = false`. The ResultSet will not advance to the next row until you
       * `request()` more data. This allows you to process LOBs asynchronously by requesting only
       * one single element at a time after processing the current one, so that the proper
       * sequencing is preserved even though processing may happen on a different thread. */
-    final def stream[T](a: Action[Effects, _, Streaming[T]], bufferNext: Boolean): DatabasePublisher[T] =
+    final def stream[T](a: StreamingAction[_, T], bufferNext: Boolean): DatabasePublisher[T] =
       createPublisher(a, s => new JdbcStreamingDatabaseActionContext(s, false, DatabaseDef.this, bufferNext))
 
     override protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[_ >: T], useSameThread: Boolean): StreamingDatabaseActionContext =

--- a/src/main/scala/scala/slick/jdbc/StaticQuery.scala
+++ b/src/main/scala/scala/slick/jdbc/StaticQuery.scala
@@ -154,14 +154,14 @@ class PlainSQLAction[P, T, E <: Effect](pconv: SetParameter[P], rconv: GetResult
   }
   override def cancelStream(ctx: StreamingActionContext[JdbcBackend], state: StreamState): Unit = state.close()
   def getDumpInfo = new DumpInfo("PlainSQLAction")
-  /*
-  override def head: DriverAction[Effect, T, NoStream] = new JdbcDriverAction[T, NoStream] {
-    def statements = streamingAction.statements
-    def run(ctx: ActionContext[Backend]): T = createInvoker[T](rsm, param).first(ctx.session)
+
+  def head: SynchronousDatabaseAction[JdbcBackend, E, T, NoStream] = new SynchronousDatabaseAction[JdbcBackend, E, T, NoStream] {
+    def run(ctx: ActionContext[JdbcBackend]): T = createInvoker.first(ctx.session)
+    def getDumpInfo = new DumpInfo("PlainSQLAction.head")
   }
-  override def headOption: DriverAction[Effect, Option[T], NoStream] = new JdbcDriverAction[Option[T], NoStream] {
-    def statements = streamingAction.statements
-    def run(ctx: ActionContext[Backend]): Option[T] = createInvoker[T](rsm, param).firstOption(ctx.session)
+
+  def headOption: SynchronousDatabaseAction[JdbcBackend, E, Option[T], NoStream] = new SynchronousDatabaseAction[JdbcBackend, E, Option[T], NoStream] {
+    def run(ctx: ActionContext[JdbcBackend]): Option[T] = createInvoker.firstOption(ctx.session)
+    def getDumpInfo = new DumpInfo("PlainSQLAction.headOption")
   }
-  */
 }

--- a/src/main/scala/scala/slick/lifted/Aliases.scala
+++ b/src/main/scala/scala/slick/lifted/Aliases.scala
@@ -50,7 +50,9 @@ trait Aliases {
   @deprecated("Use Rep[T : TypedType] instead of Column[T]", "3.0")
   val Column = lifted.Rep
 
-  type Action[-E <: action.Effect, +R, +S <: action.NoStream] = action.Action[E, R, S]
+  type Action[+R] = action.Action[R]
+  type StreamingAction[+R, +T] = action.StreamingAction[R, T]
+  type EffectfulAction[-E <: action.Effect, +R, +S <: action.NoStream] = action.EffectfulAction[E, R, S]
   val Action = action.Action
   type Effect = action.Effect
   val Effect = action.Effect

--- a/src/main/scala/scala/slick/memory/DistributedBackend.scala
+++ b/src/main/scala/scala/slick/memory/DistributedBackend.scala
@@ -14,7 +14,6 @@ trait DistributedBackend extends RelationalBackend with Logging {
   type Database = DatabaseDef
   type Session = SessionDef
   type DatabaseFactory = DatabaseFactoryDef
-  type Effects = Effect.Read with Effect.Write with Effect.Schema
 
   val Database = new DatabaseFactoryDef
   val backend: DistributedBackend = this
@@ -42,7 +41,7 @@ trait DistributedBackend extends RelationalBackend with Logging {
 
   class DatabaseFactoryDef extends super.DatabaseFactoryDef {
     /** Create a new distributed database instance that uses the global ExecutionContext. */
-    @deprecated("You should explicitly speficy an ExecutionContext in Database.apply()", "3.0")
+    @deprecated("You should explicitly specify an ExecutionContext in Database.apply()", "3.0")
     def apply(dbs: DatabaseComponent#DatabaseDef*): Database = apply(dbs, ExecutionContext.global)
 
     /** Create a new distributed database instance that uses the supplied ExecutionContext for

--- a/src/main/scala/scala/slick/memory/HeapBackend.scala
+++ b/src/main/scala/scala/slick/memory/HeapBackend.scala
@@ -16,7 +16,6 @@ trait HeapBackend extends RelationalBackend with Logging {
   type Database = DatabaseDef
   type Session = SessionDef
   type DatabaseFactory = DatabaseFactoryDef
-  type Effects = Effect.Read with Effect.Write with Effect.Schema
 
   val Database = new DatabaseFactoryDef
   val backend: HeapBackend = this
@@ -57,7 +56,7 @@ trait HeapBackend extends RelationalBackend with Logging {
 
   class DatabaseFactoryDef extends super.DatabaseFactoryDef {
     /** Create a new heap database instance that uses the global ExecutionContext. */
-    @deprecated("You should explicitly speficy an ExecutionContext in Database.apply()", "3.0")
+    @deprecated("You should explicitly specify an ExecutionContext in Database.apply()", "3.0")
     def apply(): Database = new DatabaseDef(ExecutionContext.global)
 
     /** Create a new heap database instance that uses the supplied ExecutionContext for

--- a/src/main/scala/scala/slick/util/TreeDump.scala
+++ b/src/main/scala/scala/slick/util/TreeDump.scala
@@ -21,7 +21,9 @@ object TreeDump {
   def apply(n: Dumpable, name: String = "", prefix: String = "", firstPrefix: String = null, out: PrintWriter = new PrintWriter(new OutputStreamWriter(System.out)), narrow: (Dumpable => Dumpable) = identity) {
     def dump(baseValue: Dumpable, prefix1: String, prefix2: String, name: String, level: Int) {
       val value = narrow(baseValue)
-      val di = value.getDumpInfo
+      val di =
+        if(value eq null) DumpInfo("<error: narrowed to null>", "baseValue = "+baseValue)
+        else value.getDumpInfo
       out.println(
         prefix1 +
         cyan + (if(name.nonEmpty) name + ": " else "") +

--- a/src/sphinx/code/LiftedEmbedding.scala
+++ b/src/sphinx/code/LiftedEmbedding.scala
@@ -1,5 +1,7 @@
 package com.typesafe.slick.docsnippets
 
+import scala.concurrent.{Future, Await}
+import scala.concurrent.duration.Duration
 import scala.slick.action.Unsafe
 import scala.slick.driver.H2Driver.api._
 import java.sql.Date
@@ -149,445 +151,437 @@ object LiftedEmbedding extends App {
 //#primarykey
 //#index
 
-  val db: Database = Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver")
-//#ddl
-  val schema = coffees.schema ++ suppliers.schema
-  db.run(Action.seq(
-    schema.create,
-    //...
-    schema.drop
-  ))
-//#ddl
-
-//#ddl2
-  schema.create.statements.foreach(println)
-  schema.drop.statements.foreach(println)
-//#ddl2
-  TableQuery[A].schema.create.statements.foreach(println)
-
-  ;{
-    //#filtering
-    val q1 = coffees.filter(_.supID === 101)
-    // compiles to SQL (simplified):
-    //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
-    //     from "COFFEES"
-    //     where "SUP_ID" = 101
-
-    val q2 = coffees.drop(10).take(5)
-    // compiles to SQL (simplified):
-    //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
-    //     from "COFFEES"
-    //     limit 5 offset 10
-
-    val q3 = coffees.sortBy(_.name.desc.nullsFirst)
-    // compiles to SQL (simplified):
-    //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
-    //     from "COFFEES"
-    //     order by "COF_NAME" desc nulls first
-    //#filtering
-    println(q1.result.statements.head)
-    println(q2.result.statements.head)
-    println(q3.result.statements.head)
-  }
-
-  ;{
-    //#aggregation1
-    val q = coffees.map(_.price)
-
-    val q1 = q.min
-    // compiles to SQL (simplified):
-    //   select min(x4."PRICE") from "COFFEES" x4
-
-    val q2 = q.max
-    // compiles to SQL (simplified):
-    //   select max(x4."PRICE") from "COFFEES" x4
-
-    val q3 = q.sum
-    // compiles to SQL (simplified):
-    //   select sum(x4."PRICE") from "COFFEES" x4
-
-    val q4 = q.avg
-    // compiles to SQL (simplified):
-    //   select avg(x4."PRICE") from "COFFEES" x4
-    //#aggregation1
-    println(q.result.statements.head)
-    println(q1.shaped.result.statements.head)
-    println(q2.shaped.result.statements.head)
-    println(q3.shaped.result.statements.head)
-    println(q4.shaped.result.statements.head)
-  }
-
-  ;{
-    Unsafe.runBlocking(db, schema.create)
-    //#aggregation2
-    val q1 = coffees.length
-    // compiles to SQL (simplified):
-    //   select count(1) from "COFFEES"
-
-    val q2 = coffees.exists
-    // compiles to SQL (simplified):
-    //   select exists(select * from "COFFEES")
-    //#aggregation2
-    println(q1.shaped.result.statements.head)
-    println(q2.shaped.result.statements.head)
-
-    /*TODO {
-      //#invoker
-      val l = q.list
-      val v = q.buildColl[Vector]
-      val invoker = q.invoker
-      val statement = q.selectStatement
-      //#invoker
-    }
-    {
-      val q = coffees
-      //#delete
-      val affectedRowsCount = q.delete
-      val invoker = q.deleteInvoker
-      val statement = q.deleteStatement
-      //#delete
-    }
-
-    {
-      val session = dynamicSession
-      //#invoker_explicit
-      val l = q.list(session)
-      //#invoker_explicit
-      ()
-    }*/
-  }
-
-  ;{
-    //#aggregation3
-    val q = (for {
-      c <- coffees
-      s <- c.supplier
-    } yield (c, s)).groupBy(_._1.supID)
-
-    val q2 = q.map { case (supID, css) =>
-      (supID, css.length, css.map(_._1.price).avg)
-    }
-    // compiles to SQL:
-    //   select x2."SUP_ID", count(1), avg(x2."PRICE")
-    //     from "COFFEES" x2, "SUPPLIERS" x3
-    //     where x3."SUP_ID" = x2."SUP_ID"
-    //     group by x2."SUP_ID"
-    //#aggregation3
-    println(q2.result.statements.head)
-  }
-
-  ;{
-    //#insert1
-    val insertActions = Action.seq(
-      coffees += ("Colombian", 101, 7.99, 0, 0),
-
-      coffees ++= Seq(
-        ("French_Roast", 49, 8.99, 0, 0),
-        ("Espresso",    150, 9.99, 0, 0)
-      ),
-
-      // "sales" and "total" will use the default value 0:
-      coffees.map(c => (c.name, c.supID, c.price)) += ("Colombian_Decaf", 101, 8.99)
-    )
-
-    val statement = coffees.insertStatement
-
-    // compiles to SQL:
-    //   INSERT INTO "COFFEES" ("COF_NAME","SUP_ID","PRICE","SALES","TOTAL") VALUES (?,?,?,?,?)
-    //#insert1
-    println(statement)
-
-    Unsafe.runBlocking(db, Action.seq(
+  val db: Database = Database.forConfig("h2mem1")
+  try {
+  //#ddl
+    val schema = coffees.schema ++ suppliers.schema
+  //#ddl
+    Await.result(
+  //#ddl
+    db.run(Action.seq(
       schema.create,
-      (suppliers ++= Seq(
-        (101, "", "", "", "", ""),
-        (49, "", "", "", "", ""),
-        (150, "", "", "", "", "")
-      )),
-      insertActions
+      //...
+      schema.drop
     ))
+  //#ddl
+    , Duration.Inf)
 
-    //#insert3
-    val userId =
-      (users returning users.map(_.id)) += User(None, "Stefan", "Zeiger")
-    //#insert3
-    println((users returning users.map(_.id)).insertStatement)
+  //#ddl2
+    schema.create.statements.foreach(println)
+    schema.drop.statements.foreach(println)
+  //#ddl2
+    TableQuery[A].schema.create.statements.foreach(println)
 
-    //#insert3b
-    val userWithId =
-      (users returning users.map(_.id)
-             into ((user,id) => user.copy(id=Some(id)))
-      ) += User(None, "Stefan", "Zeiger")
-    //#insert3b
-    val userWithIdRes = Unsafe.runBlocking(db, users.schema.create >> userWithId)
-    println(userWithIdRes)
+    ;{
+      //#filtering
+      val q1 = coffees.filter(_.supID === 101)
+      // compiles to SQL (simplified):
+      //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
+      //     from "COFFEES"
+      //     where "SUP_ID" = 101
 
-    //#insert4
-    class Users2(tag: Tag) extends Table[(Int, String)](tag, "users2") {
-      def id = column[Int]("id", O.PrimaryKey)
-      def name = column[String]("name")
-      def * = (id, name)
+      val q2 = coffees.drop(10).take(5)
+      // compiles to SQL (simplified):
+      //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
+      //     from "COFFEES"
+      //     limit 5 offset 10
+
+      val q3 = coffees.sortBy(_.name.desc.nullsFirst)
+      // compiles to SQL (simplified):
+      //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
+      //     from "COFFEES"
+      //     order by "COF_NAME" desc nulls first
+      //#filtering
+      println(q1.result.statements.head)
+      println(q2.result.statements.head)
+      println(q3.result.statements.head)
     }
-    val users2 = TableQuery[Users2]
 
-    val actions = Action.seq(
-      users2.schema.create,
+    ;{
+      //#aggregation1
+      val q = coffees.map(_.price)
 
-      users2 insert (users.map { u => (u.id, u.first ++ " " ++ u.last) }),
+      val q1 = q.min
+      // compiles to SQL (simplified):
+      //   select min(x4."PRICE") from "COFFEES" x4
 
-      users2 insertExpr (users.length + 1, "admin")
-    )
-    //#insert4
-    Unsafe.runBlocking(db, users.schema.create >> actions)
-  }
+      val q2 = q.max
+      // compiles to SQL (simplified):
+      //   select max(x4."PRICE") from "COFFEES" x4
 
-  ;{
-    Unsafe.runBlocking(db, Action.seq(
-      suppliers.schema.create,
-      coffees.schema.create,
-      suppliers += (101, "", "", "", "", ""),
-      coffees += ("Espresso", 101, 0, 0, 0)
-    ))
-    //#update1
-    val q = for { c <- coffees if c.name === "Espresso" } yield c.price
-    val updateAction = q.update(10.49)
+      val q3 = q.sum
+      // compiles to SQL (simplified):
+      //   select sum(x4."PRICE") from "COFFEES" x4
 
-    val statement = q.updateStatement
+      val q4 = q.avg
+      // compiles to SQL (simplified):
+      //   select avg(x4."PRICE") from "COFFEES" x4
+      //#aggregation1
+      println(q.result.statements.head)
+      println(q1.shaped.result.statements.head)
+      println(q2.shaped.result.statements.head)
+      println(q3.shaped.result.statements.head)
+      println(q4.shaped.result.statements.head)
+    }
 
-    // compiles to SQL:
-    //   update "COFFEES" set "PRICE" = ? where "COFFEES"."COF_NAME" = 'Espresso'
-    //#update1
-    println(statement)
-  }
+    ;{
+      Unsafe.runBlocking(db, schema.create)
+      //#aggregation2
+      val q1 = coffees.length
+      // compiles to SQL (simplified):
+      //   select count(1) from "COFFEES"
 
-  ;{
-    Unsafe.runBlocking(db, Action.seq(
-      users.schema.create,
-      usersForInsert ++= Seq(
-        User(None,"",""),
-        User(None,"","")
+      val q2 = coffees.exists
+      // compiles to SQL (simplified):
+      //   select exists(select * from "COFFEES")
+      //#aggregation2
+      println(q1.shaped.result.statements.head)
+      println(q2.shaped.result.statements.head)
+
+      {
+        //#result
+        val q = coffees.map(_.price)
+        val action = q.result
+        val result: Future[Seq[Double]] = db.run(action)
+        val sql = action.statements.head
+        //#result
+        Await.result(result, Duration.Inf)
+      }
+      {
+        //#delete
+        val q = coffees.filter(_.supID === 15)
+        val action = q.delete
+        val affectedRowsCount: Future[Int] = db.run(action)
+        val sql = action.statements.head
+        //#delete
+        Await.result(affectedRowsCount, Duration.Inf)
+      }
+    }
+
+    ;{
+      //#aggregation3
+      val q = (for {
+        c <- coffees
+        s <- c.supplier
+      } yield (c, s)).groupBy(_._1.supID)
+
+      val q2 = q.map { case (supID, css) =>
+        (supID, css.length, css.map(_._1.price).avg)
+      }
+      // compiles to SQL:
+      //   select x2."SUP_ID", count(1), avg(x2."PRICE")
+      //     from "COFFEES" x2, "SUPPLIERS" x3
+      //     where x3."SUP_ID" = x2."SUP_ID"
+      //     group by x2."SUP_ID"
+      //#aggregation3
+      println(q2.result.statements.head)
+    }
+
+    ;{
+      //#insert1
+      val insertActions = Action.seq(
+        coffees += ("Colombian", 101, 7.99, 0, 0),
+
+        coffees ++= Seq(
+          ("French_Roast", 49, 8.99, 0, 0),
+          ("Espresso",    150, 9.99, 0, 0)
+        ),
+
+        // "sales" and "total" will use the default value 0:
+        coffees.map(c => (c.name, c.supID, c.price)) += ("Colombian_Decaf", 101, 8.99)
       )
-    ))
 
-    {
-      //#compiled1
-      def userNameByIDRange(min: Rep[Int], max: Rep[Int]) =
-        for {
+      // Get the statement without having to specify a value to insert:
+      val sql = coffees.insertStatement
+
+      // compiles to SQL:
+      //   INSERT INTO "COFFEES" ("COF_NAME","SUP_ID","PRICE","SALES","TOTAL") VALUES (?,?,?,?,?)
+      //#insert1
+      println(sql)
+
+      Unsafe.runBlocking(db, Action.seq(
+        (suppliers ++= Seq(
+          (101, "", "", "", "", ""),
+          (49, "", "", "", "", ""),
+          (150, "", "", "", "", "")
+        )),
+        insertActions
+      ))
+
+      //#insert3
+      val userId =
+        (users returning users.map(_.id)) += User(None, "Stefan", "Zeiger")
+      //#insert3
+      println((users returning users.map(_.id)).insertStatement)
+
+      //#insert3b
+      val userWithId =
+        (users returning users.map(_.id)
+               into ((user,id) => user.copy(id=Some(id)))
+        ) += User(None, "Stefan", "Zeiger")
+      //#insert3b
+      val userWithIdRes = Unsafe.runBlocking(db, users.schema.create >> userWithId)
+      println(userWithIdRes)
+
+      //#insert4
+      class Users2(tag: Tag) extends Table[(Int, String)](tag, "users2") {
+        def id = column[Int]("id", O.PrimaryKey)
+        def name = column[String]("name")
+        def * = (id, name)
+      }
+      val users2 = TableQuery[Users2]
+
+      val actions = Action.seq(
+        users2.schema.create,
+        users2 insert (users.map { u => (u.id, u.first ++ " " ++ u.last) }),
+        users2 insertExpr (users.length + 1, "admin")
+      )
+      //#insert4
+      Unsafe.runBlocking(db, actions)
+    }
+
+    ;{
+      //#update1
+      val q = for { c <- coffees if c.name === "Espresso" } yield c.price
+      val updateAction = q.update(10.49)
+
+      // Get the statement without having to specify an updated value:
+      val sql = q.updateStatement
+
+      // compiles to SQL:
+      //   update "COFFEES" set "PRICE" = ? where "COFFEES"."COF_NAME" = 'Espresso'
+      //#update1
+      println(sql)
+    }
+
+    ;{
+      Unsafe.runBlocking(db,
+        usersForInsert ++= Seq(
+          User(None,"",""),
+          User(None,"","")
+        )
+      )
+
+      {
+        //#compiled1
+        def userNameByIDRange(min: Rep[Int], max: Rep[Int]) =
+          for {
+            u <- users if u.id >= min && u.id < max
+          } yield u.first
+
+        val userNameByIDRangeCompiled = Compiled(userNameByIDRange _)
+
+        // The query will be compiled only once:
+        val namesAction1 = userNameByIDRangeCompiled(2, 5).result
+        val namesAction2 = userNameByIDRangeCompiled(1, 3).result
+        // Also works for .insert, .update and .delete
+        //#compiled1
+      }
+
+      {
+        //#compiled2
+        val userPaged = Compiled((d: ConstColumn[Long], t: ConstColumn[Long]) => users.drop(d).take(t))
+
+        val usersAction1 = userPaged(2, 1).result
+        val usersAction2 = userPaged(1, 3).result
+        //#compiled2
+      }
+
+      {
+        //#template1
+        val userNameByID = for {
+          id <- Parameters[Int]
+          u <- users if u.id === id
+        } yield u.first
+
+        val nameAction = userNameByID(2).result.head
+
+        val userNameByIDRange = for {
+          (min, max) <- Parameters[(Int, Int)]
           u <- users if u.id >= min && u.id < max
         } yield u.first
 
-      val userNameByIDRangeCompiled = Compiled(userNameByIDRange _)
-
-      // The query will be compiled only once:
-      val namesAction1 = userNameByIDRangeCompiled(2, 5).result
-      val namesAction2 = userNameByIDRangeCompiled(1, 3).result
-      // Also works for .update and .delete
-      //#compiled1
+        val namesAction = userNameByIDRange(2, 5).result
+        //#template1
+      }
     }
 
-    {
-      //#compiled2
-      val userPaged = Compiled((d: ConstColumn[Long], t: ConstColumn[Long]) => users.drop(d).take(t))
+    ;{
+      class SalesPerDay(tag: Tag) extends Table[(Date, Int)](tag, "SALES_PER_DAY") {
+        def day = column[Date]("DAY", O.PrimaryKey)
+        def count = column[Int]("COUNT")
+        def * = (day, count)
+      }
+      val salesPerDay = TableQuery[SalesPerDay]
+      //#simplefunction1
+      // H2 has a day_of_week() function which extracts the day of week from a timestamp
+      val dayOfWeek = SimpleFunction.unary[Date, Int]("day_of_week")
 
-      val usersAction1 = userPaged(2, 1).result
-      val usersAction2 = userPaged(1, 3).result
-      //#compiled2
+      // Use the lifted function in a query to group by day of week
+      val q1 = for {
+        (dow, q) <- salesPerDay.map(s => (dayOfWeek(s.day), s.count)).groupBy(_._1)
+      } yield (dow, q.map(_._2).sum)
+      //#simplefunction1
+
+      //#simplefunction2
+      def dayOfWeek2(c: Rep[Date]) =
+        SimpleFunction[Int]("day_of_week").apply(Seq(c))
+      //#simplefunction2
+
+      assert{
+        Unsafe.runBlocking(db,
+          salesPerDay.schema.create >>
+          (salesPerDay += ( (new Date(999999999), 999) )) >>
+          {
+            //#simpleliteral
+            val current_date = SimpleLiteral[java.sql.Date]("CURRENT_DATE")
+            salesPerDay.map(_ => current_date)
+            //#simpleliteral
+          }.result.head
+        ).isInstanceOf[java.sql.Date]
+      }
     }
 
-    {
-      //#template1
-      val userNameByID = for {
-        id <- Parameters[Int]
-        u <- users if u.id === id
-      } yield u.first
+    db withDynSession {
+      //#mappedtype1
+      // An algebraic data type for booleans
+      sealed trait Bool
+      case object True extends Bool
+      case object False extends Bool
 
-      val nameAction = userNameByID(2).result.head
-
-      val userNameByIDRange = for {
-        (min, max) <- Parameters[(Int, Int)]
-        u <- users if u.id >= min && u.id < max
-      } yield u.first
-
-      val namesAction = userNameByIDRange(2, 5).result
-      //#template1
-    }
-  }
-
-  ;{
-    class SalesPerDay(tag: Tag) extends Table[(Date, Int)](tag, "SALES_PER_DAY") {
-      def day = column[Date]("DAY", O.PrimaryKey)
-      def count = column[Int]("COUNT")
-      def * = (day, count)
-    }
-    val salesPerDay = TableQuery[SalesPerDay]
-    //#simplefunction1
-    // H2 has a day_of_week() function which extracts the day of week from a timestamp
-    val dayOfWeek = SimpleFunction.unary[Date, Int]("day_of_week")
-
-    // Use the lifted function in a query to group by day of week
-    val q1 = for {
-      (dow, q) <- salesPerDay.map(s => (dayOfWeek(s.day), s.count)).groupBy(_._1)
-    } yield (dow, q.map(_._2).sum)
-    //#simplefunction1
-
-    //#simplefunction2
-    def dayOfWeek2(c: Rep[Date]) =
-      SimpleFunction[Int]("day_of_week").apply(Seq(c))
-    //#simplefunction2
-
-    assert{
-      Unsafe.runBlocking(db,
-        salesPerDay.schema.create >>
-        (salesPerDay += ( (new Date(999999999), 999) )) >>
-        {
-          //#simpleliteral
-          val current_date = SimpleLiteral[java.sql.Date]("CURRENT_DATE")
-          salesPerDay.map(_ => current_date)
-          //#simpleliteral
-        }.result.head
-      ).isInstanceOf[java.sql.Date]
-    }
-  }
-
-  db withDynSession {
-    //#mappedtype1
-    // An algebraic data type for booleans
-    sealed trait Bool
-    case object True extends Bool
-    case object False extends Bool
-
-    // And a ColumnType that maps it to Int values 1 and 0
-    implicit val boolColumnType = MappedColumnType.base[Bool, Int](
-      { b => if(b == True) 1 else 0 },    // map Bool to Int
-      { i => if(i == 1) True else False } // map Int to Bool
-    )
-
-    // You can now use Bool like any built-in column type (in tables, queries, etc.)
-    //#mappedtype1
-  }
-
-  db withDynSession {
-    //#mappedtype2
-    // A custom ID type for a table
-    case class MyID(value: Long) extends MappedTo[Long]
-
-    // Use it directly for this table's ID -- No extra boilerplate needed
-    class MyTable(tag: Tag) extends Table[(MyID, String)](tag, "MY_TABLE") {
-      def id = column[MyID]("ID")
-      def data = column[String]("DATA")
-      def * = (id, data)
-    }
-    //#mappedtype2
-  }
-
-  ;{
-    //#recordtype1
-    // A custom record class
-    case class Pair[A, B](a: A, b: B)
-
-    // A Shape implementation for Pair
-    final class PairShape[Level <: ShapeLevel, M <: Pair[_,_], U <: Pair[_,_] : ClassTag, P <: Pair[_,_]](
-      val shapes: Seq[Shape[_, _, _, _]])
-    extends MappedScalaProductShape[Level, Pair[_,_], M, U, P] {
-      def buildValue(elems: IndexedSeq[Any]) = Pair(elems(0), elems(1))
-      def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new PairShape(shapes)
-    }
-
-    implicit def pairShape[Level <: ShapeLevel, M1, M2, U1, U2, P1, P2](
-      implicit s1: Shape[_ <: Level, M1, U1, P1], s2: Shape[_ <: Level, M2, U2, P2]
-    ) = new PairShape[Level, Pair[M1, M2], Pair[U1, U2], Pair[P1, P2]](Seq(s1, s2))
-    //#recordtype1
-
-    //#recordtype2
-    // Use it in a table definition
-    class A(tag: Tag) extends Table[Pair[Int, String]](tag, "shape_a") {
-      def id = column[Int]("id", O.PrimaryKey)
-      def s = column[String]("s")
-      def * = Pair(id, s)
-    }
-    val as = TableQuery[A]
-
-    // Insert data with the custom shape
-    val insertAction = Action.seq(
-      as += Pair(1, "a"),
-      as += Pair(2, "c"),
-      as += Pair(3, "b")
-    )
-
-    // Use it for returning data from a query
-    val q2 = as
-      .map { case a => Pair(a.id, (a.s ++ a.s)) }
-      .filter { case Pair(id, _) => id =!= 1 }
-      .sortBy { case Pair(_, ss) => ss }
-      .map { case Pair(id, ss) => Pair(id, Pair(42 , ss)) }
-    // returns: Vector(Pair(3,Pair(42,"bb")), Pair(2,Pair(42,"cc")))
-    //#recordtype2
-
-    assert(Unsafe.runBlocking(db, as.schema.create >> insertAction >> q2.result) == Vector(Pair(3,Pair(42,"bb")), Pair(2,Pair(42,"cc"))))
-
-    //#case-class-shape
-    // two custom case class variants
-    case class LiftedB(a: Rep[Int], b: Rep[String])
-    case class B(a: Int, b: String)
-
-    // custom case class mapping
-    implicit object BShape extends CaseClassShape(LiftedB.tupled, B.tupled)
-
-    class BRow(tag: Tag) extends Table[B](tag, "shape_b") {
-      def id = column[Int]("id", O.PrimaryKey)
-      def s = column[String]("s")
-      def * = LiftedB(id, s)
-    }
-    val bs = TableQuery[BRow]
-
-    val insertActions = Action.seq(
-      bs += B(1, "a"),
-      bs.map(b => (b.id, b.s)) += ((2, "c")),
-      bs += B(3, "b")
-    )
-
-    val q3 = bs
-      .map { case b => LiftedB(b.id, (b.s ++ b.s)) }
-      .filter { case LiftedB(id, _) => id =!= 1 }
-      .sortBy { case LiftedB(_, ss) => ss }
-
-    // returns: Vector(B(3,"bb"), B(2,"cc"))
-    //#case-class-shape
-    assert(Unsafe.runBlocking(db, bs.schema.create >> insertActions >> q3.result) == Vector(B(3,"bb"), B(2,"cc")))
-
-    //#combining-shapes
-    // Combining multiple mapped types
-    case class LiftedC(p: Pair[Rep[Int],Rep[String]], b: LiftedB)
-    case class C(p: Pair[Int,String], b: B)
-
-    implicit object CShape extends CaseClassShape(LiftedC.tupled, C.tupled)
-
-    class CRow(tag: Tag) extends Table[C](tag, "shape_c") {
-      def id = column[Int]("id")
-      def s = column[String]("s")
-      def projection = LiftedC(
-        Pair(column("p1"),column("p2")), // (cols defined inline, type inferred)
-        LiftedB(id,s)
+      // And a ColumnType that maps it to Int values 1 and 0
+      implicit val boolColumnType = MappedColumnType.base[Bool, Int](
+        { b => if(b == True) 1 else 0 },    // map Bool to Int
+        { i => if(i == 1) True else False } // map Int to Bool
       )
-      def * = projection
+
+      // You can now use Bool like any built-in column type (in tables, queries, etc.)
+      //#mappedtype1
     }
-    val cs = TableQuery[CRow]
 
-    val insertActions2 = Action.seq(
-      cs += C(Pair(7,"x"), B(1,"a")),
-      cs += C(Pair(8,"y"), B(2,"c")),
-      cs += C(Pair(9,"z"), B(3,"b"))
-    )
+    db withDynSession {
+      //#mappedtype2
+      // A custom ID type for a table
+      case class MyID(value: Long) extends MappedTo[Long]
 
-    val q4 = cs
-      .map { case c => LiftedC(c.projection.p, LiftedB(c.id,(c.s ++ c.s))) }
-      .filter { case LiftedC(_, LiftedB(id,_)) => id =!= 1 }
-      .sortBy { case LiftedC(Pair(_,p2), LiftedB(_,ss)) => ss++p2 }
+      // Use it directly for this table's ID -- No extra boilerplate needed
+      class MyTable(tag: Tag) extends Table[(MyID, String)](tag, "MY_TABLE") {
+        def id = column[MyID]("ID")
+        def data = column[String]("DATA")
+        def * = (id, data)
+      }
+      //#mappedtype2
+    }
 
-    // returns: Vector(C(Pair(9,"z"),B(3,"bb")), C(Pair(8,"y"),B(2,"cc")))
-    //#combining-shapes
-    assert(Unsafe.runBlocking(db, cs.schema.create >> insertActions2 >> q4.result) == Vector(C(Pair(9,"z"),B(3,"bb")), C(Pair(8,"y"),B(2,"cc"))))
+    ;{
+      //#recordtype1
+      // A custom record class
+      case class Pair[A, B](a: A, b: B)
 
-    ()
-  }
+      // A Shape implementation for Pair
+      final class PairShape[Level <: ShapeLevel, M <: Pair[_,_], U <: Pair[_,_] : ClassTag, P <: Pair[_,_]](
+        val shapes: Seq[Shape[_, _, _, _]])
+      extends MappedScalaProductShape[Level, Pair[_,_], M, U, P] {
+        def buildValue(elems: IndexedSeq[Any]) = Pair(elems(0), elems(1))
+        def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new PairShape(shapes)
+      }
+
+      implicit def pairShape[Level <: ShapeLevel, M1, M2, U1, U2, P1, P2](
+        implicit s1: Shape[_ <: Level, M1, U1, P1], s2: Shape[_ <: Level, M2, U2, P2]
+      ) = new PairShape[Level, Pair[M1, M2], Pair[U1, U2], Pair[P1, P2]](Seq(s1, s2))
+      //#recordtype1
+
+      //#recordtype2
+      // Use it in a table definition
+      class A(tag: Tag) extends Table[Pair[Int, String]](tag, "shape_a") {
+        def id = column[Int]("id", O.PrimaryKey)
+        def s = column[String]("s")
+        def * = Pair(id, s)
+      }
+      val as = TableQuery[A]
+
+      // Insert data with the custom shape
+      val insertAction = Action.seq(
+        as += Pair(1, "a"),
+        as += Pair(2, "c"),
+        as += Pair(3, "b")
+      )
+
+      // Use it for returning data from a query
+      val q2 = as
+        .map { case a => Pair(a.id, (a.s ++ a.s)) }
+        .filter { case Pair(id, _) => id =!= 1 }
+        .sortBy { case Pair(_, ss) => ss }
+        .map { case Pair(id, ss) => Pair(id, Pair(42 , ss)) }
+      // returns: Vector(Pair(3,Pair(42,"bb")), Pair(2,Pair(42,"cc")))
+      //#recordtype2
+
+      assert(Unsafe.runBlocking(db, as.schema.create >> insertAction >> q2.result) == Vector(Pair(3,Pair(42,"bb")), Pair(2,Pair(42,"cc"))))
+
+      //#case-class-shape
+      // two custom case class variants
+      case class LiftedB(a: Rep[Int], b: Rep[String])
+      case class B(a: Int, b: String)
+
+      // custom case class mapping
+      implicit object BShape extends CaseClassShape(LiftedB.tupled, B.tupled)
+
+      class BRow(tag: Tag) extends Table[B](tag, "shape_b") {
+        def id = column[Int]("id", O.PrimaryKey)
+        def s = column[String]("s")
+        def * = LiftedB(id, s)
+      }
+      val bs = TableQuery[BRow]
+
+      val insertActions = Action.seq(
+        bs += B(1, "a"),
+        bs.map(b => (b.id, b.s)) += ((2, "c")),
+        bs += B(3, "b")
+      )
+
+      val q3 = bs
+        .map { case b => LiftedB(b.id, (b.s ++ b.s)) }
+        .filter { case LiftedB(id, _) => id =!= 1 }
+        .sortBy { case LiftedB(_, ss) => ss }
+
+      // returns: Vector(B(3,"bb"), B(2,"cc"))
+      //#case-class-shape
+      assert(Unsafe.runBlocking(db, bs.schema.create >> insertActions >> q3.result) == Vector(B(3,"bb"), B(2,"cc")))
+
+      //#combining-shapes
+      // Combining multiple mapped types
+      case class LiftedC(p: Pair[Rep[Int],Rep[String]], b: LiftedB)
+      case class C(p: Pair[Int,String], b: B)
+
+      implicit object CShape extends CaseClassShape(LiftedC.tupled, C.tupled)
+
+      class CRow(tag: Tag) extends Table[C](tag, "shape_c") {
+        def id = column[Int]("id")
+        def s = column[String]("s")
+        def projection = LiftedC(
+          Pair(column("p1"),column("p2")), // (cols defined inline, type inferred)
+          LiftedB(id,s)
+        )
+        def * = projection
+      }
+      val cs = TableQuery[CRow]
+
+      val insertActions2 = Action.seq(
+        cs += C(Pair(7,"x"), B(1,"a")),
+        cs += C(Pair(8,"y"), B(2,"c")),
+        cs += C(Pair(9,"z"), B(3,"b"))
+      )
+
+      val q4 = cs
+        .map { case c => LiftedC(c.projection.p, LiftedB(c.id,(c.s ++ c.s))) }
+        .filter { case LiftedC(_, LiftedB(id,_)) => id =!= 1 }
+        .sortBy { case LiftedC(Pair(_,p2), LiftedB(_,ss)) => ss++p2 }
+
+      // returns: Vector(C(Pair(9,"z"),B(3,"bb")), C(Pair(8,"y"),B(2,"cc")))
+      //#combining-shapes
+      assert(Unsafe.runBlocking(db, cs.schema.create >> insertActions2 >> q4.result) == Vector(C(Pair(9,"z"),B(3,"bb")), C(Pair(8,"y"),B(2,"cc"))))
+
+      ()
+    }
+  } finally db.close
 }

--- a/src/sphinx/database.rst
+++ b/src/sphinx/database.rst
@@ -4,11 +4,11 @@ Databases & Actions
 Anything that you can execute on a database, whether it is a getting the result of a query
 ("``myQuery.result``"), creating a table ("``myTable.schema.create``"), inserting data
 ("``myTable += item``") or something else, is an instance of
-:api:`scala.slick.action.Action`, parameterized by the result type it will produce when you
+:api:`scala.slick.action.EffectfulAction`, parameterized by the result type it will produce when you
 execute it.
 
 Actions can be combined with several different combinators (see the
-:api:`Action class <scala.slick.action.Action>` and :api:`object <scala.slick.action.Action$>` for
+:api:`EffectfulAction class <scala.slick.action.EffectfulAction>` and :api:`Action object <scala.slick.action.EffectfulAction>` for
 details), but they will always be executed strictly sequentially and (at least conceptually) in a
 single database session.
 
@@ -179,19 +179,19 @@ When executing an Action that is composed of several smaller Actions, Slick acqu
 the connection pool and releases them again as needed so that a session is not kept in use
 unnecessarily while waiting for the result from a non-database computation (e.g. the function
 passed to
-:api:`flatMap <scala.slick.action.Action@flatMap[E2<:Effect,R2,S2<:NoStream]((R)⇒Action[E2,R2,S2])(ExecutionContext):Action[EwithE2,R2,S2]>`
-that determines the next Action to run). All :api:`Action combinators <scala.slick.action.Action>`
+:api:`flatMap <scala.slick.action.EffectfulAction@flatMap[E2<:Effect,R2,S2<:NoStream]((R)⇒EffectfulAction[E2,R2,S2])(ExecutionContext):EffectfulAction[EwithE2,R2,S2]>`
+that determines the next Action to run). All :api:`Action combinators <scala.slick.action.EffectfulAction>`
 which combine two database Actions without any non-database computations in between (e.g.
-:api:`andThen <scala.slick.action.Action@andThen[E2<:Effect,R2,S2<:NoStream](Action[E2,R2,S2]):Action[EwithE2,R2,S2]>`
-or :api:`zip <scala.slick.action.Action@zip[E2<:Effect,R2](Action[E2,R2,NoStream]):Action[EwithE2,(R,R2),NoStream]>`)
+:api:`andThen <scala.slick.action.EffectfulAction@andThen[E2<:Effect,R2,S2<:NoStream](EffectfulAction[E2,R2,S2]):EffectfulAction[EwithE2,R2,S2]>`
+or :api:`zip <scala.slick.action.EffectfulAction@zip[E2<:Effect,R2](EffectfulAction[E2,R2,NoStream]):EffectfulAction[EwithE2,(R,R2),NoStream]>`)
 can fuse these Actions for more efficient execution, with the side-effect that the fused Action
 runs inside a single session. You can use
-:api:`withPinnedSession <scala.slick.action.Action@withPinnedSession:Action[E,R,S]>` to force the
+:api:`withPinnedSession <scala.slick.action.EffectfulAction@withPinnedSession:EffectfulAction[E,R,S]>` to force the
 use of a single session, keeping the existing session open even when waiting for non-database
 computations.
 
 There is a similar combinator
-:api:`transactionally <scala.slick.driver.JdbcActionComponent$JdbcActionExtensionMethods@transactionally:Action[EwithTransactional,R,S]>`
+:api:`transactionally <scala.slick.driver.JdbcActionComponent$JdbcActionExtensionMethods@transactionally:EffectfulAction[EwithTransactional,R,S]>`
 to force the use of a transaction. This guarantees that the entire Action that is executed will
 either succeed or fail atomically.  Note that failure is not guaranteed to be atomic at the level
 of an individual Action that is wrapped with ``.transactionally``, so you should not apply error

--- a/src/sphinx/database.rst
+++ b/src/sphinx/database.rst
@@ -120,6 +120,8 @@ should therefore enable prepared statement caching in the connection pool's conf
 .. index::
    pair: execute; Action
 
+.. _executing-actions:
+
 Executing Actions
 -----------------
 

--- a/src/sphinx/orm-to-slick.rst
+++ b/src/sphinx/orm-to-slick.rst
@@ -51,13 +51,18 @@ Slick works differently. To do the same in Slick you would write the following. 
 
 .. includecode:: code/OrmToSlick.scala#slickNavigation
 
-As we can see it looks very much like collection operations but the values we get are of type ``Query``. They do not store results, only a plan of the operations that are needed to create a SQL query that produces the results when needed. No database round trips happen at all in our example. To actually fetch results, we can use the ``.run`` method on one of our values.
+As we can see it looks very much like collection operations but the values we get are of type ``Query``. They do not
+store results, only a plan of the operations that are needed to create a SQL query that produces the results when
+needed. No database round trips happen at all in our example. To actually fetch results, we can have to compile the
+query to a :doc:`database Action <database>` with ``.result`` and then ``run`` it on the Database.
 
 .. includecode:: code/OrmToSlick.scala#slickExecution
 
 A single query is executed and the results returned. This makes database round trips very explicit and easy to reason about. Achieving few database round trips is easy.
 
-As you can see with Slick we do not navigate the object graph (i.e. results) directly. We navigate it by composing queries instead, which are just place-holder values for potential database round trip yet to happen. We can lazily compose queries until they describe exactly what we need and then use a single ``.run`` call for execution.
+As you can see with Slick we do not navigate the object graph (i.e. results) directly. We navigate it by composing
+queries instead, which are just place-holder values for potential database round trip yet to happen. We can lazily
+compose queries until they describe exactly what we need and then use a single ``Database.run`` call for execution.
 
 Navigating the object graph directly in an ORM is problematic as explained earlier. Slick gets away without that feature. ORMs often solve the problem by offering a declarative query language as an alternative, which is similar to how you work with Slick.
 
@@ -187,7 +192,7 @@ A variant of this question Slick new comers often ask is how they can do somethi
 
 .. includecode:: code/OrmToSlick.scala#relationshipNavigation2
 
-The problem is that this hard-codes that to exist a Person requires an Address. It can not be loaded without it. This does't fit to Slick's philosophy of giving you fine-grained control over what you load exactly. With Slick it is advised to map one table to a tuple or case class without them having object references to related objects. Instead you can write a function that joins two tables and returns them as a tuple or association case class instance, providing an association externally, not strongly tied one of the classes.
+The problem is that this hard-codes that a Person requires an Address. It can not be loaded without it. This does't fit to Slick's philosophy of giving you fine-grained control over what you load exactly. With Slick it is advised to map one table to a tuple or case class without them having object references to related objects. Instead you can write a function that joins two tables and returns them as a tuple or association case class instance, providing an association externally, not strongly tied one of the classes.
 
 .. includecode:: code/OrmToSlick.scala#associationTuple
 

--- a/src/sphinx/upgrade.rst
+++ b/src/sphinx/upgrade.rst
@@ -32,6 +32,26 @@ The old operators are deprecated but still available. Deprecation warnings will 
 Passing an explicit ``JoinType`` to the generic ``join`` operator does not make sense anymore with the new join
 semantics and is therefore deprecated, too. ``join`` is now used exclusively for inner joins.
 
+first
+-----
+
+The old Invoker API used the ``first`` and ``firstOption`` methods to get the first element of a collection-valued
+query. The same operations for streaming Actions in the new API are called ``head`` and ``headOption`` respectively,
+consistent with the names used by the Scala Collections API.
+
+Column Type
+-----------
+
+The type ``Column[T]`` has been subsumed into its supertype ``Rep[T]``. For operations which are only available for
+individual columns, an implicit ``TypedType[T]`` evidence is required. The more flexible handling of Option columns
+requires Option and non-Option columns to be treated differently when creating an implicit ``Shape``. In this case a
+the evidence needs to be of type ``OptionTypedType[T]`` or ``BaseTypedType[T]``, respectively. If you want to abstract
+over both, it may be more convenient to pass the required ``Shape`` as an implicit parameter and let it be instantiated
+at the call site where the concrete type is known.
+
+``Column[T]`` is still available as a deprecated alias for ``Rep[T]``. Due to the required implicit evidence, it
+cannot provide complete backwards compatibility in all cases.
+
 Upgrade from 2.0 to 2.1
 =======================
 


### PR DESCRIPTION
- Rename Action to EffectfulAction

- Add type aliases:
    StreamingAction[R, T] = EffectfulAction[Nothing, R, Streaming[T]]
    Action[R] = EffectfulAction[Nothing, R, NoStream]
  These allow users to write Action types down in a much simpler way
  when they don’t care about effects.

- Remove the supported Effect type from DatabaseComponent so that any
  Effect is acceptable for running and streaming an Action. Since the
  operations provided by a Profile do not use any Effect that is not
  supported by the corresponding Backend, enforcing the effects is
  unnecessary (and precludes the use of the new type aliases that drop
  the effect type).

- SimpleJdbcAction now uses Nothing (i.e. any possible effect) as its
  effect type, which is the correct assumption. It previously used
  Effect (i.e. no particular effect) to avoid casts. Since running an
  Action does not check the effects anymore, this is now unnecessary.

@cvogt The Read and Write effects are still implemented as phantom types. My original idea of reifying them to get rid of the extra type parameters doesn't work. Effects have to be inferred statically (e.g. you need to know if the second Action in a flatMap could possibly have a certain effect before executing the first one).