### PR TITLE
Only set Hikari dataSourceClassName or driverClassName but not both

### DIFF
--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -22,8 +22,11 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
     val hconf = new HikariConfig()
 
     // Connection settings
-    hconf.setDataSourceClassName(c.getStringOr("dataSourceClass", null))
-    Option(c.getStringOr("driverClassName", c.getStringOr("driver"))).map(hconf.setDriverClassName _)
+    if (c.hasPath("dataSourceClass")) {
+      hconf.setDataSourceClassName(c.getString("dataSourceClass"))
+    } else {
+      Option(c.getStringOr("driverClassName", c.getStringOr("driver"))).map(hconf.setDriverClassName _)
+    }
     hconf.setJdbcUrl(c.getStringOr("url", null))
     c.getStringOpt("user").foreach(hconf.setUsername)
     c.getStringOpt("password").foreach(hconf.setPassword)


### PR DESCRIPTION
Conflicts:
	slick/src/main/scala/slick/jdbc/JdbcDataSource.scala