### PR TITLE
Upgrade to Reactive Streams 1.0.0.RC2:

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,7 +29,7 @@ object SlickBuild extends Build {
     val slf4j = "org.slf4j" % "slf4j-api" % "1.6.4"
     val logback = "ch.qos.logback" % "logback-classic" % "0.9.28"
     val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
-    val reactiveStreamsVersion = "1.0.0.RC1"
+    val reactiveStreamsVersion = "1.0.0.RC2"
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val pools = Seq(
@@ -242,7 +242,7 @@ object SlickBuild extends Build {
       //scalacOptions in Compile += "-Yreify-copypaste",
       libraryDependencies ++=
         Dependencies.junit ++:
-        Dependencies.reactiveStreamsTCK % "test" +:
+        (Dependencies.reactiveStreamsTCK % "test").intransitive() +:
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "test") ++:
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "codegen"),
       // Run the Queryable tests (which need macros) on a forked JVM
@@ -318,7 +318,7 @@ object SlickBuild extends Build {
       unmanagedResourceDirectories in Test += (baseDirectory in aRootProject).value / "common-test-resources",
       libraryDependencies ++=
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "test") ++:
-        Dependencies.reactiveStreamsTCK +:
+        Dependencies.reactiveStreamsTCK.intransitive() +:
         Dependencies.testngExtras,
       testNGSuites := Seq("reactive-streams-tests/src/test/resources/testng.xml")
     )

--- a/src/main/scala/scala/slick/backend/DatabasePublisher.scala
+++ b/src/main/scala/scala/slick/backend/DatabasePublisher.scala
@@ -1,7 +1,5 @@
 package scala.slick.backend
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import org.reactivestreams._
 
 import scala.concurrent.{Promise, Future, ExecutionContext}
@@ -57,16 +55,5 @@ abstract class DatabasePublisher[T] extends Publisher[T] { self =>
       }
     })
     p.future
-  }
-}
-
-abstract class DatabasePublisherSupport[T] extends DatabasePublisher[T] {
-  private[this] val used = new AtomicBoolean()
-
-  protected[this] def allowSubscriber(s: Subscriber[_ >: T]): Boolean = {
-    if(used.getAndSet(true)) {
-      s.onError(new IllegalStateException("Database Action Publisher may not be subscribed to more than once"))
-      false
-    } else true
   }
 }


### PR DESCRIPTION
- Exclude transitive dependencies for the TCK (broken in RC2)

- Check for null Subscriber in DatabasePublisher.allowSubscriber

- Call onSubscribe before onError when a DatabasePublisher rejects a
  repeated subscribe() request