### PR TITLE
Bring HikariCP in line with play-slick version and silence warnings

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,7 +33,7 @@ object SlickBuild extends Build {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val pools = Seq(
-      "com.zaxxer" % "HikariCP-java6" % "2.0.1"
+      "com.zaxxer" % "HikariCP-java6" % "2.3.7"
     )
     val mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams) ++ pools.map(_ % "optional")
     val h2 = "com.h2database" % "h2" % "1.4.187"

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -168,8 +168,10 @@ trait JdbcBackend extends RelationalBackend {
       *     of connections to keep in the pool.</li>
       *   <li>`connectionTimeout` (Duration, optional, default: 1s): The maximum time to wait
       *     before a call to getConnection is timed out. If this time is exceeded without a
-      *     connection becoming available, a SQLException will be thrown. 100ms is the minimum
+      *     connection becoming available, a SQLException will be thrown. 1000ms is the minimum
       *     value.</li>
+      *   <li>`validationTimeout` (Duration, optional, default: 1s): The maximum amount of time
+      *     that a connection will be tested for aliveness. 1000ms is the minimum value.</li>
       *   <li>`idleTimeout` (Duration, optional, default: 10min): The maximum amount
       *     of time that a connection is allowed to sit idle in the pool. A value of 0 means that
       *     idle connections are never removed from the pool.</li>

--- a/slick/src/main/scala/slick/jdbc/JdbcDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcDataSource.scala
@@ -150,6 +150,7 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
 
     // Pool configuration
     hconf.setConnectionTimeout(c.getMillisecondsOr("connectionTimeout", 1000))
+    hconf.setValidationTimeout(c.getMillisecondsOr("validationTimeout", 1000))
     hconf.setIdleTimeout(c.getMillisecondsOr("idleTimeout", 600000))
     hconf.setMaxLifetime(c.getMillisecondsOr("maxLifetime", 1800000))
     hconf.setLeakDetectionThreshold(c.getMillisecondsOr("leakDetectionThreshold", 0))


### PR DESCRIPTION
This PR brings the HikariCP version in line with the one used by play-slick, and sets a default for the validationTimeout value that will silence the log warning spam you'll see otherwise. The tests seem to pass, and this version of hikari-cp is going to see a lot of use as people migrate to play 2.4, so it seems reasonable to upgrade the dependency.

Happy to make any adjustments or add tests with a little instruction as to where.