### PR TITLE
Fix view source for scaladoc and edit this file on github for docs.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -107,7 +107,7 @@ object SlickBuild extends Build {
       "-doc-version", v,
       "-doc-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
       "-sourcepath", src.getPath, // needed for scaladoc to strip the location of the linked source path
-      "-doc-source-url", "https://github.com/slick/slick/blob/"+v+"/src/main€{FILE_PATH}.scala",
+      "-doc-source-url", "https://github.com/slick/slick/blob/"+v+"/slick/src/main€{FILE_PATH}.scala",
       "-implicits",
       "-diagrams", // requires graphviz
       "-groups"

--- a/slick/src/sphinx/conf.py
+++ b/slick/src/sphinx/conf.py
@@ -88,7 +88,7 @@ html_theme = "theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = { 'github' : 'https://github.com/slick/slick/edit/master/src/sphinx/' }
+html_theme_options = { 'github' : 'https://github.com/slick/slick/edit/master/slick/src/sphinx/' }
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['.']
 


### PR DESCRIPTION
I cherry pick a commit from master. The goal is that the links on the Slick 3 documentation page work again. See #1210