### PR TITLE
Add the correct scala-sbt repo for resolving sbt-testng-plugin

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -304,6 +304,7 @@ object SlickBuild extends Build {
     settings = Defaults.coreDefaultSettings ++ sharedSettings ++ testNGSettings ++ Seq(
       name := "Slick-ReactiveStreamsTests",
       unmanagedResourceDirectories in Test += (baseDirectory in aRootProject).value / "common-test-resources",
+      resolvers += Resolver.sbtPluginRepo("releases"),
       libraryDependencies ++=
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "test") ++:
         Dependencies.reactiveStreamsTCK +:


### PR DESCRIPTION
The recent move of the sbt repo on scala-sbt.org to Airtifactory broke sbt-testng-plugin.