### PR TITLE
Return correct name for default drivers in BasicDriver.toString:

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/driver/DriverNameTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/driver/DriverNameTest.scala
@@ -1,0 +1,13 @@
+package slick.test.driver
+
+import org.junit.Test
+import org.junit.Assert._
+import slick.driver.{SQLiteDriver, H2Driver}
+
+class DriverNameTest {
+
+  @Test def testDriverNames: Unit = {
+    assertEquals("H2Driver", H2Driver.toString)
+    assertEquals("SQLiteDriver", SQLiteDriver.toString)
+  }
+}

--- a/slick/src/main/scala/slick/profile/BasicProfile.scala
+++ b/slick/src/main/scala/slick/profile/BasicProfile.scala
@@ -123,7 +123,7 @@ trait BasicDriver extends BasicProfile {
   override def toString = {
     val cl = getClass.getName
     if(cl.startsWith("slick.driver.") && cl.endsWith("$"))
-      cl.substring(19, cl.length-1)
+      cl.substring(13, cl.length-1)
     else super.toString
   }
 


### PR DESCRIPTION
This got broken during the refactoring of the package structure from
`scala.slick` to `slick`. Test in DriverNameTest.