### PR TITLE
Impossible to use custom slick driver in dynamic classloading environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-script: sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf +testAll
+script: sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf +testAll mimaReportBinaryIssues
 jdk:
   - openjdk6
 notifications:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -203,7 +203,7 @@ object SlickBuild extends Build {
       sdlcCheckDir := (target in com.typesafe.sbt.SbtSite.SiteKeys.makeSite).value,
       sdlc <<= sdlc dependsOn (doc in Compile, com.typesafe.sbt.SbtSite.SiteKeys.makeSite),
       test := (), testOnly :=  (), // suppress test status output
-      previousArtifact := Some("com.typesafe.slick" %% "slick" % binaryCompatSlickVersion),
+      previousArtifact := Some("com.typesafe.slick" % ("slick_" + scalaBinaryVersion.value)  % binaryCompatSlickVersion),
       binaryIssueFilters ++= Seq(
         ProblemFilters.exclude[MissingClassProblem]("slick.util.MacroSupportInterpolationImpl$"),
         ProblemFilters.exclude[MissingClassProblem]("slick.util.MacroSupportInterpolationImpl")

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -14,7 +14,7 @@ import javax.naming.InitialContext
 import slick.dbio._
 import slick.backend.{DatabasePublisher, DatabaseComponent, RelationalBackend}
 import slick.SlickException
-import slick.util.{LogUtil, GlobalConfig, SlickLogger, AsyncExecutor}
+import slick.util._
 import slick.util.ConfigExtensionMethods._
 
 import org.slf4j.LoggerFactory
@@ -220,7 +220,7 @@ trait JdbcBackend extends RelationalBackend {
       *               connection pools (in particular, the default [[HikariCPJdbcDataSource]]).
       */
     def forConfig(path: String, config: Config = ConfigFactory.load(), driver: Driver = null): Database = {
-      val source = JdbcDataSource.forConfig(if(path.isEmpty) config else config.getConfig(path), driver, path)
+      val source = JdbcDataSource.forConfig(if(path.isEmpty) config else config.getConfig(path), driver, path, ClassLoaderUtil.defaultClassLoader)
       val executor = AsyncExecutor(path, config.getIntOr("numThreads", 20), config.getIntOr("queueSize", 1000))
       forSource(source, executor)
     }

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -3,6 +3,7 @@ package slick.jdbc
 import java.net.URI
 
 import com.typesafe.config.ConfigException
+import slick.util.ClassLoaderUtil
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -160,7 +161,7 @@ object ActionBasedSQLInterpolation {
     val uri = StaticDatabaseConfigMacros.getURI(ctxt)
     //TODO The database configuration and connection should be cached for subsequent macro invocations
     val dc =
-      try DatabaseConfig.forURI[JdbcProfile](new URI((uri))) catch {
+      try DatabaseConfig.forURI[JdbcProfile](new URI(uri), ClassLoaderUtil.defaultClassLoader) catch {
         case ex @ (_: ConfigException | _: SlickException) =>
           ctxt.abort(ctxt.enclosingPosition, s"""Cannot load @StaticDatabaseConfig("$uri"): ${ex.getMessage}""")
       }

--- a/slick/src/main/scala/slick/util/ClassLoaderUtil.scala
+++ b/slick/src/main/scala/slick/util/ClassLoaderUtil.scala
@@ -1,0 +1,22 @@
+package slick.util
+
+/**
+ * Utilities for working with classloaders
+ */
+object ClassLoaderUtil {
+
+  /** Get the default classloader to use to dynamically load classes. */
+  val defaultClassLoader: ClassLoader = {
+    new ClassLoader(this.getClass.getClassLoader) {
+      override def loadClass(name: String): Class[_] = {
+        try {
+          // Try the context classloader first. But, during macro compilation, it's probably wrong, so fallback to this
+          // classloader.
+          Thread.currentThread().getContextClassLoader.loadClass(name)
+        } catch {
+          case e: ClassNotFoundException => super.loadClass(name)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Slick uses [`Class.forName(String)`](https://github.com/slick/slick/blob/master/slick/src/main/scala/slick/backend/DatabaseConfig.scala#L57-L58) to load a custom slick driver.  This breaks dynamic classloading environments such as Play, as seen in https://github.com/playframework/play-slick/issues/266.

Slick should instead take, as a configuration parameter, a classloader that should be used for all classloading.  An inferior solution, but one that could be used if breaking binary compatibility is a concern, is to use the context classloader.