### PR TITLE
Update conf.py

### DIFF
--- a/slick/src/sphinx/conf.py
+++ b/slick/src/sphinx/conf.py
@@ -88,7 +88,7 @@ html_theme = "theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = { 'github' : 'https://github.com/slick/slick/edit/master/src/sphinx/' }
+html_theme_options = { 'github' : 'https://github.com/slick/slick/edit/master/slick/src/sphinx/' }
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['.']
 


### PR DESCRIPTION
Uses same value for html_theme_options like in the master branch. At the moment the "EDIT THIS PAGE ON GITHUB" button on the slick 3.0.0 documentation page is not working.