### PR TITLE
Improve logging

### DIFF
--- a/common-test-resources/logback.xml
+++ b/common-test-resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>*** \(%logger{30}\) %msg%n</pattern>
+            <pattern>*** \(%logger{30}\)%green(%X{debugId}) %msg%n</pattern>
         </encoder>
     </appender>
     <root level="${log.root:-info}">
@@ -38,9 +38,9 @@
     <logger name="slick.jdbc.JdbcBackend.benchmark"         level="${log.jdbc.bench:-info}" />
     <logger name="slick.jdbc.StatementInvoker.result"       level="${log.jdbc.result:-info}" />
     <logger name="slick.jdbcJdbcModelBuilder"               level="${log.createModel:-info}" />
-    <logger name="slick.ast.Node$"                          level="${log.qcomp.assignTypes:-inherited}" />
-    <logger name="slick.memory.HeapBackend$"                level="${log.heap:-inherited}" />
+    <logger name="slick.ast.Node"                           level="${log.qcomp.assignTypes:-inherited}" />
+    <logger name="slick.memory.HeapBackend"                 level="${log.heap:-inherited}" />
     <logger name="slick.memory.QueryInterpreter"            level="${log.interpreter:-inherited}" />
     <logger name="slick.relational.ResultConverterCompiler" level="${log.resultConverter:-inherited}" />
-    <logger name="slick.util.AsyncExecutor$"                level="${log.asyncExecutor:-inherited}" />
+    <logger name="slick.util.AsyncExecutor"                 level="${log.asyncExecutor:-inherited}" />
 </configuration>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,7 @@ object SlickBuild extends Build {
       "com.google.inject" % "guice" % "2.0"
     )
     val slf4j = "org.slf4j" % "slf4j-api" % "1.6.4"
-    val logback = "ch.qos.logback" % "logback-classic" % "0.9.28"
+    val logback = "ch.qos.logback" % "logback-classic" % "1.1.3"
     val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
     val reactiveStreamsVersion = "1.0.0.RC4"
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion

--- a/reactive-streams-tests/src/test/resources/logback-test.xml
+++ b/reactive-streams-tests/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>*** \(%logger{30}\) %msg%n</pattern>
+            <pattern>*** \(%logger{30}\)%green(%X{debugId}) %msg%n</pattern>
         </encoder>
     </appender>
     <root level="${log.root:-info}">

--- a/slick-direct/src/main/scala/slick/direct/SlickBackend.scala
+++ b/slick-direct/src/main/scala/slick/direct/SlickBackend.scala
@@ -12,7 +12,7 @@ import slick.ast.{Library, FunctionSymbol, ColumnOption}
 import slick.ast.Util._
 import slick.ast.TypeUtil._
 import slick.compiler.CompilerState
-import slick.util.{TreeDump, SQLBuilder}
+import slick.util.{TreePrinter, SQLBuilder}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeRef
 import scala.annotation.StaticAnnotation
@@ -413,7 +413,7 @@ class SlickBackend( val driver: JdbcDriver, mapper:Mapper ) extends QueryableBac
   }
   protected[slick] def dump( queryable:BaseQueryable[_] ) = {
     val (_,query) = this.toQuery(queryable)
-    TreeDump(query.node)
+    TreePrinter.default.print(query.node)
   }
   import scala.collection.generic.CanBuildFrom
   import slick.jdbc.{PositionedParameters, PositionedResult}

--- a/slick-testkit/src/doctest/resources/logback.xml
+++ b/slick-testkit/src/doctest/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>*** \(%logger{30}\) %msg%n</pattern>
+            <pattern>*** \(%logger{30}\)%green(%X{debugId}) %msg%n</pattern>
         </encoder>
     </appender>
     <root level="${log.root:-info}">
@@ -37,10 +37,10 @@
     <logger name="slick.jdbc.JdbcBackend.statement"         level="${log.jdbc.statement:-info}" />
     <logger name="slick.jdbc.JdbcBackend.benchmark"         level="${log.jdbc.bench:-info}" />
     <logger name="slick.jdbc.StatementInvoker.result"       level="${log.jdbc.result:-info}" />
-    <logger name="slick.jdbc.meta"                          level="${log.createModel:-info}" />
-    <logger name="slick.ast.Node$"                          level="${log.qcomp.assignTypes:-inherited}" />
-    <logger name="slick.memory.HeapBackend$"                level="${log.heap:-inherited}" />
+    <logger name="slick.jdbcJdbcModelBuilder"               level="${log.createModel:-info}" />
+    <logger name="slick.ast.Node"                           level="${log.qcomp.assignTypes:-inherited}" />
+    <logger name="slick.memory.HeapBackend"                 level="${log.heap:-inherited}" />
     <logger name="slick.memory.QueryInterpreter"            level="${log.interpreter:-inherited}" />
     <logger name="slick.relational.ResultConverterCompiler" level="${log.resultConverter:-inherited}" />
-    <logger name="slick.util.AsyncExecutor$"                level="${log.asyncExecutor:-inherited}" />
+    <logger name="slick.util.AsyncExecutor"                 level="${log.asyncExecutor:-inherited}" />
 </configuration>

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -246,27 +246,27 @@ class JoinTest extends AsyncTest[RelationalTestDB] {
       q1 = for {
         (c, i) <- categories.sortBy(_.id).zipWithIndex
       } yield (c.id, i)
-      _ <- q1.result.map(_ shouldBe List((1,0), (2,1), (3,2), (4,3)))
+      _ <- mark("q1", q1.result).map(_ shouldBe List((1,0), (2,1), (3,2), (4,3)))
       q2 = for {
         (c, p) <- categories.sortBy(_.id) zip posts.sortBy(_.category)
       } yield (c.id, p.category)
-      _ <- q2.result.map(_ shouldBe List((1,-1), (2,1), (3,2), (4,2)))
+      _ <- mark("q2", q2.result).map(_ shouldBe List((1,-1), (2,1), (3,2), (4,2)))
       q3 = for {
         (c, p) <- categories zip posts
       } yield (c.id, p.category)
-      _ <- q3.result.map(_ shouldBe List((1, -1), (3, 1), (2, 2), (4, 3)))
+      _ <- mark("q3", q3.result).map(_ shouldBe List((1, -1), (3, 1), (2, 2), (4, 3)))
       q4 = for {
         res <- categories.zipWith(posts, (c: Categories, p: Posts) => (c.id, p.category))
       } yield res
-      _ <- q4.result.map(_ shouldBe List((1, -1), (3, 1), (2, 2), (4, 3)))
+      _ <- mark("q4", q4.result).map(_ shouldBe List((1, -1), (3, 1), (2, 2), (4, 3)))
       q5 = for {
         (c, i) <- categories.zipWithIndex
       } yield (c.id, i)
-      _ <- q5.result.map(_ shouldBe List((1,0), (3,1), (2,2), (4,3)))
+      _ <- mark("q5", q5.result).map(_ shouldBe List((1,0), (3,1), (2,2), (4,3)))
       q6 = for {
         ((c, p), i) <- (categories zip posts).zipWithIndex
       } yield (c.id, p.category, i)
-      _ <- q6.result.map(_ shouldBe List((1, -1, 0), (3, 1, 1), (2, 2, 2), (4, 3, 3)))
+      _ <- mark("q6", q6.result).map(_ shouldBe List((1, -1, 0), (3, 1, 1), (2, 2, 2), (4, 3, 3)))
     } yield ()
   }
 

--- a/slick-testkit/src/test/scala/slick/benchmark/UnboxedBenchmark.scala
+++ b/slick-testkit/src/test/scala/slick/benchmark/UnboxedBenchmark.scala
@@ -3,7 +3,7 @@ package slick.benchmark
 import slick.ast._
 import slick.jdbc._
 import slick.relational._
-import slick.util.TreeDump
+import slick.util.TreePrinter
 import com.typesafe.slick.testkit.util.DelegateResultSet
 
 @deprecated("Using deprecated .simple API", "3.0")
@@ -55,7 +55,7 @@ object UnboxedBenchmark extends App {
 
   def runTest(n: Node) {
     val rsm = driver.queryCompiler.run(n).tree
-    TreeDump(rsm)
+    TreePrinter.default.print(rsm)
     val ResultSetMapping(_, _, CompiledMapping(converter, _)) = rsm
     for(i <- 1 to 5) {
       val pr = createFakePR(10000000, converter.asInstanceOf[ResultConverter[JdbcResultConverterDomain, _]])

--- a/slick/src/main/scala/slick/SlickException.scala
+++ b/slick/src/main/scala/slick/SlickException.scala
@@ -1,10 +1,31 @@
 package slick
 
+import slick.util.{GlobalConfig, DumpInfo, TreePrinter, Dumpable}
+
 /** All Exceptions that are thrown directly by Slick are of type `SlickException`.
   * Other Exceptions originating in non-Slick code are generally not wrapped but
   * passed on directly.
-
+  *
   * @param msg The error message
   * @param parent An optional parent Exception or `null`
   */
 class SlickException(msg: String, parent: Throwable = null) extends RuntimeException(msg, parent)
+
+/** A SlickException that contains a `Dumpable` with more details. */
+class SlickTreeException(msg: String, detail: Dumpable, parent: Throwable = null, mark: (Dumpable => Boolean) = null, removeUnmarked: Boolean = true)
+  extends SlickException(SlickTreeException.format(msg, detail, mark, removeUnmarked), parent)
+
+private[slick] object SlickTreeException {
+  val treePrinter = new TreePrinter(prefix = DumpInfo.highlight(if(GlobalConfig.unicodeDump) "\u2503 " else "| "))
+
+  def format(msg: String, detail: Dumpable, _mark: (Dumpable => Boolean), removeUnmarked: Boolean): String =
+    if(detail eq null) msg else msg + {
+      try {
+        val mark = if(_mark eq null) ((_: Dumpable) => false) else _mark
+        val tp = treePrinter.copy(mark = mark)
+        val markedTop =
+          if(!removeUnmarked || (_mark eq null)) detail else tp.findMarkedTop(detail)
+        "\n" + tp.get(markedTop)
+      } catch { case t: Throwable => " <Error formatting detail: " + t + ">" }
+    }
+}

--- a/slick/src/main/scala/slick/backend/DatabaseComponent.scala
+++ b/slick/src/main/scala/slick/backend/DatabaseComponent.scala
@@ -319,10 +319,10 @@ trait DatabaseComponent { self =>
         ctx.sequenceCounter += 1
         val logA = a.nonFusedEquivalentAction
         val aPrefix = if(a eq logA) "" else "[fused] "
-        val dump = TreeDump.get(logA, prefix = "    ", firstPrefix = aPrefix, narrow = {
+        val dump = new TreePrinter(prefix = "    ", firstPrefix = aPrefix, narrow = {
           case a: DBIOAction[_, _, _] => a.nonFusedEquivalentAction
           case o => o
-        })
+        }).get(logA)
         val msg = DumpInfo.highlight("#" + ctx.sequenceCounter) + ": " + dump.substring(0, dump.length-1)
         actionLogger.debug(msg)
       }

--- a/slick/src/main/scala/slick/jdbc/JdbcResultConverter.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcResultConverter.scala
@@ -5,7 +5,6 @@ import java.sql.{PreparedStatement, ResultSet}
 import slick.relational._
 import slick.SlickException
 import slick.ast.ScalaBaseType
-import slick.util.{TreeDump => Dump} //--
 
 /** Specialized JDBC ResultConverter for non-`Option` values. */
 class BaseResultConverter[@specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean) T](val ti: JdbcType[T], val name: String, val idx: Int) extends ResultConverter[JdbcResultConverterDomain, T] {

--- a/slick/src/main/scala/slick/util/LogUtil.scala
+++ b/slick/src/main/scala/slick/util/LogUtil.scala
@@ -2,9 +2,12 @@ package slick.util
 
 /** Utilities for logging and creating tree & table dumps. */
 private[slick] object LogUtil {
-  val (cNormal, cGreen, cYellow, cBlue, cCyan) =
-    if(GlobalConfig.ansiDump) ("\u001B[0m", "\u001B[32m", "\u001B[33m", "\u001B[34m", "\u001B[36m")
-    else ("", "", "", "", "")
+  val (cNormal, cBlack, cRed, cGreen, cYellow, cBlue, cMagenta, cCyan) =
+    if(GlobalConfig.ansiDump) ("\u001B[0m", "\u001B[30m", "\u001B[31m", "\u001B[32m", "\u001B[33m", "\u001B[34m", "\u001B[35m", "\u001B[36m")
+    else ("", "", "", "", "", "", "", "")
+  val (bRed, bGreen, bYellow, bBlue, bMagenta, bCyan) =
+    if(GlobalConfig.ansiDump) ("\u001B[41m", "\u001B[42m", "\u001B[43m", "\u001B[44m", "\u001B[45m", "\u001B[46m")
+    else ("", "", "", "", "", "")
 
   private[this] val multi = if(GlobalConfig.unicodeDump) "\u2507 " else "  "
   private[this] val multilineBorderPrefix = cYellow + multi + cNormal

--- a/slick/src/main/scala/slick/util/Logging.scala
+++ b/slick/src/main/scala/slick/util/Logging.scala
@@ -2,6 +2,8 @@ package slick.util
 
 import org.slf4j.{ Logger => Slf4jLogger, LoggerFactory }
 
+import scala.reflect.ClassTag
+
 final class SlickLogger(val slf4jLogger: Slf4jLogger) {
   @inline
   def debug(msg: => String, n: => Dumpable): Unit =
@@ -41,6 +43,15 @@ final class SlickLogger(val slf4jLogger: Slf4jLogger) {
   def trace(msg: => String, t: Throwable) { if (slf4jLogger.isTraceEnabled) slf4jLogger.trace(msg, t) }
 }
 
+object SlickLogger {
+  def apply[T](implicit ct: ClassTag[T]): SlickLogger =
+    new SlickLogger(LoggerFactory.getLogger(ct.runtimeClass))
+}
+
 trait Logging {
-  protected[this] lazy val logger = new SlickLogger(LoggerFactory.getLogger(getClass))
+  protected[this] lazy val logger = {
+    val n = getClass.getName
+    val cln = if(n endsWith "$") n.substring(0, n.length-1) else n
+    new SlickLogger(LoggerFactory.getLogger(cln))
+  }
 }

--- a/slick/src/main/scala/slick/util/Logging.scala
+++ b/slick/src/main/scala/slick/util/Logging.scala
@@ -1,13 +1,12 @@
 package slick.util
 
-import org.slf4j.{ Logger => Slf4jLogger, LoggerFactory }
+import org.slf4j.{Logger => Slf4jLogger, LoggerFactory}
 
 import scala.reflect.ClassTag
 
 final class SlickLogger(val slf4jLogger: Slf4jLogger) {
   @inline
-  def debug(msg: => String, n: => Dumpable): Unit =
-    debug(msg+"\n"+TreeDump.get(n, prefix = DumpInfo.highlight(if(GlobalConfig.unicodeDump) "\u2503 " else "| ")))
+  def debug(msg: => String, n: => Dumpable): Unit = debug(msg+"\n"+SlickLogger.treePrinter.get(n))
 
   @inline
   def isDebugEnabled = slf4jLogger.isDebugEnabled()
@@ -44,6 +43,9 @@ final class SlickLogger(val slf4jLogger: Slf4jLogger) {
 }
 
 object SlickLogger {
+  private val treePrinter =
+    new TreePrinter(prefix = DumpInfo.highlight(if(GlobalConfig.unicodeDump) "\u2503 " else "| "))
+
   def apply[T](implicit ct: ClassTag[T]): SlickLogger =
     new SlickLogger(LoggerFactory.getLogger(ct.runtimeClass))
 }


### PR DESCRIPTION
- Upgrade to latest logback 1.1.3 and remove ending “$” from all logger
  names. Parsing these names is currently broken in logback (see
  http://jira.qos.ch/browse/LOGBACK-978) and might also cause problems
  with other frameworks.

- Add `mark` methods to GenericTest to put a debug ID into the MDC (and
  also use it as the action name when marking a DBIOAction).

- Update logback configs accordingly to print this debug ID.