### PR TITLE
Codegen: Suppress output of schema.create if ddlEnabled is false

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
@@ -17,6 +17,8 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
                    extends GeneratorHelpers[Code,TermName,TypeName]{ codegen =>
   model.assertConsistency
 
+  /** Enables DDL Generation. */
+   val ddlEnabled = true
   /** Table code generators. */
   final lazy val tables: Seq[Table] = model.tables.map(Table).sortBy(_.TableClass.rawName.toLowerCase)
   /** Table code generators indexed by db table name. */

--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -24,21 +24,23 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
         "import slick.jdbc.{GetResult => GR}\n"
       } else ""
     ) +
-    "\n/** DDL for all tables. Call .create to execute. */" +
-    (
-      if(tables.length > 5)
-        "\nlazy val schema = Array(" + tables.map(_.TableValue.name + ".schema").mkString(", ") + ").reduceLeft(_ ++ _)"
-      else
-        "\nlazy val schema = " + tables.map(_.TableValue.name + ".schema").mkString(" ++ ")
-    ) +
-    "\n@deprecated(\"Use .schema instead of .ddl\", \"3.0\")"+
-    "\ndef ddl = schema" +
-    "\n\n" +
+    (if(ddlEnabled){
+      "\n/** DDL for all tables. Call .create to execute. */" +
+      (
+        if(tables.length > 5)
+          "\nlazy val schema = Array(" + tables.map(_.TableValue.name + ".schema").mkString(", ") + ").reduceLeft(_ ++ _)"
+        else
+          "\nlazy val schema = " + tables.map(_.TableValue.name + ".schema").mkString(" ++ ")
+      ) +
+      "\n@deprecated(\"Use .schema instead of .ddl\", \"3.0\")"+
+      "\ndef ddl = schema" +
+      "\n\n"
+    } else "") +
     tables.map(_.code.mkString("\n")).mkString("\n\n")
   }
 
   protected def tuple(i: Int) = termName(s"_${i+1}")
-  
+
   abstract class TableDef(model: m.Table) extends super.TableDef(model){
 
     def compoundType(types: Seq[String]): String = {


### PR DESCRIPTION
Currently the Codegenerator couldn't be configured to disable ddl generation.
I introduced a new val called ddlEnabled which could be set to false to suppress ddl generation on customized SourceCodeGenerators