### PR TITLE
add one more parameter `typeName` to `JdbcModelBuilder.jdbcTypeToScala`

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
@@ -97,9 +97,8 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
 
   class Builders(val tablesByQName: Map[MQName, TableBuilder])
 
-  /** Converts from java.sql.Types to the corresponding Java class name (with fully qualified path). */
-  /** Converts from java.sql.Types to the corresponding Java class name (with fully qualified path). */
-  def jdbcTypeToScala(jdbcType: Int): ClassTag[_] = {
+  /** Converts from java.sql.Types w/ type name to the corresponding Java class name (with fully qualified path). */
+  def jdbcTypeToScala(jdbcType: Int, typeName: String = ""): ClassTag[_] = {
     import java.sql.Types._
     import scala.reflect.classTag
     // see TABLE B-1 of JSR-000221 JBDCTM API Specification 4.1 Maintenance Release

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -73,7 +73,7 @@ object ActionBasedSQLInterpolation {
             case null => Vector()
             case resultMeta => Vector.tabulate(resultMeta.getColumnCount) { i =>
               val modelBuilder = dc.driver.createModelBuilder(Nil, true)(scala.concurrent.ExecutionContext.global)
-              modelBuilder.jdbcTypeToScala(resultMeta.getColumnType(i + 1))
+              modelBuilder.jdbcTypeToScala(resultMeta.getColumnType(i + 1), resultMeta.getColumnTypeName(i + 1))
             }
           }
         }


### PR DESCRIPTION
Can I add one more parameter `typeName` to `JdbcModelBuilder.jdbcTypeToScala`, and let `tsqlImpl` to use it?

Which enable us to extend it more easily in subclass of JdbcDriver.
Currently I'm using it to implement tminglei/slick-pg#176.


_BTW, we used `ClassTag` here, which only holds the erased class info and lead to `mapping db type to scala type with type parameter` can't support by `slick`.
Do you have a plan to enhance it?_