### PR TITLE
UUID regression testkit

### DIFF
--- a/slick-testkit/src/codegen/resources/dbs/uuid.sql
+++ b/slick-testkit/src/codegen/resources/dbs/uuid.sql
@@ -1,0 +1,3 @@
+create table "person" ("id" INTEGER NOT NULL PRIMARY KEY,
+                       "uuid" UUID NOT NULL,
+                       "uuid_def" UUID DEFAULT('2f3f866c-d8e6-11e2-bb56-50e549c9b654'));

--- a/slick-testkit/src/codegen/scala/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/GenerateRoundtripSources.scala
@@ -117,10 +117,10 @@ class Tables(val profile: JdbcProfile){
 
   // Clob disabled because it fails in postgres and mysql, see https://github.com/slick/slick/issues/637
   class TypeTest(tag: Tag) extends Table[(
-    String,Boolean,Byte,Short,Int,Long,Float,Double,String,java.sql.Date,java.sql.Time,java.sql.Timestamp,java.sql.Blob//,java.sql.Clob
+    String,Boolean,Byte,Short,Int,Long,Float,Double,String,java.sql.Date,java.sql.Time,java.sql.Timestamp,java.util.UUID,java.sql.Blob//,java.sql.Clob
       ,Option[Int]
       ,(
-      Option[Boolean],Option[Byte],Option[Short],Option[Int],Option[Long],Option[Float],Option[Double],Option[String],Option[java.sql.Date],Option[java.sql.Time],Option[java.sql.Timestamp],Option[java.sql.Blob]//,Option[java.sql.Clob]
+      Option[Boolean],Option[Byte],Option[Short],Option[Int],Option[Long],Option[Float],Option[Double],Option[String],Option[java.sql.Date],Option[java.sql.Time],Option[java.sql.Timestamp],Option[java.util.UUID],Option[java.sql.Blob]//,Option[java.sql.Clob]
       )
     )](tag, "TYPE_TEST") {
     def `type` = column[String]("type") // <- test escaping of keywords
@@ -137,6 +137,7 @@ class Tables(val profile: JdbcProfile){
     def java_sql_Date = column[java.sql.Date]("java_sql_Date")
     def java_sql_Time = column[java.sql.Time]("java_sql_Time")
     def java_sql_Timestamp = column[java.sql.Timestamp]("java_sql_Timestamp")
+    def java_util_UUID = column[java.util.UUID]("java_util_UUID")
     def java_sql_Blob = column[java.sql.Blob]("java_sql_Blob")
     //def java_sql_Clob = column[java.sql.Clob]("java_sql_Clob")
 
@@ -155,15 +156,16 @@ class Tables(val profile: JdbcProfile){
     def Option_java_sql_Date = column[Option[java.sql.Date]]("Option_java_sql_Date")
     def Option_java_sql_Time = column[Option[java.sql.Time]]("Option_java_sql_Time")
     def Option_java_sql_Timestamp = column[Option[java.sql.Timestamp]]("Option_java_sql_Timestamp")
+    def Option_java_util_UUID = column[Option[java.util.UUID]]("Option_java_util_UUID")
     def Option_java_sql_Blob = column[Option[java.sql.Blob]]("Option_java_sql_Blob")
     def Option_java_sql_Option_Blob = column[Option[Option[java.sql.Blob]]]("Option_java_sql_Blob")
     //def Option_java_sql_Clob = column[Option[java.sql.Clob]]("Option_java_sql_Clob")
     def * = (
       `type`,
-      Boolean,Byte,Short,Int,Long,Float,Double,String,java_sql_Date,java_sql_Time,java_sql_Timestamp,java_sql_Blob//,java_sql_Clob
+      Boolean,Byte,Short,Int,Long,Float,Double,String,java_sql_Date,java_sql_Time,java_sql_Timestamp,java_util_UUID,java_sql_Blob//,java_sql_Clob
       ,None_Int
       ,(
-      Option_Boolean,Option_Byte,Option_Short,Option_Int,Option_Long,Option_Float,Option_Double,Option_String,Option_java_sql_Date,Option_java_sql_Time,Option_java_sql_Timestamp,Option_java_sql_Blob//,Option_java_sql_Clob
+      Option_Boolean,Option_Byte,Option_Short,Option_Int,Option_Long,Option_Float,Option_Double,Option_String,Option_java_sql_Date,Option_java_sql_Time,Option_java_sql_Timestamp,Option_java_util_UUID,Option_java_sql_Blob//,Option_java_sql_Clob
       )
       )
     def pk = primaryKey("PK", (Int,Long))

--- a/src/main/scala/scala/slick/driver/H2Driver.scala
+++ b/src/main/scala/scala/slick/driver/H2Driver.scala
@@ -51,12 +51,20 @@ trait H2Driver extends JdbcDriver { driver =>
     }
     override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta) {
       override def length = super.length.filter(_ != Int.MaxValue) // H2 sometimes show this value, but doesn't accept it back in the DBType
+      override def default = rawDefault.map((_,tpe)).collect{
+          case (v,"java.util.UUID") => Some(Some(java.util.UUID.fromString(v.replaceAll("[\'\"]", "")))) //strip quotes
+        }.getOrElse{super.default}
+      override def tpe = dbType match {
+        case Some("UUID") => "java.util.UUID"
+        case _ => super.tpe
+      }
     }
   }
 
   override def createModelBuilder(tables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext): JdbcModelBuilder =
     new ModelBuilder(tables, ignoreInvalidDefaults)
 
+  override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
   override def createUpsertBuilder(node: Insert): InsertBuilder = new UpsertBuilder(node)
   override def createCountingInsertInvoker[U](compiled: CompiledInsert) = new CountingInsertInvoker[U](compiled)
@@ -81,6 +89,12 @@ trait H2Driver extends JdbcDriver { driver =>
       case (Some(t), None   ) => b"\nlimit $t"
       case (None, Some(d)   ) => b"\nlimit -1 offset $d"
       case _ =>
+    }
+  }
+
+  class JdbcTypes extends super.JdbcTypes {
+    override val uuidJdbcType = new UUIDJdbcType {
+      override def sqlTypeName(size: Option[RelationalProfile.ColumnOption.Length]) = "UUID"
     }
   }
 

--- a/src/main/scala/scala/slick/driver/PostgresDriver.scala
+++ b/src/main/scala/scala/slick/driver/PostgresDriver.scala
@@ -69,6 +69,11 @@ trait PostgresDriver extends JdbcDriver { driver =>
         case (IntPattern(v),"Int") => Some(Some(v.toInt))
         case (IntPattern(v),"Long") => Some(Some(v.toLong))
         case ("NULL::character varying","String") => Some(None)
+        case (v,"java.util.UUID") => {
+          val uuid = v.replaceAll("[\'\"]", "") //strip quotes
+                      .stripSuffix("::uuid") //strip suffix
+          Some(Some(java.util.UUID.fromString(uuid)))
+        }
       }.getOrElse{
         val d = super.default
         if(meta.nullable == Some(true) && d == None){
@@ -83,6 +88,7 @@ trait PostgresDriver extends JdbcDriver { driver =>
       override def tpe = meta.typeName match {
         case "bytea" => "Array[Byte]"
         case "lo" if meta.sqlType == java.sql.Types.DISTINCT => "java.sql.Blob"
+        case "uuid" => "java.util.UUID"
         case _ => super.tpe
       }
     }


### PR DESCRIPTION
Hi @szeiger 

This PR covers:

* add UUID column for roundtrip tests
* a port of #989 for v3.0 (with tests)
* creating unified test for Postgres and H2
* new test showed, that #1058 is wrong (in my defence I must say, that I did tests for H2 in Postgres [compatibility mode](http://www.h2database.com/html/features.html#compatibility))

If this task should be separated in few commits, or something should not be here or else, please tell me, I'll try to fix this.

Basically it is a follow up of #1069.

Cheers,  Nick.