### PR TITLE
Fix AutoInc for H2.

### DIFF
--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
@@ -51,7 +51,7 @@ class Tables(val profile: JdbcProfile){
 
   /** Tests table with self-referring foreign key */
   class SelfRef(tag: Tag) extends Table[(Int,Option[Int])](tag, "SELF_REF") {
-    def id = column[Int]("id",O.AutoInc)
+    def id = column[Int]("id",O.PrimaryKey,O.AutoInc)
     def parent = column[Option[Int]]("parent")
     def parentFK = foreignKey("parent_fk", parent, SelfRef)(_.id.?)
     def * = (id,parent)


### PR DESCRIPTION
IDENTITY in H2 implies PRIMARY KEY, which is not only not what is
wanted when just AutoInc is specified, but also breaks when used in
conjunction with PrimaryKey.  Use AUTO_INCREMENT instead.

Fixes issue #763.
