### PR TITLE
Rename generic JdbcDriver to FallbackJdbcDriver

### DIFF
--- a/slick-testkit/src/codegen/scala/GenerateMainSources.scala
+++ b/slick-testkit/src/codegen/scala/GenerateMainSources.scala
@@ -13,7 +13,6 @@ import scala.slick.dbio.DBIO
 import scala.slick.codegen.{OutputHelpers, SourceCodeGenerator}
 import scala.slick.driver._
 import scala.slick.jdbc.JdbcBackend
-import scala.slick.driver.JdbcDriver
 import scala.slick.jdbc.meta.MTable
 import scala.slick.model.Model
 

--- a/slick-testkit/src/test/scala/scala/slick/benchmark/Benchmark.scala
+++ b/slick-testkit/src/test/scala/scala/slick/benchmark/Benchmark.scala
@@ -1,6 +1,6 @@
 package scala.slick.benchmark
 
-import scala.slick.driver.JdbcDriver.api._
+import scala.slick.driver.FallbackJdbcDriver.api._
 
 object Benchmark {
 

--- a/slick-testkit/src/test/scala/scala/slick/test/compile/NestedShapesTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/compile/NestedShapesTest.scala
@@ -1,7 +1,7 @@
 package scala.slick.test.compile
 
 import com.typesafe.slick.testkit.util.ShouldNotTypecheck
-import scala.slick.driver.JdbcDriver.api._
+import scala.slick.driver.FallbackJdbcDriver.api._
 import scala.slick.lifted.{Shape, ShapeLevel}
 
 class NestedShapesTest {

--- a/slick-testkit/src/test/scala/scala/slick/test/jdbc/TypedStaticQueryTest.scala
+++ b/slick-testkit/src/test/scala/scala/slick/test/jdbc/TypedStaticQueryTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import scala.slick.collection.heterogenous.HNil
 import scala.slick.collection.heterogenous.syntax._
 import scala.slick.dbio.DBIO
-import scala.slick.driver.JdbcDriver.api._
+import scala.slick.driver.FallbackJdbcDriver.api._
 
 @TSQLConfig("default")
 class TypedStaticQueryTest {

--- a/src/main/scala/scala/slick/driver/JdbcProfile.scala
+++ b/src/main/scala/scala/slick/driver/JdbcProfile.scala
@@ -145,6 +145,11 @@ trait JdbcDriver extends SqlDriver
   override val profile: JdbcProfile = this
 }
 
-/** A generic driver for JDBC-based databases. This can be used as a fallback
-  * when a specific driver for a database is not available. */
+@deprecated("Use FallbackJdbcDriver instead of this.", "3.0")
 object JdbcDriver extends JdbcDriver
+
+/** A best-effort driver for JDBC-based databases not officially
+  * supported by Slick. This can be used as a fallback. It may
+  * not work and requires the DBMS to be SQL standard conformant.
+  * You can for example use this fallback with the Firebird database. */
+object FallbackJdbcDriver extends JdbcDriver

--- a/src/main/scala/scala/slick/jdbc/StaticQuery.scala
+++ b/src/main/scala/scala/slick/jdbc/StaticQuery.scala
@@ -160,8 +160,8 @@ object ActionBasedSQLInterpolation {
           case null => Vector()
           case resultMeta => Vector.tabulate(resultMeta.getColumnCount) { i =>
               val configHandler = macroConnHelper.configHandler
-//              val driver = if (configHandler.slickDriver.isDefined) configHandler.SlickDriver else scala.slick.driver.JdbcDriver
-              val driver = scala.slick.driver.JdbcDriver
+//              val driver = if (configHandler.slickDriver.isDefined) configHandler.SlickDriver else scala.slick.driver.FallbackJdbcDriver
+              val driver = scala.slick.driver.FallbackJdbcDriver
               val modelBuilder = driver.createModelBuilder(Nil, true)(scala.concurrent.ExecutionContext.global)
               modelBuilder.jdbcTypeToScala(resultMeta.getColumnType(i + 1))
           }

--- a/src/main/scala/scala/slick/jdbc/TypedStaticQuery.scala
+++ b/src/main/scala/scala/slick/jdbc/TypedStaticQuery.scala
@@ -372,7 +372,7 @@ object TypedStaticQuery {
 //    TODO: Fix this!
 //    lazy final val JdbcDriver = Class.forName(connectionParameter(jdbcDriver, "jdbcDriver")).asInstanceOf[java.sql.Driver]
     
-//    lazy final val SlickDriver = Class.forName(connectionParameter(slickDriver, "slickDriver")).asInstanceOf[scala.slick.driver.JdbcDriver]
+//    lazy final val SlickDriver = Class.forName(connectionParameter(slickDriver, "slickDriver")).asInstanceOf[scala.slick.driver.FallbackJdbcDriver]
 
   }
 }

--- a/src/sphinx/code/PlainSQL.scala
+++ b/src/sphinx/code/PlainSQL.scala
@@ -1,7 +1,7 @@
 package com.typesafe.slick.examples.jdbc
 
 //#imports
-import scala.slick.driver.JdbcDriver.backend.Database
+import scala.slick.driver.FallbackJdbcDriver.backend.Database
 import Database.dynamicSession
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 //#imports

--- a/src/sphinx/userdefined.rst
+++ b/src/sphinx/userdefined.rst
@@ -56,7 +56,7 @@ common scenario is mapping an application-specific type to an already supported 
 This can be done much simpler by using
 :api:`MappedColumnType <scala.slick.driver.JdbcProfile@MappedColumnType:JdbcDriver.MappedJdbcType.type>`
 which takes care of all the boilerplate. It comes with the usual import from the driver. Do not import
-it from the :api:`JdbcDriver <scala.slick.driver.JdbcDriver$>` singleton object.
+it from the :api:`FallbackJdbcDriver <scala.slick.driver.FallbackJdbcDriver$>` singleton object.
 
 .. includecode:: code/LiftedEmbedding.scala#mappedtype1
 


### PR DESCRIPTION
People keep using JdbcDriver when they shouldn't. This name change better convey's it's idea in the name.

Examples of people misusing it:
http://stackoverflow.com/questions/24000759/scala-slick-delete-not-working
http://stackoverflow.com/questions/28529005/exception-when-upgrading-to-slick-3-0-0-m1-asynchronous-query

review by @szeiger 