### PR TITLE
Workaround SI-7139 caused by eponymous type alias and object

### DIFF
--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -120,7 +120,9 @@ sealed trait DBIOAction[+R, +S <: NoStream, -E <: Effect] extends Dumpable {
   def isLogged: Boolean = false
 }
 
-object DBIO {
+private object DBIO extends DBIOModule // for backwards binary compatbility
+
+class DBIOModule {
   /** Convert a `Future` to a [[DBIOAction]]. */
   def from[R](f: Future[R]): DBIOAction[R, NoStream, Effect] = FutureAction[R](f)
 

--- a/slick/src/main/scala/slick/dbio/package.scala
+++ b/slick/src/main/scala/slick/dbio/package.scala
@@ -8,4 +8,5 @@ package object dbio {
 
   /** Simplified type for a [[DBIOAction]] without streaming or effect tracking */
   type DBIO[+R] = DBIOAction[R, NoStream, Effect.All]
+  val DBIO = new DBIOModule
 }


### PR DESCRIPTION
A type alias in a package object is a bad idea if the package
contains an object of the same name.

This commit also adds a val to the package object that behaves
the same as the object. Defintions in package objects overrwrite
definitions in the package.

I've left the object in place (marked private) to maintain backwards
binary compatibility. I had some trouble running MiMa, so I'd ask the
reviewer to double check this for me.

As reported:

  https://www.assembla.com/spaces/scala-ide/support/tickets/1002527#
  http://stackoverflow.com/questions/30436661/error-value-seq-is-not-a-member-of-object-slick-dbio-dbio

Tested manually as follows:

```
% git co -
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.

% sbt compile
[info] Loading global plugins from /Users/jason/.sbt/0.13/plugins
[info] Loading project definition from /Users/jason/code/orgs/slick/slick/project
[info] Set current project to root (in build file:/Users/jason/code/orgs/slick/slick/)
[info] Compiling 2 Scala sources to /Users/jason/code/orgs/slick/slick/slick/target/scala-2.10/classes...
[info] Compiling 61 Scala sources to /Users/jason/code/orgs/slick/slick/slick/target/scala-2.10/classes...
[warn] there were 4 unchecked warning(s); re-run with -unchecked for details
[warn] one warning found
[info] Compiling 5 Scala sources to /Users/jason/code/orgs/slick/slick/slick-codegen/target/scala-2.10/classes...
[info] Compiling 39 Scala sources to /Users/jason/code/orgs/slick/slick/slick-testkit/target/scala-2.10/classes...
[success] Total time: 59 s, completed 06/08/2015 10:02:49 PM

% scala-hash v2.10.5 -classpath slick/target/scala-2.10/classes/
Welcome to Scala version 2.10.5-20150226-164155-88c5407613 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_51).
Type in expressions to have them evaluated.
Type :help for more information.

scala> slick.dbio.DBIO.seq _
res0: Seq[slick.dbio.DBIOAction[_, slick.dbio.NoStream, Nothing]] => slick.dbio.DBIOAction[Unit,slick.dbio.NoStream,Nothing] = <function1>

scala> slick.dbio.DBIO.seq _
<console>:8: error: value seq is not a member of object slick.dbio.DBIO
              slick.dbio.DBIO.seq _
                              ^

scala>

% git co -
Switched to branch 'topic/workaround-SI-7139'
Your branch is up-to-date with 'retronym/topic/workaround-SI-7139'.

% sbt compile
[info] Loading global plugins from /Users/jason/.sbt/0.13/plugins
[info] Loading project definition from /Users/jason/code/orgs/slick/slick/project
[info] Set current project to root (in build file:/Users/jason/code/orgs/slick/slick/)
[info] Compiling 2 Scala sources to /Users/jason/code/orgs/slick/slick/slick/target/scala-2.10/classes...
[info] Compiling 61 Scala sources to /Users/jason/code/orgs/slick/slick/slick/target/scala-2.10/classes...
[warn] there were 4 unchecked warning(s); re-run with -unchecked for details
[warn] one warning found
[info] Compiling 1 Scala source to /Users/jason/code/orgs/slick/slick/slick-codegen/target/scala-2.10/classes...
[info] Compiling 39 Scala sources to /Users/jason/code/orgs/slick/slick/slick-testkit/target/scala-2.10/classes...
[success] Total time: 58 s, completed 06/08/2015 10:04:25 PM
topic/workaround-SI-7139 /code/orgs/slick/slick scala-hash v2.10.5 -classpath slick/target/scala-2.10/classes/
Welcome to Scala version 2.10.5-20150226-164155-88c5407613 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_51).
Type in expressions to have them evaluated.
Type :help for more information.

scala> slick.dbio.DBIO.seq _
res0: Seq[slick.dbio.DBIOAction[_, slick.dbio.NoStream, Nothing]] => slick.dbio.DBIOAction[Unit,slick.dbio.NoStream,Nothing] = <function1>

scala> slick.dbio.DBIO.seq _
res1: Seq[slick.dbio.DBIOAction[_, slick.dbio.NoStream, Nothing]] => slick.dbio.DBIOAction[Unit,slick.dbio.NoStream,Nothing] = <function1>

scala> slick.dbio.DBIO.seq _
res2: Seq[slick.dbio.DBIOAction[_, slick.dbio.NoStream, Nothing]] => slick.dbio.DBIOAction[Unit,slick.dbio.NoStream,Nothing] = <function1>

```