### PR TITLE
Upgrade to Reactive Streams 1.0.0.RC4:

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,7 +29,7 @@ object SlickBuild extends Build {
     val slf4j = "org.slf4j" % "slf4j-api" % "1.6.4"
     val logback = "ch.qos.logback" % "logback-classic" % "0.9.28"
     val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
-    val reactiveStreamsVersion = "1.0.0.RC3"
+    val reactiveStreamsVersion = "1.0.0.RC4"
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val pools = Seq(

--- a/reactive-streams-tests/src/test/scala/slick/test/stream/HeapPublisherTest.scala
+++ b/reactive-streams-tests/src/test/scala/slick/test/stream/HeapPublisherTest.scala
@@ -8,9 +8,5 @@ import slick.memory.MemoryDriver
 class HeapPublisherTest extends RelationalPublisherTest[MemoryDriver](MemoryDriver, 300L) {
   import driver.api._
 
-  @BeforeClass def setUpDB: Unit =
-    db = Database(ExecutionContext.global)
-
-  @AfterClass def tearDownDB: Unit =
-    db.close()
+  def createDB = Database(ExecutionContext.global)
 }

--- a/reactive-streams-tests/src/test/scala/slick/test/stream/JdbcPublisherTest.scala
+++ b/reactive-streams-tests/src/test/scala/slick/test/stream/JdbcPublisherTest.scala
@@ -2,21 +2,18 @@ package slick.test.stream
 
 import org.testng.annotations.{AfterClass, BeforeClass}
 
+import slick.driver.{H2Driver, JdbcProfile}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import slick.driver.{H2Driver, JdbcProfile}
 import scala.util.control.NonFatal
 
 class JdbcPublisherTest extends RelationalPublisherTest[JdbcProfile](H2Driver, 1000L) {
   import driver.api._
 
-  @BeforeClass def setUpDB: Unit = {
-    db = Database.forURL("jdbc:h2:mem:DatabasePublisherTest", driver = "org.h2.Driver")
-    //db = Database.forURL("jdbc:derby:memory:JdbcPublisherTest;create=true", driver = "org.apache.derby.jdbc.EmbeddedDriver")
+  def createDB = {
+    val db = Database.forURL("jdbc:h2:mem:DatabasePublisherTest", driver = "org.h2.Driver", keepAliveConnection = true)
     // Wait until the database has been initialized and can process queries:
     try { Await.result(db.run(sql"select 1".as[Int]), Duration.Inf) } catch { case NonFatal(ex) => }
+    db
   }
-
-  @AfterClass def tearDownDB: Unit =
-    db.close()
 }


### PR DESCRIPTION
- Allow multiple independent Subscribers for a DatabasePublisher.

- Change TCK tests to allow multi-subscriber scenarios to be tested.
  Instead of creating independent tables for each test, we not create
  a single table of the maximum size and reuse that.

- Fix a race condition in `scheduleSynchronousStreaming`: Requesting
  more elements (or canceling / failing the stream) while the initial
  streaming still runs can lead to a negative demand even after the
  first atomic transition, so we need to calculate the proper positive
  demand.