### PR TITLE
Fix the implicit conversions for Compiled queries.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MutateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MutateTest.scala
@@ -43,7 +43,7 @@ class MutateTest extends AsyncTest[JdbcTestDB] {
       ts.schema.create,
       ts ++= Seq((1,1), (1,2), (1,3), (1,4)),
       ts ++= Seq((2,5), (2,6), (2,7), (2,8))
-    ) andThen runnableStreamableCompiledQueryActionExtensionMethods(tsByA(1)).mutate(sendEndMarker = true).transactionally
+    ) andThen tsByA(1).mutate(sendEndMarker = true).transactionally
 
     foreach(db.stream(a)){ m =>
       if(!m.end) m.delete

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
@@ -93,6 +93,7 @@ class TemplateTest extends AsyncTest[RelationalTestDB] {
     seq(
       ts.schema.create,
       Compiled(ts.map(identity)) += (1, "a"),
+      Compiled(ts.map(identity)).result.map(_ shouldBe Seq((1, "a"))),
       Compiled(ts) ++= Seq((2, "b"), (3, "c")),
       byIdAndS(1, "a").result.map(r => r.toSet shouldBe Set((1, "a"))),
       byIdAndSC(1, "a").result.map((r: Seq[(Int, String)]) => r.toSet shouldBe Set((1, "a"))),

--- a/slick/src/main/scala/slick/profile/BasicProfile.scala
+++ b/slick/src/main/scala/slick/profile/BasicProfile.scala
@@ -57,7 +57,7 @@ trait BasicProfile extends BasicActionComponent { driver: BasicDriver =>
     implicit def streamableCompiledQueryActionExtensionMethods[RU, EU](c: StreamableCompiled[_, RU, EU]): StreamingQueryActionExtensionMethods[RU, EU] =
       createStreamingQueryActionExtensionMethods[RU, EU](c.compiledQuery, c.param)
     // Applying a CompiledFunction always results in only a RunnableCompiled, not a StreamableCompiled, so we need this:
-    implicit def runnableStreamableCompiledQueryActionExtensionMethods[R, RU, EU, C[_]](c: RunnableCompiled[Query[R, EU, C], RU]): StreamingQueryActionExtensionMethods[RU, EU] =
+    implicit def streamableAppliedCompiledFunctionActionExtensionMethods[R, RU, EU, C[_]](c: AppliedCompiledFunction[_, Query[R, EU, C], RU]): StreamingQueryActionExtensionMethods[RU, EU] =
       createStreamingQueryActionExtensionMethods[RU, EU](c.compiledQuery, c.param)
     // This only works on Scala 2.11 due to SI-3346:
     implicit def recordQueryActionExtensionMethods[M, R](q: M)(implicit shape: Shape[_ <: FlatShapeLevel, M, R, _]): QueryActionExtensionMethods[R, NoStream] =


### PR DESCRIPTION
The previous design created some ambiguities. Restricting the extra
implicit conversion for AppliedCompiledFunction to actually require
an AppliedCompiledFunction instead of a more generic RunnableCompiled
should prevent this.

Tests in TemplateTest.testCompiled, MutateTest.testDeleteMutate.