### PR TITLE
[Docs] Change deprecated BoneCP connection pool reference to HikariCP

### DIFF
--- a/src/sphinx/connection.rst
+++ b/src/sphinx/connection.rst
@@ -230,7 +230,7 @@ Slick does not provide a connection pool implementation of its own. When you
 run a managed application in some container (e.g. JEE or Spring), you should
 generally use the connection pool provided by the container. For stand-alone
 applications you can use an external pool implementation like DBCP_, c3p0_
-or BoneCP_.
+or HikariCP_.
 
 Note that Slick uses *prepared* statements wherever possible but it does not
 cache them on its own. You should therefore enable prepared statement caching


### PR DESCRIPTION
Hey,

looking for connection pool solution to use with slick I found that last one mentioned in docs (BoneCP, https://github.com/wwadge/bonecp) was deprecated in favor of HikariCP, https://github.com/brettwooldridge/HikariCP. Information about deprecation in BoneCP github repo readme. 

With this pool request I change only 2.1 branch, if you'd like me to change another ones accordingly let me know. 

Thanks,
Igor