### PR TITLE
Use unconstrained text type as default on PostgreSQL

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
@@ -55,10 +55,10 @@ class TemplateTest extends AsyncTest[RelationalTestDB] {
       _ <- Action.seq(uids.map(uid => orders.map(o => (o.userID, o.product)) += (uid, if(uid < 4) "Product A" else "Product B")): _*)
       _ <- q1.result.map(_ shouldBe List("Apu"))
       _ <- q2.result.map(_ shouldBe List("Apu"))
-      _ <- q3.result.map(_ shouldBe List("Marge","Apu","Carl","Lenny"))
-      _ <- q4.result.map(_ shouldBe List("Marge", "Apu"))
+      _ <- q3.result.map(_.toSet shouldBe Set("Marge","Apu","Carl","Lenny"))
+      _ <- q4.result.map(_.toSet shouldBe Set("Marge", "Apu"))
       _ <- q5a.result.map(_ shouldBe List("Apu"))
-      _ <- q5b.result.map(_ shouldBe List("Homer","Marge","Apu","Carl","Lenny"))
+      _ <- q5b.result.map(_.toSet shouldBe Set("Homer","Marge","Apu","Carl","Lenny"))
     } yield ()
   }
 

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -98,6 +98,7 @@ trait PostgresDriver extends JdbcDriver { driver =>
   override protected lazy val useServerSideUpsertReturning = false
 
   override def defaultSqlTypeName(tmd: JdbcType[_]): String = tmd.sqlType match {
+    case java.sql.Types.VARCHAR => "VARCHAR"
     case java.sql.Types.BLOB => "lo"
     case java.sql.Types.DOUBLE => "DOUBLE PRECISION"
     /* PostgreSQL does not have a TINYINT type, so we use SMALLINT instead. */


### PR DESCRIPTION
Fixes #129