### PR TITLE
Use force-insert semantics for inserting from queries and expressions.

### DIFF
--- a/src/main/scala/scala/slick/driver/JdbcActionComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcActionComponent.scala
@@ -382,22 +382,22 @@ trait JdbcActionComponent extends SqlActionComponent { driver: JdbcDriver =>
     type QueryInsertResult
 
     /** Get the SQL statement for inserting a single row from a scalar expression */
-    def insertStatementFor[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): String
+    def forceInsertStatementFor[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): String
 
     /** Get the SQL statement for inserting data produced by another query */
-    def insertStatementFor[TT, C[_]](query: Query[TT, U, C]): String
+    def forceInsertStatementFor[TT, C[_]](query: Query[TT, U, C]): String
 
     /** Get the SQL statement for inserting data produced by another query */
-    def insertStatementFor[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): String
+    def forceInsertStatementFor[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): String
 
     /** Insert a single row from a scalar expression */
-    def insertExpr[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream]
+    def forceInsertExpr[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream]
 
     /** Insert data produced by another query */
-    def insert[TT, C[_]](query: Query[TT, U, C]): DriverAction[Effect.Write, QueryInsertResult, NoStream]
+    def forceInsertQuery[TT, C[_]](query: Query[TT, U, C]): DriverAction[Effect.Write, QueryInsertResult, NoStream]
 
     /** Insert data produced by another query */
-    def insert[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream]
+    def forceInsertQuery[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream]
   }
 
   /** An InsertInvoker that returns the number of affected rows. */
@@ -457,12 +457,12 @@ trait JdbcActionComponent extends SqlActionComponent { driver: JdbcDriver =>
     def ++= (values: Iterable[U]): DriverAction[Effect.Write, MultiInsertResult, NoStream] = wrapAction("++=", inv.insertStatement, inv.++=(values)(_))
     def forceInsertAll(values: Iterable[U]): DriverAction[Effect.Write, MultiInsertResult, NoStream] = wrapAction("forceInsertAll", inv.forceInsertStatement, inv.forceInsertAll(values.toSeq: _*)(_))
     def insertOrUpdate(value: U): DriverAction[Effect.Write, SingleInsertOrUpdateResult, NoStream] = wrapAction("insertOrUpdate", inv.insertOrUpdateStatement(value), inv.insertOrUpdate(value)(_))
-    def insertStatementFor[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]) = fullInv.insertStatementFor(c)
-    def insertStatementFor[TT, C[_]](query: Query[TT, U, C]) = fullInv.insertStatementFor(query)
-    def insertStatementFor[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]) = fullInv.insertStatementFor(compiledQuery)
-    def insertExpr[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream] = wrapAction("insertExpr", fullInv.insertExprStatement(c), fullInv.insertExpr(c)(shape, _))
-    def insert[TT, C[_]](query: Query[TT, U, C]): DriverAction[Effect.Write, QueryInsertResult, NoStream] = wrapAction("insert(query)", fullInv.insertStatement(query), fullInv.insert(query)(_))
-    def insert[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream] = wrapAction("insert(compiledQuery)", fullInv.insertStatement(compiledQuery), fullInv.insert(compiledQuery)(_))
+    def forceInsertStatementFor[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]) = fullInv.insertStatementFor(c)
+    def forceInsertStatementFor[TT, C[_]](query: Query[TT, U, C]) = fullInv.insertStatementFor(query)
+    def forceInsertStatementFor[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]) = fullInv.insertStatementFor(compiledQuery)
+    def forceInsertExpr[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream] = wrapAction("forceInsertExpr", fullInv.insertExprStatement(c), fullInv.insertExpr(c)(shape, _))
+    def forceInsertQuery[TT, C[_]](query: Query[TT, U, C]): DriverAction[Effect.Write, QueryInsertResult, NoStream] = wrapAction("insert(query)", fullInv.insertStatement(query), fullInv.insert(query)(_))
+    def forceInsertQuery[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): DriverAction[Effect.Write, QueryInsertResult, NoStream] = wrapAction("insert(compiledQuery)", fullInv.insertStatement(compiledQuery), fullInv.insert(compiledQuery)(_))
   }
 
   protected class CountingInsertActionComposerImpl[U](inv: CountingInsertInvokerDef[U]) extends InsertActionComposerImpl[U](inv) with CountingInsertActionComposer[U] {

--- a/src/main/scala/scala/slick/driver/JdbcInsertInvokerComponent.scala
+++ b/src/main/scala/scala/slick/driver/JdbcInsertInvokerComponent.scala
@@ -168,10 +168,10 @@ trait JdbcInsertInvokerComponent extends BasicInsertInvokerComponent{ driver: Jd
     def insertStatementFor[TT](c: TT)(implicit shape: Shape[_ <: FlatShapeLevel, TT, U, _]): String = insertStatementFor(Query(c)(shape))
 
     protected def buildSubquery[TT, C[_]](query: Query[TT, U, C]): SQLBuilder.Result =
-      compiled.standardInsert.ibr.buildInsert(queryCompiler.run(query.toNode).tree)
+      compiled.forceInsert.ibr.buildInsert(queryCompiler.run(query.toNode).tree)
 
     protected def buildSubquery[TT, C[_]](compiledQuery: CompiledStreamingExecutable[Query[TT, U, C], _, _]): SQLBuilder.Result =
-      compiled.standardInsert.ibr.buildInsert(compiledQuery.compiledQuery)
+      compiled.forceInsert.ibr.buildInsert(compiledQuery.compiledQuery)
 
     protected def preparedInsert[T](sql: String)(f: PreparedStatement => T)(implicit session: Backend#Session) =
       session.withPreparedStatement(sql)(f)

--- a/src/sphinx/code/LiftedEmbedding.scala
+++ b/src/sphinx/code/LiftedEmbedding.scala
@@ -333,8 +333,8 @@ object LiftedEmbedding extends App {
 
       val actions = Action.seq(
         users2.schema.create,
-        users2 insert (users.map { u => (u.id, u.first ++ " " ++ u.last) }),
-        users2 insertExpr (users.length + 1, "admin")
+        users2 forceInsertQuery (users.map { u => (u.id, u.first ++ " " ++ u.last) }),
+        users2 forceInsertExpr (users.length + 1, "admin")
       )
       //#insert4
       Blocking.run(db, actions)

--- a/src/sphinx/upgrade.rst
+++ b/src/sphinx/upgrade.rst
@@ -68,6 +68,13 @@ of Invokers. The code generator, which uses this API, has been completely rewrit
 supports the same functionality and the same concepts but any customization of the code generator will have to be
 changed. See the code generator tests and the :doc:`code-generation` chapter for examples.
 
+Inserting from Queries and Expressions
+--------------------------------------
+
+In Slick 2.0, soft inserts became the default for inserting raw values. Inserting from another query or a computed
+expression still uses force-insert semantics. The new DBIO API properly reflects this by renaming ``insert(Query)``
+to ``forceInsertQuery(Query)`` and ``insertExpr`` to ``forceInsertExpr``.
+
 Upgrade from 2.0 to 2.1
 =======================
 


### PR DESCRIPTION
It always worked this way up to Slick 2.0. In 2.1 we made soft inserts
the default but they are not used for inserting from queries and
expressions. The implementation in 2.1 had two problems: The generated
statements were wrong (using the force-insert statement instead of the
soft-insert statement) and the method names didn’t reflect the semantics
properly.

Fixes #983. Test in InsertTest.testForced.