### PR TITLE
change slf4j dependency to `provided`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,7 @@ object SlickBuild extends Build {
     val testngExtras = Seq(
       "com.google.inject" % "guice" % "2.0"
     )
-    val slf4j = "org.slf4j" % "slf4j-api" % "1.6.4"
+    val slf4j = "org.slf4j" % "slf4j-api" % "1.6.4" % "provided"
     val logback = "ch.qos.logback" % "logback-classic" % "0.9.28"
     val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
     val reactiveStreamsVersion = "1.0.0.RC3"


### PR DESCRIPTION
Hi @szeiger / @cvogt,

Can we change slf4j dependency to `provided`?
It can allow `slick` users to declare their slf4j dependency freely, and fix `slick-pg` [#136](https://github.com/tminglei/slick-pg/issues/136).

Thanks,
Minglei