### PR TITLE
No cache timeout

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/jdbc/ProxyDataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/ProxyDataSourceTest.scala
@@ -58,7 +58,7 @@ class ProxyDataSourceTest {
 }
 
 class NoBindingProxyDataSource extends ProxyDataSource {
-  def lookup(serviceName: String): Future[Option[(InetSocketAddress, Option[FiniteDuration])]] =
+  def lookup(serviceName: String): Future[Option[InetSocketAddress]] =
     Future.successful(None)
 }
 
@@ -67,11 +67,11 @@ class InitialDelayProxyDataSource extends ProxyDataSource {
   @BeanProperty var host: String = "localhost"
   @BeanProperty var port: Int = 0
 
-  private[this] var f: Future[Option[(InetSocketAddress, Option[FiniteDuration])]] = _
+  private[this] var f: Future[Option[InetSocketAddress]] = _
 
-  def lookup(serviceName: String): Future[Option[(InetSocketAddress, Option[FiniteDuration])]] = synchronized {
+  def lookup(serviceName: String): Future[Option[InetSocketAddress]] = synchronized {
     if(f eq null)
-      f = Future(blocking { Thread.sleep(delay); Some((new InetSocketAddress(host, port), None)) })(ExecutionContext.global)
+      f = Future(blocking { Thread.sleep(delay); Some(new InetSocketAddress(host, port)) })(ExecutionContext.global)
     f
   }
 }

--- a/slick-testkit/src/test/scala/slick/test/jdbc/ProxyDataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/ProxyDataSourceTest.scala
@@ -1,6 +1,5 @@
 package slick.test.jdbc
 
-import java.net.InetSocketAddress
 import java.sql.SQLException
 
 import org.junit.{Assert, Test}
@@ -58,7 +57,7 @@ class ProxyDataSourceTest {
 }
 
 class NoBindingProxyDataSource extends ProxyDataSource {
-  def lookup(serviceName: String): Future[Option[InetSocketAddress]] =
+  def lookup(serviceName: String): Future[Option[(String, Int)]] =
     Future.successful(None)
 }
 
@@ -67,11 +66,11 @@ class InitialDelayProxyDataSource extends ProxyDataSource {
   @BeanProperty var host: String = "localhost"
   @BeanProperty var port: Int = 0
 
-  private[this] var f: Future[Option[InetSocketAddress]] = _
+  private[this] var f: Future[Option[(String, Int)]] = _
 
-  def lookup(serviceName: String): Future[Option[InetSocketAddress]] = synchronized {
+  def lookup(serviceName: String): Future[Option[(String, Int)]] = synchronized {
     if(f eq null)
-      f = Future(blocking { Thread.sleep(delay); Some(new InetSocketAddress(host, port)) })(ExecutionContext.global)
+      f = Future(blocking { Thread.sleep(delay); Some((host, port)) })(ExecutionContext.global)
     f
   }
 }


### PR DESCRIPTION
Two commits:

* Removed the TTL associated with a lookup as caching is the responsibility of the `lookup` function.
* Some code improvements.
* Replaced the use of `InetAddress` with just a host/port tuple - less ceromony.

Note that this issue remains: https://github.com/playframework/play-slick/issues/275#issuecomment-112265869

I'm also concerned about the critical sections. For example, it would be possible for one thread to `close` the source, and another to continue to call `getConnection`, and for them to have different values of `state`.