### PR TITLE
Add two more expr customization for pg `current_date` and `current_time`

### DIFF
--- a/slick/src/main/scala/slick/driver/PostgresDriver.scala
+++ b/slick/src/main/scala/slick/driver/PostgresDriver.scala
@@ -140,6 +140,8 @@ trait PostgresDriver extends JdbcDriver { driver =>
       case Library.IfNull(ch, d) => b"coalesce($ch, $d)"
       case Library.NextValue(SequenceNode(name)) => b"nextval('$name')"
       case Library.CurrentValue(SequenceNode(name)) => b"currval('$name')"
+      case Library.CurrentDate() => b"current_date"
+      case Library.CurrentTime() => b"current_time"
       case _ => super.expr(n, skipParens)
     }
   }


### PR DESCRIPTION
Add two more expr customization for pg `current_date` and `current_time`.

Without it, we will encounter runtime errors like this:
```
[info] - Threeten date Lifted support *** FAILED ***
[info]   org.postgresql.util.PSQLException: ERROR: function curdate() does not exist
[info]   Hint: No function matches the given name and argument types. You might need to add explicit type casts.
[info]   Position: 35
[info]   at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2270)
[info]   at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1998)
[info]   at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
[info]   at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:570)
[info]   at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:420)
[info]   at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:413)
[info]   at slick.jdbc.StatementInvoker.results(StatementInvoker.scala:39)
[info]   at slick.jdbc.StatementInvoker.iteratorTo(StatementInvoker.scala:22)
[info]   at slick.jdbc.Invoker$class.first(Invoker.scala:31)
[info]   at slick.jdbc.StatementInvoker.first(StatementInvoker.scala:16)
[info]   ...
```

----------------------------------------
p.s. occurred at tminglei/slick-pg#202, not encountered before. 