### PR TITLE
Only set Hikari dataSourceClassName or driverClassName but not both

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcDataSource.scala
@@ -146,8 +146,11 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
     val hconf = new HikariConfig()
 
     // Connection settings
-    hconf.setDataSourceClassName(c.getStringOr("dataSourceClass", null))
-    Option(c.getStringOr("driverClassName", c.getStringOr("driver"))).map(hconf.setDriverClassName _)
+    if (c.hasPath("dataSourceClass")) {
+      hconf.setDataSourceClassName(c.getString("dataSourceClass"))
+    } else {
+      Option(c.getStringOr("driverClassName", c.getStringOr("driver"))).map(hconf.setDriverClassName _)
+    }
     hconf.setJdbcUrl(c.getStringOr("url", null))
     c.getStringOpt("user").foreach(hconf.setUsername)
     c.getStringOpt("password").foreach(hconf.setPassword)


### PR DESCRIPTION
This popped up while testing DatabaseUrlDataSource. Without this guard, HikariCP throws:

```
Caused by: java.lang.IllegalStateException: both driverClassName and dataSourceClassName are specified, one or the other should be used
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1103)
 	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
 	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:62)
 	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:145)
 	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
 	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
 	at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:205)
 	at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:199)
 	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
 	... 10 more
 	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:199)
 	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:180)
 Oops, cannot start the server.
 	at com.zaxxer.hikari.AbstractHikariConfig.validate(AbstractHikariConfig.java:772)
 	at slick.jdbc.HikariCPJdbcDataSource$.forConfig(JdbcDataSource.scala:179)
 	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:75)
 	at slick.jdbc.HikariCPJdbcDataSource$.forConfig(JdbcDataSource.scala:140)
 	at slick.jdbc.JdbcDataSource$.forConfig(JdbcDataSource.scala:40)
 	at slick.jdbc.JdbcBackend$DatabaseFactoryDef$class.forConfig(JdbcBackend.scala:226)
 	at slick.jdbc.JdbcBackend$$anon$3.forConfig(JdbcBackend.scala:33)
 	at slick.jdbc.JdbcBackend$class.createDatabase(JdbcBackend.scala:36)
 	at slick.jdbc.JdbcBackend$.createDatabase(JdbcBackend.scala:496)
 	at slick.jdbc.JdbcBackend$.createDatabase(JdbcBackend.scala:496)
 	at slick.backend.DatabaseConfig$$anon$1.db(DatabaseConfig.scala:94)
 	at slick.backend.DatabaseConfig$$anon$1.db$lzycompute(DatabaseConfig.scala:95)
 	at play.api.db.slick.evolutions.internal.DBApiAdapter$DatabaseAdapter.getConnection(DBApiAdapter.scala:54)
```