### PR TITLE
Database.forConfig uses provided config params `numThreads` and `queueSize`

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -263,8 +263,9 @@ trait JdbcBackend extends RelationalBackend {
       */
     def forConfig(path: String, config: Config = ConfigFactory.load(), driver: Driver = null,
                   classLoader: ClassLoader = ClassLoaderUtil.defaultClassLoader): Database = {
-      val source = JdbcDataSource.forConfig(if(path.isEmpty) config else config.getConfig(path), driver, path, classLoader)
-      val executor = AsyncExecutor(path, config.getIntOr("numThreads", 20), config.getIntOr("queueSize", 1000))
+      val usedConfig = if(path.isEmpty) config else config.getConfig(path)
+      val source = JdbcDataSource.forConfig(usedConfig, driver, path, classLoader)
+      val executor = AsyncExecutor(path, usedConfig.getIntOr("numThreads", 20), usedConfig.getIntOr("queueSize", 1000))
       forSource(source, executor)
     }
   }


### PR DESCRIPTION
The existing implementation of Database.forConfig was ignoring the `path`
passed to it when looking up the value of `numThreads` and `queueSize` in
the config.

I would have loved to provide a test together with the fix, but I would have
to resort to reflection to retrieve the values used to set up the thread pool,
and that seems fragile. Therefore, there is no test with this fix.