### PR TITLE
Backport #1204, #1208 and the required DriverDataSource from #1201 to 3.0

### DIFF
--- a/common-test-resources/application.conf
+++ b/common-test-resources/application.conf
@@ -13,3 +13,15 @@ tsql {
     keepAliveConnection = true
   }
 }
+
+// HikariCP with DATABASE_URL parsing
+databaseUrl {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "slick.test.jdbc.MockDriver"
+    url = "postgres://user:pass@host/dbname"
+    properties = {
+      foo = bar
+    }
+  }
+}

--- a/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
@@ -1,0 +1,12 @@
+package slick.test.jdbc
+
+import org.junit.Test
+import org.junit.Assert._
+import slick.backend.DatabaseConfig
+import slick.driver.JdbcProfile
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class DataSourceTest {
+}

--- a/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
@@ -1,12 +1,49 @@
 package slick.test.jdbc
 
+import java.sql.{SQLException, DriverPropertyInfo, Connection, Driver}
+import java.util.Properties
+import java.util.logging.Logger
+
 import org.junit.Test
 import org.junit.Assert._
 import slick.backend.DatabaseConfig
 import slick.driver.JdbcProfile
+import slick.jdbc.JdbcBackend
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 class DataSourceTest {
+  @Test def testDatabaseUrlDataSource: Unit = {
+    import slick.driver.H2Driver.api.actionBasedSQLInterpolation
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrl")
+    try {
+      try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
+      val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
+      assertEquals("jdbc:postgresql://host/dbname", url)
+      assertEquals("user", info.getProperty("user"))
+      assertEquals("pass", info.getProperty("password"))
+      assertEquals("bar", info.getProperty("foo"))
+    } finally db.close
+  }
+}
+
+object MockDriver {
+  @volatile private var last: Option[(String, Properties)] = None
+  def getLast = last
+  def reset: Unit = last = None
+}
+
+class MockDriver extends Driver {
+  def acceptsURL(url: String): Boolean = true
+  def jdbcCompliant(): Boolean = false
+  def getPropertyInfo(url: String, info: Properties): Array[DriverPropertyInfo] = Array()
+  def getMinorVersion: Int = 0
+  def getParentLogger: Logger = throw new SQLException("feature not implemented")
+  def connect(url: String, info: Properties): Connection = {
+    MockDriver.last = Some((url, info))
+    throw new SQLException("Connection data has been recorded")
+  }
+  def getMajorVersion: Int = 0
 }

--- a/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
@@ -1,39 +1,27 @@
 package slick.jdbc
 
-import scala.language.reflectiveCalls
-
-import java.io.{PrintWriter, Closeable}
-import java.sql._
-import java.util.Properties
-import java.util.logging.Logger
-import javax.sql.DataSource
-
-import slick.SlickException
-import slick.util.{ClassLoaderUtil, Logging, ignoreFollowOnError}
-
-import scala.beans.BeanProperty
-import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
-
-object DatabaseUrlDataSource {
+/** A DataSource that wraps the DriverManager API. It can be configured as a Java Bean and used
+  * both stand-alone and as a source for a connection pool. This implementation is design
+  * specifically to handle a non-JDBC Database URL in the format defined by the libpq standard.
+  */
+class DatabaseUrlDataSource extends DriverDataSource(null) {
 
   private val PostgresFullUrl = "^postgres://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
   private val MysqlFullUrl = "^mysql://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
   private val MysqlCustomProperties = ".*\\?(.*)".r
 
-  def extractUrl(databaseUrl: Option[String]): String = {
-    extractUrlComponents(Some(databaseUrl.getOrElse(defaultUrl)))._1.orNull
+  @volatile private[this] var initialized = false
+
+  override def init: Unit = if(!initialized) {
+    val (jdbcUrl, userAndPass) = extractUrl(Some(if (url == null) defaultUrl else url))
+    url = jdbcUrl.orNull
+    user = userAndPass.map(_._1).getOrElse(user)
+    password = userAndPass.map(_._2).getOrElse(password)
+    initialized = true
+    super.init
   }
 
-  def extractUser(databaseUrl: Option[String], default:String): String = {
-    extractUrlComponents(Some(databaseUrl.getOrElse(defaultUrl)))._2.map(_._1).getOrElse(default)
-  }
-
-  def extractPassword(databaseUrl: Option[String], default:String): String = {
-    extractUrlComponents(Some(databaseUrl.getOrElse(defaultUrl)))._2.map(_._2).getOrElse(default)
-  }
-
-  def extractUrlComponents(databaseUrl: Option[String]): (Option[String], Option[(String, String)]) = {
+  private[this] def extractUrl(databaseUrl: Option[String]): (Option[String], Option[(String, String)]) = {
     databaseUrl match {
       case Some(PostgresFullUrl(username, password, host, dbname)) =>
         Some(s"jdbc:postgresql://$host/$dbname") -> Some(username -> password)
@@ -51,38 +39,7 @@ object DatabaseUrlDataSource {
     }
   }
 
-  def defaultUrl():String = {
+  private[this] def defaultUrl():String = {
     System.getenv("DATABASE_URL")
   }
 }
-
-/** A DataSource that wraps the DriverManager API. It can be configured as a Java Bean and used
-  * both stand-alone and as a source for a connection pool. */
-class DatabaseUrlDataSource(
-    /** The Database URL */
-    dbUrl: String,
-    /** Optional user name */
-    dbUrlUser: String = null,
-    /** Optional password */
-    dbUrlPassword: String = null,
-    /** Optional connection properties */
-    dbUrlProperties: Properties = null,
-    /** Name of the `java.sql.Driver` class. This must be set unless a `driverObject` is set
-      * directly or the driver is already registered with the DriverManager. */
-    dbUrlDriverClassName: String = null,
-    /** When `close()` is called, try to deregister a driver that was registered by this instance. */
-    dbUrlDeregisterDriver: Boolean = false,
-    /** The JDBC driver to use. If this is set, `driverClassName` will be ignored. */
-    dbUrlDriverObject: Driver = null,
-    /** The ClassLoader that is used to load `driverClassName` */
-    dbUrlClassLoader: ClassLoader = ClassLoaderUtil.defaultClassLoader
-  ) extends DriverDataSource(
-    DatabaseUrlDataSource.extractUrl(Some(dbUrl)),
-    DatabaseUrlDataSource.extractUser(Some(dbUrl), dbUrlUser),
-    DatabaseUrlDataSource.extractPassword(Some(dbUrl), dbUrlPassword),
-    dbUrlProperties,
-    dbUrlDriverClassName,
-    dbUrlDeregisterDriver,
-    dbUrlDriverObject,
-    dbUrlClassLoader
-  ) { }

--- a/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
@@ -1,0 +1,88 @@
+package slick.jdbc
+
+import scala.language.reflectiveCalls
+
+import java.io.{PrintWriter, Closeable}
+import java.sql._
+import java.util.Properties
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+import slick.SlickException
+import slick.util.{ClassLoaderUtil, Logging, ignoreFollowOnError}
+
+import scala.beans.BeanProperty
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+object DatabaseUrlDataSource {
+
+  private val PostgresFullUrl = "^postgres://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
+  private val MysqlFullUrl = "^mysql://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
+  private val MysqlCustomProperties = ".*\\?(.*)".r
+
+  def extractUrl(databaseUrl: Option[String]): String = {
+    extractUrlComponents(Some(databaseUrl.getOrElse(defaultUrl)))._1.orNull
+  }
+
+  def extractUser(databaseUrl: Option[String], default:String): String = {
+    extractUrlComponents(Some(databaseUrl.getOrElse(defaultUrl)))._2.map(_._1).getOrElse(default)
+  }
+
+  def extractPassword(databaseUrl: Option[String], default:String): String = {
+    extractUrlComponents(Some(databaseUrl.getOrElse(defaultUrl)))._2.map(_._2).getOrElse(default)
+  }
+
+  def extractUrlComponents(databaseUrl: Option[String]): (Option[String], Option[(String, String)]) = {
+    databaseUrl match {
+      case Some(PostgresFullUrl(username, password, host, dbname)) =>
+        Some(s"jdbc:postgresql://$host/$dbname") -> Some(username -> password)
+
+      case Some(url @ MysqlFullUrl(username, password, host, dbname)) =>
+        val defaultProperties = "?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci"
+        val addDefaultPropertiesIfNeeded = MysqlCustomProperties.findFirstMatchIn(url).map(_ => "").getOrElse(defaultProperties)
+        Some(s"jdbc:mysql://$host/${dbname + addDefaultPropertiesIfNeeded}") -> Some(username -> password)
+
+      case Some(url) =>
+        Some(url) -> None
+
+      case None =>
+        None -> None
+    }
+  }
+
+  def defaultUrl():String = {
+    System.getenv("DATABASE_URL")
+  }
+}
+
+/** A DataSource that wraps the DriverManager API. It can be configured as a Java Bean and used
+  * both stand-alone and as a source for a connection pool. */
+class DatabaseUrlDataSource(
+    /** The Database URL */
+    dbUrl: String,
+    /** Optional user name */
+    dbUrlUser: String = null,
+    /** Optional password */
+    dbUrlPassword: String = null,
+    /** Optional connection properties */
+    dbUrlProperties: Properties = null,
+    /** Name of the `java.sql.Driver` class. This must be set unless a `driverObject` is set
+      * directly or the driver is already registered with the DriverManager. */
+    dbUrlDriverClassName: String = null,
+    /** When `close()` is called, try to deregister a driver that was registered by this instance. */
+    dbUrlDeregisterDriver: Boolean = false,
+    /** The JDBC driver to use. If this is set, `driverClassName` will be ignored. */
+    dbUrlDriverObject: Driver = null,
+    /** The ClassLoader that is used to load `driverClassName` */
+    dbUrlClassLoader: ClassLoader = ClassLoaderUtil.defaultClassLoader
+  ) extends DriverDataSource(
+    DatabaseUrlDataSource.extractUrl(Some(dbUrl)),
+    DatabaseUrlDataSource.extractUser(Some(dbUrl), dbUrlUser),
+    DatabaseUrlDataSource.extractPassword(Some(dbUrl), dbUrlPassword),
+    dbUrlProperties,
+    dbUrlDriverClassName,
+    dbUrlDeregisterDriver,
+    dbUrlDriverObject,
+    dbUrlClassLoader
+  ) { }

--- a/slick/src/main/scala/slick/jdbc/DriverDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DriverDataSource.scala
@@ -1,0 +1,129 @@
+package slick.jdbc
+
+import scala.language.reflectiveCalls
+
+import java.io.{PrintWriter, Closeable}
+import java.sql._
+import java.util.Properties
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+import slick.SlickException
+import slick.util.{ClassLoaderUtil, Logging, ignoreFollowOnError}
+
+import scala.beans.BeanProperty
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+/** A DataSource that wraps the DriverManager API. It can be configured as a Java Bean and used
+  * both stand-alone and as a source for a connection pool. */
+class DriverDataSource(
+    /** The JDBC URL (required) */
+    @BeanProperty @volatile var url: String,
+    /** Optional user name */
+    @BeanProperty @volatile var user: String = null,
+    /** Optional password */
+    @BeanProperty @volatile var password: String = null,
+    /** Optional connection properties */
+    @BeanProperty @volatile var properties: Properties = null,
+    /** Name of the `java.sql.Driver` class. This must be set unless a `driverObject` is set
+      * directly or the driver is already registered with the DriverManager. */
+    @BeanProperty @volatile var driverClassName: String = null,
+    /** When `close()` is called, try to deregister a driver that was registered by this instance. */
+    @BeanProperty @volatile var deregisterDriver: Boolean = false,
+    /** The JDBC driver to use. If this is set, `driverClassName` will be ignored. */
+    @volatile var driverObject: Driver = null,
+    /** The ClassLoader that is used to load `driverClassName` */
+    @volatile var classLoader: ClassLoader = ClassLoaderUtil.defaultClassLoader
+  ) extends DataSource with Closeable with Logging {
+
+  def this() = this(null)
+
+  // Alias for `driverClassName`
+  def getDriver: String = driverClassName
+  def setDriver(s: String): Unit = driverClassName = s
+
+  // State that gets initialized by `init`
+  @volatile private[this] var registered: Boolean = false
+  @volatile private[this] var initialized = false
+  private[this] var driver: Driver = _
+  private[this] var connectionProps: Properties = _
+
+  def init: Unit = if(!initialized) {
+    try {
+      initialized = true
+      if(url eq null) throw new SQLException("Required parameter \"url\" missing in DriverDataSource")
+      driver = if(driverObject eq null) {
+        if(driverClassName ne null) {
+          DriverManager.getDrivers.asScala.find(_.getClass.getName == driverClassName).getOrElse {
+            logger.debug(s"Driver $driverClassName not already registered; trying to load it")
+            val cl = classLoader.loadClass(driverClassName)
+            registered = true
+            DriverManager.getDrivers.asScala.find(_.getClass.getName == driverClassName).getOrElse {
+              logger.debug(s"Loaded driver $driverClassName but it did not register with DriverManager; trying to instantiate directly")
+              try cl.newInstance.asInstanceOf[Driver] catch { case ex: Exception =>
+                logger.debug(s"Instantiating driver class $driverClassName failed; asking DriverManager to handle URL $url", ex)
+                try DriverManager.getDriver(url) catch { case ex: Exception =>
+                  throw new SlickException(s"Driver $driverClassName does not know how to handle URL $url", ex)
+                }
+              }
+            }
+          }
+        } else try DriverManager.getDriver(url) catch { case ex: Exception =>
+          throw new SlickException(s"No driver specified and DriverManager does not know how to handle URL $url", ex)
+        }
+      } else driverObject
+      if(!driver.acceptsURL(url)) {
+        close()
+        throw new SlickException(s"Driver ${driver.getClass.getName} does not know how to handle URL $url")
+      }
+      connectionProps = propsWithUserAndPassword(properties, user, password)
+    } catch { case NonFatal(ex) =>
+      try close() catch ignoreFollowOnError
+      throw ex
+    } finally initialized = true
+  }
+
+  private[this] def propsWithUserAndPassword(p: Properties, user: String, password: String): Properties = {
+    if((p ne null) && (user eq null) && (password eq null)) p else {
+      val p2 = new Properties(p)
+      if(user ne null) p2.setProperty("user", user)
+      if(password ne null) p2.setProperty("password", password)
+      p2
+    }
+  }
+
+  def getConnection: Connection = {
+    init
+    driver.connect(url, connectionProps)
+  }
+
+  def getConnection(username: String, password: String): Connection = {
+    init
+    driver.connect(url, propsWithUserAndPassword(connectionProps, username, password))
+  }
+
+  def close(): Unit = if(registered && deregisterDriver && (driver ne null)) {
+    DriverManager.deregisterDriver(driver)
+    registered = false
+  }
+
+  def getLoginTimeout: Int = DriverManager.getLoginTimeout
+
+  def setLoginTimeout(seconds: Int): Unit = DriverManager.setLoginTimeout(seconds)
+
+  def getLogWriter: PrintWriter = throw new SQLFeatureNotSupportedException()
+
+  def setLogWriter(out: PrintWriter): Unit = throw new SQLFeatureNotSupportedException()
+
+  def getParentLogger: Logger = {
+    try driver.asInstanceOf[{ def getParentLogger(): Logger }].getParentLogger
+    catch { case _: NoSuchMethodException => throw new SQLFeatureNotSupportedException() }
+  }
+
+  def isWrapperFor(iface: Class[_]): Boolean = iface.isInstance(this)
+
+  def unwrap[T](iface: Class[T]): T =
+    if(iface.isInstance(this)) this.asInstanceOf[T]
+    else throw new SQLException(getClass.getName+" is not a wrapper for "+iface)
+}


### PR DESCRIPTION
This adds the essential bits for using `DatabaseUrlDataSource` via HikariCP to 3.0. Unlike in master, the required machinery for also supporting it for `connectionPool=disabled` is not available.