### PR TITLE
Further query compiler performance improvements

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -253,6 +253,8 @@ object SlickBuild extends Build {
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "codegen"),
       parallelExecution in Test := false,
       fork in run := true,
+      //connectInput in run := true,
+      //javaOptions in run += "-agentpath:/Applications/YourKit_Java_Profiler_2015_build_15072.app/Contents/Resources/bin/mac/libyjpagent.jnilib",
       javaOptions in run += "-Dslick.ansiDump=true",
       //javaOptions in run += "-verbose:gc",
       compile in Test ~= { a =>

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
@@ -576,7 +576,7 @@ class NewQuerySemanticsTest extends AsyncTest[RelationalTestDB] {
     import slick.ast.Util._
     val qc = new QueryCompiler(tdb.driver.queryCompiler.phases.takeWhile(_.name != "codeGen"))
     val cs = qc.run(q.toNode)
-    val found = cs.tree.collect { case c: Comprehension => c }.size
+    val found = cs.tree.collect { case c: Comprehension => c }.length
     if(found != exp)
       throw cs.symbolNamer.use(new SlickTreeException(s"Found $found Comprehension nodes, should be $exp",
         cs.tree, mark = (_.isInstanceOf[Comprehension]), removeUnmarked = false))

--- a/slick-testkit/src/test/scala/slick/benchmark/CompilerBenchmark.scala
+++ b/slick-testkit/src/test/scala/slick/benchmark/CompilerBenchmark.scala
@@ -35,7 +35,15 @@ object CompilerBenchmark {
       val (asts, t2) = time("Creating ASTs", COUNT_TONODE)(queries.map(_.toNode))
       phases.foreach(p => phaseNanos += (p.name -> new Array[Long](1)))
       //asts.zipWithIndex.foreach { case (n, i) => println(i); compiler.run(n) }
+      /*if(i == RUNS-1) {
+        println("Attach profiler and press Return")
+        Console.readLine()
+      }*/
       val (compiled, t3) = time("Compiling", COUNT_COMPILE)(asts.map(compiler.run(_)))
+      /*if(i == RUNS-1) {
+        println("Detach profiler and press Return")
+        Console.readLine()
+      }*/
       println(String.format("Creating: %1$7.3f ms, toNode: %2$7.3f ms, compiling: %3$7.3f ms", t1.asInstanceOf[AnyRef], t2.asInstanceOf[AnyRef], t3.asInstanceOf[AnyRef]))
     }
 

--- a/slick/src/main/scala/slick/ast/ClientSideOp.scala
+++ b/slick/src/main/scala/slick/ast/ClientSideOp.scala
@@ -3,6 +3,7 @@ package slick.ast
 import slick.ast.Util._
 import slick.ast.TypeUtil._
 import slick.SlickException
+import slick.util.ConstArray
 
 /**
  * An operation which is expected to be run on the client side.
@@ -30,7 +31,7 @@ object ClientSideOp {
 final case class First(val child: Node) extends UnaryNode with SimplyTypedNode with ClientSideOp {
   type Self = First
   protected[this] def rebuild(ch: Node) = copy(child = ch)
-  protected def buildType = children.head.nodeType.asCollectionType.elementType
+  protected def buildType = child.nodeType.asCollectionType.elementType
   def nodeMapServerSide(keepType: Boolean, r: Node => Node) = mapChildren(r, keepType)
 }
 
@@ -46,9 +47,9 @@ final case class ResultSetMapping(generator: TermSymbol, from: Node, map: Node) 
   def right = map
   override def childNames = Seq("from "+generator, "map")
   protected[this] def rebuild(left: Node, right: Node) = copy(from = left, map = right)
-  def generators = Vector((generator, from))
+  def generators = ConstArray((generator, from))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(generator = gen(0))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(generator = gen(0))
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val from2 = from.infer(scope, typeChildren)
     val (map2, newType) = from2.nodeType match {
@@ -59,7 +60,7 @@ final case class ResultSetMapping(generator: TermSymbol, from: Node, map: Node) 
         val map2 = map.infer(scope + (generator -> t), typeChildren)
         (map2, map2.nodeType)
     }
-    withChildren(Vector(from2, map2)) :@ (if(!hasType) newType else nodeType)
+    withChildren(ConstArray[Node](from2, map2)) :@ (if(!hasType) newType else nodeType)
   }
   def nodeMapServerSide(keepType: Boolean, r: Node => Node) = {
     val this2 = mapScopedChildren {
@@ -73,16 +74,17 @@ final case class ResultSetMapping(generator: TermSymbol, from: Node, map: Node) 
 
 /** A switch for special-cased parameters that needs to be interpreted in order
   * to find the correct query string for the query arguments. */
-final case class ParameterSwitch(cases: IndexedSeq[((Any => Boolean), Node)], default: Node) extends SimplyTypedNode with ClientSideOp {
+final case class ParameterSwitch(cases: ConstArray[((Any => Boolean), Node)], default: Node) extends SimplyTypedNode with ClientSideOp {
   type Self = ParameterSwitch
   def children = cases.map(_._2) :+ default
-  override def childNames = cases.map("[" + _._1 + "]") :+ "default"
-  protected[this] def rebuild(ch: IndexedSeq[Node]): Self =
-    copy(cases = (cases, ch).zipped.map { (c, n) => (c._1, n) }, default = ch.last)
+  override def childNames = cases.map("[" + _._1 + "]").toSeq :+ "default"
+  protected[this] def rebuild(ch: ConstArray[Node]): Self =
+    copy(cases = cases.zip(ch).map { case (c, n) => (c._1, n) }, default = ch.last)
   protected def buildType = default.nodeType
   def nodeMapServerSide(keepType: Boolean, r: Node => Node): Self = {
-    val ch2 = mapOrNull(children)(r)
-    val this2 = if(ch2 eq null) this else rebuild(ch2)
+    val ch = children
+    val ch2 = ch.endoMap(r)
+    val this2 = if(ch2 eq ch) this else rebuild(ch2)
     if(keepType && hasType) this2 :@ nodeType
     else this2
   }

--- a/slick/src/main/scala/slick/ast/Insert.scala
+++ b/slick/src/main/scala/slick/ast/Insert.scala
@@ -1,25 +1,27 @@
 package slick.ast
 
+import slick.util.ConstArray
+
 /** Represents an Insert operation. */
 final case class Insert(tableSym: TermSymbol, table: Node, linear: Node) extends BinaryNode with DefNode {
   type Self = Insert
   def left = table
   def right = linear
   override def childNames = Vector("table "+tableSym, "linear")
-  def generators = Vector((tableSym, table))
+  def generators = ConstArray((tableSym, table))
   def rebuild(l: Node, r: Node) = copy(table = l, linear = r)
-  def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(tableSym = gen(0))
+  def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(tableSym = gen(0))
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val table2 = table.infer(scope, typeChildren)
     val lin2 = linear.infer(scope + (tableSym -> table2.nodeType), typeChildren)
-    withChildren(Vector(table2, lin2)) :@ (if(!hasType) lin2.nodeType else nodeType)
+    withChildren(ConstArray[Node](table2, lin2)) :@ (if(!hasType) lin2.nodeType else nodeType)
   }
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
 }
 
 /** A column in an Insert operation. */
-final case class InsertColumn(children: IndexedSeq[Node], fs: FieldSymbol, buildType: Type) extends Node with SimplyTypedNode {
+final case class InsertColumn(children: ConstArray[Node], fs: FieldSymbol, buildType: Type) extends Node with SimplyTypedNode {
   type Self = InsertColumn
-  protected[this] def rebuild(ch: IndexedSeq[Node]) = copy(children = ch)
+  protected[this] def rebuild(ch: ConstArray[Node]) = copy(children = ch)
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = fs.toString)
 }

--- a/slick/src/main/scala/slick/ast/Library.scala
+++ b/slick/src/main/scala/slick/ast/Library.scala
@@ -1,5 +1,7 @@
 package slick.ast
 
+import slick.util.ConstArray
+
 /**
  * The standard library for query operators.
  */
@@ -104,15 +106,15 @@ class FunctionSymbol(val name: String) extends TermSymbol {
 
   /** Match an Apply of this Symbol */
   def unapplySeq(n: Node) = n match {
-    case Apply(sym, ch) if sym eq this => Some(ch)
+    case Apply(sym, ch) if sym eq this => Some(ch.toSeq)
     case _ => None
   }
 
   /** Create a typed Apply of this Symbol */
-  def typed(tpe: Type, ch: Node*): Apply = Apply(this, ch.toIndexedSeq)(tpe)
+  def typed(tpe: Type, ch: Node*): Apply = Apply(this, ConstArray.from(ch))(tpe)
 
   /** Create a typed Apply of this Symbol */
-  def typed[T : ScalaBaseType](ch: Node*): Apply = Apply(this, ch.toIndexedSeq)(implicitly[ScalaBaseType[T]])
+  def typed[T : ScalaBaseType](ch: Node*): Apply = Apply(this, ConstArray.from(ch))(implicitly[ScalaBaseType[T]])
 
   override def toString = "Function "+name
 }

--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable.ListBuffer
 import scala.language.existentials
 import scala.reflect.ClassTag
 import slick.SlickException
-import slick.util.{Logging, Dumpable, DumpInfo, GlobalConfig}
+import slick.util.{Logging, Dumpable, DumpInfo, GlobalConfig, ConstArray}
 import Util._
 import TypeUtil._
 
@@ -17,7 +17,7 @@ trait Node extends Dumpable {
   private var _type: Type = UnassignedType
 
   /** All child nodes of this node. Must be implemented by subclasses. */
-  def children: IndexedSeq[Node]
+  def children: ConstArray[Node]
 
   /** Names for the child nodes to show in AST dumps. Defaults to a numbered sequence starting at 0
     * but can be overridden by subclasses to produce more suitable names. */
@@ -25,11 +25,14 @@ trait Node extends Dumpable {
 
   /** Rebuild this node with a new list of children. Implementations of this method must not reuse
     * the current node. This method always returns a fresh copy. */
-  protected[this] def rebuild(ch: IndexedSeq[Node]): Self
+  protected[this] def rebuild(ch: ConstArray[Node]): Self
+
+  /** Build a copy of this node with the current children. */
+  protected[this] def buildCopy: Self = rebuild(children)
 
   /** Rebuild this node with new child nodes unless all children are identical to the current ones,
     * in which case this node is returned. */
-  final def withChildren(ch2: IndexedSeq[Node]): Self = {
+  final def withChildren(ch2: ConstArray[Node]): Self = {
     val ch = children
     val len = ch.length
     var i = 0
@@ -44,8 +47,9 @@ trait Node extends Dumpable {
     * children. If all new children are identical to the old ones, this node is returned. If
     * ``keepType`` is true, the type of this node is kept even when the children have changed. */
   def mapChildren(f: Node => Node, keepType: Boolean = false): Self = {
-    val ch2 = mapOrNull(children)(f)
-    val n: Self = if(ch2 eq null) this else rebuild(ch2)
+    val ch = children
+    val ch2 = ch.endoMap(f)
+    val n: Self = if(ch2 eq ch) this else rebuild(ch2)
     if(!keepType || (_type eq UnassignedType)) n else (n :@ _type).asInstanceOf[Self]
   }
 
@@ -63,11 +67,11 @@ trait Node extends Dumpable {
 
   /** Return this Node with no Type assigned (if it has not yet been observed) or an untyped copy. */
   final def untyped: Self =
-    if(seenType || _type != UnassignedType) rebuild(children) else this
+    if(seenType || _type != UnassignedType) buildCopy else this
 
   /** Return this Node with a Type assigned (if no other type has been seen for it yet) or a typed copy. */
   final def :@ (newType: Type): Self = {
-    val n: Self = if(seenType && newType != _type) rebuild(children) else this
+    val n: Self = if(seenType && newType != _type) buildCopy else this
     n._type = newType
     n
   }
@@ -94,7 +98,7 @@ trait Node extends Dumpable {
     val ch = this match {
       // Omit path details unless dumpPaths is set
       case Path(l @ (_ :: _ :: _)) if !GlobalConfig.dumpPaths => Vector.empty
-      case _ => childNames.zip(children).toVector
+      case _ => childNames.zip(children.toSeq).toVector
     }
     DumpInfo(objName, mainInfo, if(t != UnassignedType) ": " + t.toString else "", ch)
   }
@@ -116,10 +120,10 @@ trait SimplyTypedNode extends Node {
 }
 
 /** An expression that represents a conjunction of expressions. */
-final case class ProductNode(children: IndexedSeq[Node]) extends SimplyTypedNode {
+final case class ProductNode(children: ConstArray[Node]) extends SimplyTypedNode {
   type Self = ProductNode
   override def getDumpInfo = super.getDumpInfo.copy(name = "ProductNode", mainInfo = "")
-  protected[this] def rebuild(ch: IndexedSeq[Node]): Self = copy(ch)
+  protected[this] def rebuild(ch: ConstArray[Node]): Self = copy(ch)
   override def childNames: Iterable[String] = Stream.from(1).map(_.toString)
   protected def buildType: Type = ProductType(children.map { ch =>
     val t = ch.nodeType
@@ -127,10 +131,10 @@ final case class ProductNode(children: IndexedSeq[Node]) extends SimplyTypedNode
     t
   })
   def flatten: ProductNode = {
-    def f(n: Node): IndexedSeq[Node] = n match {
+    def f(n: Node): ConstArray[Node] = n match {
       case ProductNode(ns) => ns.flatMap(f)
       case StructNode(els) => els.flatMap(el => f(el._2))
-      case n => IndexedSeq(n)
+      case n => ConstArray(n)
     }
     ProductNode(f(this))
   }
@@ -138,16 +142,16 @@ final case class ProductNode(children: IndexedSeq[Node]) extends SimplyTypedNode
 
 /** An expression that represents a structure, i.e. a conjunction where the
   * individual components have Symbols associated with them. */
-final case class StructNode(elements: IndexedSeq[(TermSymbol, Node)]) extends SimplyTypedNode with DefNode {
+final case class StructNode(elements: ConstArray[(TermSymbol, Node)]) extends SimplyTypedNode with DefNode {
   type Self = StructNode
   override def getDumpInfo = super.getDumpInfo.copy(name = "StructNode", mainInfo = "")
-  override def childNames = elements.map(_._1.toString)
+  override def childNames = elements.map(_._1.toString).toSeq
   val children = elements.map(_._2)
-  override protected[this] def rebuild(ch: IndexedSeq[Node]) =
+  override protected[this] def rebuild(ch: ConstArray[Node]) =
     new StructNode(elements.zip(ch).map{ case ((s,_),n) => (s,n) })
   def generators = elements
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]): Node =
-    copy(elements = (elements, gen).zipped.map((e, s) => (s, e._2)))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]): Node =
+    copy(elements = elements.zip(gen).map { case (e, s) => (s, e._2) })
 
   override protected def buildType: Type = StructType(elements.map { case (s, n) =>
     val t = n.nodeType
@@ -185,8 +189,8 @@ object LiteralNode {
 trait BinaryNode extends Node {
   def left: Node
   def right: Node
-  lazy val children = Vector(left, right)
-  protected[this] final def rebuild(ch: IndexedSeq[Node]): Self = rebuild(ch(0), ch(1))
+  lazy val children = ConstArray(left, right)
+  protected[this] final def rebuild(ch: ConstArray[Node]): Self = rebuild(ch(0), ch(1))
   protected[this] def rebuild(left: Node, right: Node): Self
   override final def mapChildren(f: Node => Node, keepType: Boolean = false): Self = {
     val l = left
@@ -197,12 +201,13 @@ trait BinaryNode extends Node {
     val _type = peekType
     if(!keepType || (_type eq UnassignedType)) n else (n :@ _type).asInstanceOf[Self]
   }
+  override final protected[this] def buildCopy: Self = rebuild(left, right)
 }
 
 trait UnaryNode extends Node {
   def child: Node
-  lazy val children = Vector(child)
-  protected[this] final def rebuild(ch: IndexedSeq[Node]): Self = rebuild(ch(0))
+  lazy val children = ConstArray(child)
+  protected[this] final def rebuild(ch: ConstArray[Node]): Self = rebuild(ch(0))
   protected[this] def rebuild(child: Node): Self
   override final def mapChildren(f: Node => Node, keepType: Boolean = false): Self = {
     val ch = child
@@ -211,13 +216,15 @@ trait UnaryNode extends Node {
     val _type = peekType
     if(!keepType || (_type eq UnassignedType)) n else (n :@ _type).asInstanceOf[Self]
   }
+  override final protected[this] def buildCopy: Self = rebuild(child)
 }
 
 trait NullaryNode extends Node {
-  val children = Vector.empty
-  protected[this] final def rebuild(ch: IndexedSeq[Node]): Self = rebuild
+  def children = ConstArray.empty
+  protected[this] final def rebuild(ch: ConstArray[Node]): Self = rebuild
   protected[this] def rebuild: Self
   override final def mapChildren(f: Node => Node, keepType: Boolean = false): Self = this
+  override final protected[this] def buildCopy: Self = rebuild
 }
 
 /** An expression that represents a plain value lifted into a Query. */
@@ -263,7 +270,7 @@ object Subquery {
 abstract class FilteredQuery extends Node {
   protected[this] def generator: TermSymbol
   def from: Node
-  def generators = Vector((generator, from))
+  def generators = ConstArray((generator, from))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = this match {
     case p: Product => p.productIterator.filterNot(n => n.isInstanceOf[Node] || n.isInstanceOf[Symbol]).mkString(", ")
     case _ => ""
@@ -272,7 +279,7 @@ abstract class FilteredQuery extends Node {
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val from2 = from.infer(scope, typeChildren)
     val genScope = scope + (generator -> from2.nodeType.asCollectionType.elementType)
-    val ch2: IndexedSeq[Node] = children.map { ch =>
+    val ch2: ConstArray[Node] = children.map[Node] { ch =>
       if(ch eq from) from2 else ch.infer(genScope, typeChildren)
     }
     (withChildren(ch2) :@ (if(!hasType) ch2.head.nodeType else nodeType)).asInstanceOf[Self]
@@ -286,7 +293,7 @@ final case class Filter(generator: TermSymbol, from: Node, where: Node) extends 
   def right = where
   override def childNames = Seq("from "+generator, "where")
   protected[this] def rebuild(left: Node, right: Node) = copy(from = left, where = right)
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(generator = gen(0))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(generator = gen(0))
 }
 
 object Filter {
@@ -297,13 +304,13 @@ object Filter {
 }
 
 /** A .sortBy call of type (CollectionType(c, t), _) => CollectionType(c, t). */
-final case class SortBy(generator: TermSymbol, from: Node, by: IndexedSeq[(Node, Ordering)]) extends FilteredQuery with DefNode {
+final case class SortBy(generator: TermSymbol, from: Node, by: ConstArray[(Node, Ordering)]) extends FilteredQuery with DefNode {
   type Self = SortBy
   lazy val children = from +: by.map(_._1)
-  protected[this] def rebuild(ch: IndexedSeq[Node]) =
+  protected[this] def rebuild(ch: ConstArray[Node]) =
     copy(from = ch(0), by = by.zip(ch.tail).map{ case ((_, o), n) => (n, o) })
-  override def childNames = ("from "+generator) +: by.zipWithIndex.map("by" + _._2)
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(generator = gen(0))
+  override def childNames = ("from "+generator) +: by.zipWithIndex.map("by" + _._2).toSeq
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(generator = gen(0))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = by.map(_._2).mkString(", "))
 }
 
@@ -334,16 +341,16 @@ final case class GroupBy(fromGen: TermSymbol, from: Node, by: Node, identity: Ty
   def right = by
   override def childNames = Seq("from "+fromGen, "by")
   protected[this] def rebuild(left: Node, right: Node) = copy(from = left, by = right)
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(fromGen = gen(0))
-  def generators = Vector((fromGen, from))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(fromGen = gen(0))
+  def generators = ConstArray((fromGen, from))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = identity.toString)
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val from2 = from.infer(scope, typeChildren)
     val from2Type = from2.nodeType.asCollectionType
     val by2 = by.infer(scope + (fromGen -> from2Type.elementType), typeChildren)
-    withChildren(Vector(from2, by2)) :@ (
+    withChildren(ConstArray[Node](from2, by2)) :@ (
       if(!hasType)
-        CollectionType(from2Type.cons, ProductType(IndexedSeq(NominalType(identity, by2.nodeType), CollectionType(TypedCollectionTypeConstructor.seq, from2Type.elementType))))
+        CollectionType(from2Type.cons, ProductType(ConstArray(NominalType(identity, by2.nodeType), CollectionType(TypedCollectionTypeConstructor.seq, from2Type.elementType))))
       else nodeType)
   }
 }
@@ -378,12 +385,12 @@ final case class Drop(from: Node, count: Node) extends FilteredQuery with Binary
   * (CollectionType(c, t), CollectionType(_, u)) => CollecionType(c, (Option(t), Option(u))). */
 final case class Join(leftGen: TermSymbol, rightGen: TermSymbol, left: Node, right: Node, jt: JoinType, on: Node) extends DefNode {
   type Self = Join
-  lazy val children = IndexedSeq(left, right, on)
-  protected[this] def rebuild(ch: IndexedSeq[Node]) = copy(left = ch(0), right = ch(1), on = ch(2))
+  lazy val children = ConstArray(left, right, on)
+  protected[this] def rebuild(ch: ConstArray[Node]) = copy(left = ch(0), right = ch(1), on = ch(2))
   override def childNames = Seq("left "+leftGen, "right "+rightGen, "on")
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = jt.toString)
-  def generators = Vector((leftGen, left), (rightGen, right))
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) =
+  def generators = ConstArray((leftGen, left), (rightGen, right))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) =
     copy(leftGen = gen(0), rightGen = gen(1))
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val left2 = left.infer(scope, typeChildren)
@@ -397,8 +404,8 @@ final case class Join(leftGen: TermSymbol, rightGen: TermSymbol, left: Node, rig
       case JoinType.OuterOption => (OptionType(left2Type.elementType), OptionType(right2Type.elementType))
       case _ => (left2Type.elementType, right2Type.elementType)
     }
-    withChildren(Vector(left2, right2, on2)) :@ (
-      if(!hasType) CollectionType(left2Type.cons, ProductType(IndexedSeq(joinedLeftType, joinedRightType)))
+    withChildren(ConstArray[Node](left2, right2, on2)) :@ (
+      if(!hasType) CollectionType(left2Type.cons, ProductType(ConstArray(joinedLeftType, joinedRightType)))
       else nodeType)
   }
 }
@@ -421,9 +428,9 @@ final case class Bind(generator: TermSymbol, from: Node, select: Node) extends B
   def right = select
   override def childNames = Seq("from "+generator, "select")
   protected[this] def rebuild(left: Node, right: Node) = copy(from = left, select = right)
-  def generators = Vector((generator, from))
+  def generators = ConstArray((generator, from))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(generator = gen(0))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(generator = gen(0))
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val from2 = from.infer(scope, typeChildren)
     val from2Type = from2.nodeType.asCollectionType
@@ -444,13 +451,13 @@ final case class Aggregate(sym: TermSymbol, from: Node, select: Node) extends Bi
   def right = select
   override def childNames = Seq("from "+sym, "select")
   protected[this] def rebuild(left: Node, right: Node) = copy(from = left, select = right)
-  def generators = Vector((sym, from))
+  def generators = ConstArray((sym, from))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(sym = gen(0))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(sym = gen(0))
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val from2 :@ CollectionType(_, el) = from.infer(scope, typeChildren)
     val select2 = select.infer(scope + (sym -> el), typeChildren)
-    withChildren(Vector(from2, select2)) :@ (if(!hasType) select2.nodeType else nodeType)
+    withChildren(ConstArray[Node](from2, select2)) :@ (if(!hasType) select2.nodeType else nodeType)
   }
 }
 
@@ -461,13 +468,13 @@ final case class TableExpansion(generator: TermSymbol, table: Node, columns: Nod
   def right = columns
   override def childNames = Seq("table "+generator, "columns")
   protected[this] def rebuild(left: Node, right: Node) = copy(table = left, columns = right)
-  def generators = Vector((generator, table))
+  def generators = ConstArray((generator, table))
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(generator = gen(0))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(generator = gen(0))
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     val table2 = table.infer(scope, typeChildren)
     val columns2 = columns.infer(scope + (generator -> table2.nodeType.asCollectionType.elementType), typeChildren)
-    withChildren(Vector(table2, columns2)) :@ (if(!hasType) table2.nodeType else nodeType)
+    withChildren(ConstArray[Node](table2, columns2)) :@ (if(!hasType) table2.nodeType else nodeType)
   }
 }
 
@@ -497,9 +504,9 @@ final case class Select(in: Node, field: TermSymbol) extends PathElement with Un
 }
 
 /** A function call expression. */
-final case class Apply(sym: TermSymbol, children: IndexedSeq[Node])(val buildType: Type) extends SimplyTypedNode {
+final case class Apply(sym: TermSymbol, children: ConstArray[Node])(val buildType: Type) extends SimplyTypedNode {
   type Self = Apply
-  protected[this] def rebuild(ch: IndexedSeq[slick.ast.Node]) = copy(children = ch)(buildType)
+  protected[this] def rebuild(ch: ConstArray[slick.ast.Node]) = copy(children = ch)(buildType)
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = sym.toString)
 }
 
@@ -598,20 +605,20 @@ final case class RangeFrom(start: Long = 1L) extends NullaryNode with SimplyType
 
 /** A conditional expression; The clauses should be: `(if then)+ else`.
   * The result type is taken from the first `then` (i.e. the second clause). */
-final case class IfThenElse(clauses: IndexedSeq[Node]) extends SimplyTypedNode {
+final case class IfThenElse(clauses: ConstArray[Node]) extends SimplyTypedNode {
   type Self = IfThenElse
-  val children = clauses
+  def children = clauses
   override def childNames = (0 until clauses.length-1).map { i => if(i%2 == 0) "if" else "then" } :+ "else"
-  protected[this] def rebuild(ch: IndexedSeq[Node]): Self = copy(clauses = ch)
+  protected[this] def rebuild(ch: ConstArray[Node]): Self = copy(clauses = ch)
   protected def buildType = clauses(1).nodeType
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
   private[this] def mapClauses(f: Node => Node, keepType: Boolean, pred: Int => Boolean): IfThenElse = {
     var equal = true
-    val mapped = clauses.toIterator.zipWithIndex.map { case (n, i) =>
+    val mapped = clauses.zipWithIndex.map { case (n, i) =>
       val n2 = if(pred(i)) f(n) else n
       if(n2 ne n) equal = false
       n2
-    }.toVector
+    }
     val this2 = if(equal) this else rebuild(mapped)
     if(peekType == UnassignedType || !keepType) this2 else this2 :@ peekType
   }
@@ -639,23 +646,23 @@ final case class IfThenElse(clauses: IndexedSeq[Node]) extends SimplyTypedNode {
 final case class OptionApply(child: Node) extends UnaryNode with SimplyTypedNode {
   type Self = OptionApply
   protected[this] def rebuild(ch: Node) = copy(child = ch)
-  protected def buildType = OptionType(children.head.nodeType)
+  protected def buildType = OptionType(child.nodeType)
 }
 
 /** The catamorphism of OptionType. */
 final case class OptionFold(from: Node, ifEmpty: Node, map: Node, gen: TermSymbol) extends DefNode {
   type Self = OptionFold
-  def children = IndexedSeq(from, ifEmpty, map)
-  def generators = IndexedSeq((gen, from))
-  override def childNames = IndexedSeq("from "+gen, "ifEmpty", "map")
-  protected[this] def rebuild(ch: IndexedSeq[Node]) = copy(ch(0), ch(1), ch(2))
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]) = copy(gen = gen(0))
+  lazy val children = ConstArray(from, ifEmpty, map)
+  def generators = ConstArray((gen, from))
+  override def childNames = Vector("from "+gen, "ifEmpty", "map")
+  protected[this] def rebuild(ch: ConstArray[Node]) = copy(ch(0), ch(1), ch(2))
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(gen = gen(0))
   protected[this] def withInferredType(scope: Type.Scope, typeChildren: Boolean) = {
     val from2 = from.infer(scope, typeChildren)
     val ifEmpty2 = ifEmpty.infer(scope, typeChildren)
     val genScope = scope + (gen -> from2.nodeType.structural.asOptionType.elementType)
     val map2 = map.infer(genScope, typeChildren)
-    withChildren(IndexedSeq(from2, ifEmpty2, map2)) :@ (if(!hasType) map2.nodeType else nodeType)
+    withChildren(ConstArray[Node](from2, ifEmpty2, map2)) :@ (if(!hasType) map2.nodeType else nodeType)
   }
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
 }
@@ -663,7 +670,7 @@ final case class OptionFold(from: Node, ifEmpty: Node, map: Node, gen: TermSymbo
 final case class GetOrElse(child: Node, default: () => Any) extends UnaryNode with SimplyTypedNode {
   type Self = GetOrElse
   protected[this] def rebuild(ch: Node) = copy(child = ch)
-  protected def buildType = children.head.nodeType.structural.asOptionType.elementType
+  protected def buildType = child.nodeType.structural.asOptionType.elementType
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
 }
 

--- a/slick/src/main/scala/slick/ast/Symbol.scala
+++ b/slick/src/main/scala/slick/ast/Symbol.scala
@@ -1,6 +1,7 @@
 package slick.ast
 
 import Util._
+import slick.util.ConstArray
 import scala.collection.mutable.HashMap
 import scala.util.DynamicVariable
 
@@ -49,19 +50,20 @@ class AnonSymbol extends TermSymbol {
 
 /** A Node which introduces Symbols. */
 trait DefNode extends Node {
-  def generators: IndexedSeq[(TermSymbol, Node)]
-  protected[this] def rebuildWithSymbols(gen: IndexedSeq[TermSymbol]): Node
+  def generators: ConstArray[(TermSymbol, Node)]
+  protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]): Node
 
   final def mapScopedChildren(f: (Option[TermSymbol], Node) => Node): Self with DefNode = {
     val all = (generators.iterator.map{ case (sym, n) => (Some(sym), n) } ++
-      children.drop(generators.length).iterator.map{ n => (None, n) }).toIndexedSeq
+      children.iterator.drop(generators.length).map{ n => (None, n) }).toIndexedSeq
     val mapped = all.map(f.tupled)
-    if((all, mapped).zipped.map((a, m) => a._2 eq m).contains(false)) rebuild(mapped).asInstanceOf[Self with DefNode]
+    if((all, mapped).zipped.map((a, m) => a._2 eq m).contains(false)) rebuild(ConstArray.from(mapped)).asInstanceOf[Self with DefNode]
     else this
   }
   final def mapSymbols(f: TermSymbol => TermSymbol): Node = {
-    val s2 = mapOrNull(generators.map(_._1))(f)
-    if(s2 eq null) this else rebuildWithSymbols(s2)
+    val s = generators.map(_._1)
+    val s2 = s.endoMap(f)
+    if(s2 eq s) this else rebuildWithSymbols(s2)
   }
 }
 

--- a/slick/src/main/scala/slick/ast/Util.scala
+++ b/slick/src/main/scala/slick/ast/Util.scala
@@ -1,7 +1,7 @@
 package slick.ast
 
 import slick.ast.TypeUtil.:@
-import slick.util.{ConstArray, ConstArrayBuilder}
+import slick.util.ConstArray
 
 import scala.collection
 import scala.collection.mutable
@@ -29,14 +29,17 @@ final class NodeOps(val tree: Node) extends AnyVal {
   import Util._
   import NodeOps._
 
-  @inline def collect[T](pf: PartialFunction[Node, T], stopOnMatch: Boolean = false): ConstArray[T] = {
-    val b = new ConstArrayBuilder[T]
-    def f(n: Node): Unit = pf.andThen[Unit] { case t =>
-      b += t
-      if(!stopOnMatch) n.children.foreach(f)
-    }.orElse[Node, Unit]{ case _ =>
-      n.children.foreach(f)
-    }.apply(n)
+  def collect[T](pf: PartialFunction[Node, T], stopOnMatch: Boolean = false): ConstArray[T] = {
+    val retNull: (Node => T) = (_ => null.asInstanceOf[T])
+    val b = ConstArray.newBuilder[T]()
+    def f(n: Node): Unit = {
+      val r = pf.applyOrElse(n, retNull)
+      if(r.asInstanceOf[AnyRef] ne null) {
+        b += r
+        if(!stopOnMatch) n.childrenForeach(f)
+      }
+      else n.childrenForeach(f)
+    }
     f(tree)
     b.result
   }
@@ -44,8 +47,15 @@ final class NodeOps(val tree: Node) extends AnyVal {
   def collectAll[T](pf: PartialFunction[Node, ConstArray[T]]): ConstArray[T] = collect[ConstArray[T]](pf).flatten
 
   def replace(f: PartialFunction[Node, Node], keepType: Boolean = false, bottomUp: Boolean = false): Node = {
-    def g(n: Node): Node = n.mapChildren(_.replace(f, keepType, bottomUp), keepType)
-    if(bottomUp) f.applyOrElse(g(tree), identity[Node]) else f.applyOrElse(tree, g)
+    if(bottomUp) {
+      def r(n: Node): Node = f.applyOrElse(g(n), identity[Node])
+      def g(n: Node): Node = n.mapChildren(r, keepType)
+      r(tree)
+    } else {
+      def r(n: Node): Node = f.applyOrElse(n, g)
+      def g(n: Node): Node = n.mapChildren(r, keepType)
+      r(tree)
+    }
   }
 
   /** Replace nodes in a bottom-up traversal while invalidating TypeSymbols. Any later references
@@ -53,6 +63,7 @@ final class NodeOps(val tree: Node) extends AnyVal {
     * retyped afterwards to get the correct new TypeSymbols in. The PartialFunction may return
     * `null`, which is considered the same as not matching. */
   def replaceInvalidate(f: PartialFunction[Node, (Node, TypeSymbol)]): Node = {
+    import TypeUtil.typeToTypeUtil
     val invalid = mutable.HashSet.empty[TypeSymbol]
     val default = (_: Node) => null
     def tr(n: Node): Node = {
@@ -62,7 +73,7 @@ final class NodeOps(val tree: Node) extends AnyVal {
         invalid += res._2
         res._1
       } else n2 match {
-        case n2: PathElement if containsTS(n2.nodeType, invalid) => n2.untyped
+        case n2: PathElement if n2.nodeType.containsSymbol(invalid) => n2.untyped
         case _ => n2
       }
     }
@@ -70,8 +81,9 @@ final class NodeOps(val tree: Node) extends AnyVal {
   }
 
   def untypeReferences(invalid: Set[TypeSymbol]): Node = {
+    import TypeUtil.typeToTypeUtil
     if(invalid.isEmpty) tree else replace({
-      case n: PathElement if containsTS(n.nodeType, invalid) => n.untyped
+      case n: PathElement if n.nodeType.containsSymbol(invalid) => n.untyped
     }, bottomUp = true)
   }
 
@@ -88,15 +100,5 @@ final class NodeOps(val tree: Node) extends AnyVal {
     case (s: FieldSymbol, StructNode(ch)) => ch.find{ case (s2,_) => s == s2 }.get._2
     case (s: ElementSymbol, ProductNode(ch)) => ch(s.idx-1)
     case (s, n) => Select(n, s)
-  }
-}
-
-private object NodeOps {
-  private def containsTS(t: Type, invalid: collection.Set[TypeSymbol]): Boolean = {
-    if(invalid.isEmpty) false else t match {
-      case NominalType(ts, exp) => invalid.contains(ts) || containsTS(exp, invalid)
-      case t: AtomicType => false
-      case t => t.children.exists(ch => containsTS(ch, invalid))
-    }
   }
 }

--- a/slick/src/main/scala/slick/compiler/AssignUniqueSymbols.scala
+++ b/slick/src/main/scala/slick/compiler/AssignUniqueSymbols.scala
@@ -53,6 +53,7 @@ class AssignUniqueSymbols extends Phase {
 
   def hasNominalType(t: Type): Boolean = t match {
     case _: NominalType => true
+    case _: AtomicType => false
     case _ => t.children.exists(hasNominalType)
   }
 }

--- a/slick/src/main/scala/slick/compiler/CreateResultSetMapping.scala
+++ b/slick/src/main/scala/slick/compiler/CreateResultSetMapping.scala
@@ -4,6 +4,7 @@ import slick.SlickException
 import slick.ast._
 import Util._
 import TypeUtil._
+import slick.util.ConstArray
 
 /** Create a ResultSetMapping root node, ensure that the top-level server-side node returns a
   * collection, and hoist client-side type conversions into the ResultSetMapping. The original
@@ -36,7 +37,7 @@ class CreateResultSetMapping extends Phase {
 
   /** Create a structured return value for the client side, based on the
     * result type (which may contain MappedTypes). */
-  def createResult(ref: Ref, tpe: Type, syms: IndexedSeq[TermSymbol]): Node = {
+  def createResult(ref: Ref, tpe: Type, syms: ConstArray[TermSymbol]): Node = {
     var curIdx = 0
     def f(tpe: Type): Node = {
       logger.debug("Creating mapping from "+tpe)

--- a/slick/src/main/scala/slick/compiler/CreateResultSetMapping.scala
+++ b/slick/src/main/scala/slick/compiler/CreateResultSetMapping.scala
@@ -48,7 +48,7 @@ class CreateResultSetMapping extends Phase {
           ProductNode(ch.map { case (_, t) => f(t) })
         case t: MappedScalaType =>
           TypeMapping(f(t.baseType), t.mapper, t.classTag)
-        case o @ OptionType(Type.Structural(el)) if el.children.nonEmpty =>
+        case o @ OptionType(Type.Structural(el)) if !el.isInstanceOf[AtomicType] =>
           val discriminator = Select(ref, syms(curIdx)).infer()
           curIdx += 1
           val data = f(o.elementType)

--- a/slick/src/main/scala/slick/compiler/EmulateOuterJoins.scala
+++ b/slick/src/main/scala/slick/compiler/EmulateOuterJoins.scala
@@ -3,6 +3,7 @@ package slick.compiler
 import slick.ast._
 import Util._
 import TypeUtil._
+import slick.util.ConstArray
 
 /** An optional phase which rewrites outer joins into more commonly supported
   * operations for use on databases that lack outer join support.
@@ -32,14 +33,14 @@ class EmulateOuterJoins(val useLeftJoin: Boolean, val useRightJoin: Boolean) ext
           Filter(lgen2, left,
             Library.Not.typed(on.nodeType, Library.Exists.typed(on.nodeType, Filter(rgen2, right, on2)))
           ),
-          Pure(ProductNode(Vector(Ref(bgen), nullStructFor(right.nodeType.structural.asCollectionType.elementType))))
+          Pure(ProductNode(ConstArray(Ref(bgen), nullStructFor(right.nodeType.structural.asCollectionType.elementType))))
         ), true).infer())
     case Join(leftGen, rightGen, left, right, JoinType.Right, on) if !useRightJoin =>
       // as rightJoin bs on e => bs leftJoin as on { (b, a) => e(a, b) } map { case (b, a) => (a, b) }
       val bgen = new AnonSymbol
       convert(Bind(bgen,
         Join(rightGen, leftGen, right, left, JoinType.Left, on),
-        Pure(ProductNode(Vector(Select(Ref(bgen), ElementSymbol(2)), Select(Ref(bgen), ElementSymbol(1)))))
+        Pure(ProductNode(ConstArray(Select(Ref(bgen), ElementSymbol(2)), Select(Ref(bgen), ElementSymbol(1)))))
       ).infer())
     case Join(leftGen, rightGen, left, right, JoinType.Outer, on) =>
       // as fullJoin bs on e => (as leftJoin bs on e) unionAll bs.filter(b => !exists(as.filter(a => e(a, b)))).map(b => (nulls, b))
@@ -53,7 +54,7 @@ class EmulateOuterJoins(val useLeftJoin: Boolean, val useRightJoin: Boolean) ext
           Filter(rgen2, right,
             Library.Not.typed(on.nodeType, Library.Exists.typed(on.nodeType, Filter(lgen2, left, on2)))
           ),
-          Pure(ProductNode(Vector(nullStructFor(left.nodeType.structural.asCollectionType.elementType), Ref(bgen))))
+          Pure(ProductNode(ConstArray(nullStructFor(left.nodeType.structural.asCollectionType.elementType), Ref(bgen))))
         ), true).infer())
     case n => n.mapChildren(convert, true)
   }

--- a/slick/src/main/scala/slick/compiler/ExpandConditionals.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandConditionals.scala
@@ -16,7 +16,7 @@ class ExpandConditionals extends Phase {
 
   def expand(n: Node): Node = {
     val invalid = mutable.HashSet.empty[TypeSymbol]
-    def invalidate(n: Node): Unit = invalid ++= n.nodeType.collect { case NominalType(ts, _) => ts }
+    def invalidate(n: Node): Unit = invalid ++= n.nodeType.collect { case NominalType(ts, _) => ts }.toSeq
 
     def tr(n: Node): Node = n.mapChildren(tr, keepType = true) match {
       // Expand multi-column SilentCasts

--- a/slick/src/main/scala/slick/compiler/ExpandConditionals.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandConditionals.scala
@@ -3,6 +3,7 @@ package slick.compiler
 import slick.ast._
 import Util._
 import TypeUtil._
+import slick.util.{ConstArray, ConstArrayOp}
 
 import scala.collection.mutable
 
@@ -37,7 +38,7 @@ class ExpandConditionals extends Phase {
 
       // Expand multi-column IfThenElse
       case (cond @ IfThenElse(_)) :@ Type.Structural(ProductType(chTypes)) =>
-        val ch = (1 to chTypes.length).map { idx =>
+        val ch = ConstArrayOp.from(1 to chTypes.length).map { idx =>
           val sym = ElementSymbol(idx)
           tr(cond.mapResultClauses(n => n.select(sym)).infer())
         }
@@ -49,7 +50,7 @@ class ExpandConditionals extends Phase {
         StructNode(ch).infer()
 
       // Optimize null-propagating single-column IfThenElse
-      case IfThenElse(Seq(Library.==(r, LiteralNode(null)), Library.SilentCast(LiteralNode(None)), c @ Library.SilentCast(r2))) if r == r2 => c
+      case IfThenElse(ConstArray(Library.==(r, LiteralNode(null)), Library.SilentCast(LiteralNode(None)), c @ Library.SilentCast(r2))) if r == r2 => c
 
       // Fix Untyped nulls in else clauses
       case cond @ IfThenElse(clauses) if (clauses.last match { case LiteralNode(None) :@ OptionType(ScalaBaseType.nullType) => true; case _ => false }) =>

--- a/slick/src/main/scala/slick/compiler/ExpandRecords.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandRecords.scala
@@ -12,9 +12,9 @@ class ExpandRecords extends Phase {
 
   def expandPath(n: Node): Node = n.nodeType.structural match {
     case StructType(ch) =>
-      StructNode(ch.map { case (s, t) => (s, expandPath(n.select(s) :@ t)) }(collection.breakOut))
+      StructNode(ch.map { case (s, t) => (s, expandPath(n.select(s) :@ t)) })
     case p: ProductType =>
-      ProductNode(p.numberedElements.map { case (s, t) => expandPath(n.select(s) :@ t) }.toVector)
+      ProductNode(p.elements.zipWithIndex.map { case (t, i) => expandPath(n.select(new ElementSymbol(i+1)) :@ t) })
     case t => n.asInstanceOf[PathElement].untypedPath
   }
 }

--- a/slick/src/main/scala/slick/compiler/ExpandSums.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandSums.scala
@@ -1,5 +1,6 @@
 package slick.compiler
 
+import slick.util.ConstArray
 import slick.{SlickTreeException, SlickException}
 import slick.ast._
 import Util._
@@ -27,8 +28,8 @@ class ExpandSums extends Phase {
     val tree2 = tree.mapChildren(n => tr(n, discCandidates), keepType = true)
     val tree3 = tree2 match {
       // Expand multi-column null values in ELSE branches (used by Rep[Option].filter) with correct type
-      case IfThenElse(IndexedSeq(pred, then1 :@ tpe, LiteralNode(None) :@ OptionType(ScalaBaseType.nullType))) =>
-        IfThenElse(Vector(pred, then1, buildMultiColumnNone(tpe))) :@ tpe
+      case IfThenElse(ConstArray(pred, then1 :@ tpe, LiteralNode(None) :@ OptionType(ScalaBaseType.nullType))) =>
+        IfThenElse(ConstArray(pred, then1, buildMultiColumnNone(tpe))) :@ tpe
 
       // Primitive OptionFold representing GetOrElse -> translate to GetOrElse
       case OptionFold(from :@ OptionType.Primitive(_), LiteralNode(v), Ref(s), gen) if s == gen =>
@@ -45,7 +46,7 @@ class ExpandSums extends Phase {
               case r @ Ref(s) if s == gen => silentCast(r.nodeType, from)
             }, keepType = true)
             val ifEmpty2 = silentCast(ifDefined.nodeType.structural, ifEmpty)
-            IfThenElse(Vector(pred, ifEmpty2, ifDefined))
+            IfThenElse(ConstArray(pred, ifEmpty2, ifDefined))
         }
         n2.infer()
 
@@ -61,7 +62,7 @@ class ExpandSums extends Phase {
               case r @ Ref(s) if s == gen => silentCast(r.nodeType, from.select(ElementSymbol(2)).infer())
             }, keepType = true)
             val ifEmpty2 = silentCast(ifDefined.nodeType.structural, ifEmpty)
-            if(left == Disc1) ifDefined else IfThenElse(IndexedSeq(pred, ifDefined, ifEmpty2))
+            if(left == Disc1) ifDefined else IfThenElse(ConstArray(pred, ifDefined, ifEmpty2))
         }
         n2.infer()
 
@@ -69,7 +70,7 @@ class ExpandSums extends Phase {
       case n @ OptionApply(_) :@ OptionType.Primitive(_) => n
 
       // Other OptionApply -> translate to product form
-      case n @ OptionApply(ch) => ProductNode(Vector(Disc1, silentCast(toOptionColumns(ch.nodeType), ch))).infer()
+      case n @ OptionApply(ch) => ProductNode(ConstArray(Disc1, silentCast(toOptionColumns(ch.nodeType), ch))).infer()
 
       // Non-primitive GetOrElse
       // (.get is only defined on primitive Options, but this can occur inside of HOFs like .map)
@@ -108,7 +109,7 @@ class ExpandSums extends Phase {
         case _ => Set.empty
       }
       def find(t: Type, path: List[TermSymbol]): Vector[List[TermSymbol]] = t.structural match {
-        case StructType(defs) => defs.flatMap { case (s, t) => find(t, s :: path) }(collection.breakOut)
+        case StructType(defs) => defs.toSeq.flatMap { case (s, t) => find(t, s :: path) }(collection.breakOut)
         case p: ProductType => p.numberedElements.flatMap { case (s, t) => find(t, s :: path) }.toVector
         case _: AtomicType => Vector(path)
         case _ => Vector.empty
@@ -136,7 +137,7 @@ class ExpandSums extends Phase {
           logger.debug("No suitable discriminator column found in "+elemType)
           (Disc1, false)
       }
-      val extend :@ CollectionType(_, extendedElementType) = Bind(extendGen, side, Pure(ProductNode(Vector(disc, Ref(extendGen))))).infer()
+      val extend :@ CollectionType(_, extendedElementType) = Bind(extendGen, side, Pure(ProductNode(ConstArray(disc, Ref(extendGen))))).infer()
       val sideInCondition = Select(Ref(sym) :@ extendedElementType, ElementSymbol(2)).infer()
       val on2 = on.replace({
         case Ref(s) if s == sym => sideInCondition
@@ -165,12 +166,12 @@ class ExpandSums extends Phase {
       val v = if(createDisc) {
         val protoDisc = Select(ref, ElementSymbol(1)).infer()
         val rest = Select(ref, ElementSymbol(2))
-        val disc = IfThenElse(Vector(Library.==.typed[Boolean](silentCast(OptionType(protoDisc.nodeType), protoDisc), LiteralNode(null)), DiscNone, Disc1))
-        ProductNode(Vector(disc, rest))
+        val disc = IfThenElse(ConstArray(Library.==.typed[Boolean](silentCast(OptionType(protoDisc.nodeType), protoDisc), LiteralNode(null)), DiscNone, Disc1))
+        ProductNode(ConstArray(disc, rest))
       } else ref
       silentCast(trType(elemType.asInstanceOf[ProductType].children(idx)), v)
     }
-    val ref = ProductNode(Vector(optionCast(0, ldisc), optionCast(1, rdisc))).infer()
+    val ref = ProductNode(ConstArray(optionCast(0, ldisc), optionCast(1, rdisc))).infer()
     val pure2 = pure.replace({
       case Ref(s) if s == bsym => ref
 
@@ -204,7 +205,7 @@ class ExpandSums extends Phase {
   def trType(tpe: Type): Type = {
     def f(tpe: Type): Type = tpe.mapChildren(f) match {
       case t @ OptionType.Primitive(_) => t
-      case OptionType(ch) => ProductType(Vector(ScalaBaseType.optionDiscType.optionType, toOptionColumns(ch)))
+      case OptionType(ch) => ProductType(ConstArray(ScalaBaseType.optionDiscType.optionType, toOptionColumns(ch)))
       case t => t
     }
     val tpe2 = f(tpe)
@@ -223,8 +224,8 @@ class ExpandSums extends Phase {
   /** Fuse unnecessary Option operations */
   def fuse(n: Node): Node = n match {
     // Option.map
-    case IfThenElse(IndexedSeq(Library.==(disc, Disc1), ProductNode(Seq(Disc1, map)), ProductNode(Seq(DiscNone, _)))) =>
-      ProductNode(Vector(disc, map)).infer()
+    case IfThenElse(ConstArray(Library.==(disc, Disc1), ProductNode(ConstArray(Disc1, map)), ProductNode(ConstArray(DiscNone, _)))) =>
+      ProductNode(ConstArray(disc, map)).infer()
     case n => n
   }
 

--- a/slick/src/main/scala/slick/compiler/ExpandTables.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandTables.scala
@@ -48,7 +48,7 @@ class ExpandTables extends Phase {
   /** Create an expression that copies a structured value, expanding tables in it. */
   def createResult(expansions: Map[TableIdentitySymbol, (TermSymbol, Node)], path: Node, tpe: Type): Node = tpe match {
     case p: ProductType =>
-      ProductNode(ConstArray.from(p.numberedElements.map { case (s, t) => createResult(expansions, Select(path, s), t) }.toVector))
+      ProductNode(p.elements.zipWithIndex.map { case (t, i) => createResult(expansions, Select(path, ElementSymbol(i+1)), t) })
     case NominalType(tsym: TableIdentitySymbol, _) if expansions contains tsym =>
       val (sym, exp) = expansions(tsym)
       exp.replace { case Ref(s) if s == sym => path }

--- a/slick/src/main/scala/slick/compiler/ExpandTables.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandTables.scala
@@ -3,6 +3,7 @@ package slick.compiler
 import slick.ast._
 import Util._
 import TypeUtil._
+import slick.util.ConstArray
 
 /** Expand table-valued expressions in the result type to their star projection and compute the
   * missing structural expansions of table types. After this phase the AST should always be
@@ -14,7 +15,7 @@ class ExpandTables extends Phase {
     // Find table fields
     val structs = tree.collect[(TypeSymbol, (FieldSymbol, Type))] {
       case s @ Select(_ :@ (n: NominalType), sym: FieldSymbol) => n.sourceNominalType.sym -> (sym -> s.nodeType)
-    }.groupBy(_._1).map { case (ts, v) => (ts, NominalType(ts, StructType(v.map(_._2).toMap.toIndexedSeq))) }
+    }.toSeq.groupBy(_._1).map { case (ts, v) => (ts, NominalType(ts, StructType(ConstArray.from(v.map(_._2).toMap)))) }
     logger.debug("Found Selects for NominalTypes: "+structs.keySet.mkString(", "))
 
     val tree2 = tree.replace {
@@ -47,7 +48,7 @@ class ExpandTables extends Phase {
   /** Create an expression that copies a structured value, expanding tables in it. */
   def createResult(expansions: Map[TableIdentitySymbol, (TermSymbol, Node)], path: Node, tpe: Type): Node = tpe match {
     case p: ProductType =>
-      ProductNode(p.numberedElements.map { case (s, t) => createResult(expansions, Select(path, s), t) }.toVector)
+      ProductNode(ConstArray.from(p.numberedElements.map { case (s, t) => createResult(expansions, Select(path, s), t) }.toVector))
     case NominalType(tsym: TableIdentitySymbol, _) if expansions contains tsym =>
       val (sym, exp) = expansions(tsym)
       exp.replace { case Ref(s) if s == sym => path }

--- a/slick/src/main/scala/slick/compiler/FlattenProjections.scala
+++ b/slick/src/main/scala/slick/compiler/FlattenProjections.scala
@@ -38,7 +38,7 @@ class FlattenProjections extends Phase {
         logger.debug("Translated "+p.pathString+" to:", p2)
         p2
       case n: Bind =>
-        n.mapScopedChildren { case (o, ch) => tr(ch, topLevel && o.isEmpty) }
+        n.mapChildren { ch => tr(ch, topLevel && (ch ne n.from)) }
       case u: Union =>
         n.mapChildren { ch => tr(ch, true) }
       case n => n.mapChildren(tr(_, false))
@@ -81,7 +81,7 @@ class FlattenProjections extends Phase {
       n match {
         case StructNode(ch) => ch.foreach { case (s, n) => flatten(n, s :: path) }
         case p: ProductNode =>
-          p.children.iterator.zipWithIndex.foreach { case (n, i) => flatten(n, new ElementSymbol(i+1) :: path) }
+          p.children.zipWithIndex.foreach { case (n, i) => flatten(n, new ElementSymbol(i+1) :: path) }
         case n =>
           if(collapse) {
             defsM.get(n) match {

--- a/slick/src/main/scala/slick/compiler/FlattenProjections.scala
+++ b/slick/src/main/scala/slick/compiler/FlattenProjections.scala
@@ -1,5 +1,7 @@
 package slick.compiler
 
+import slick.util.ConstArray
+
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import slick.ast._
 import Util._
@@ -102,6 +104,6 @@ class FlattenProjections extends Phase {
       }
     }
     flatten(n, Nil)
-    (StructNode(defs), paths.toMap)
+    (StructNode(ConstArray.from(defs)), paths.toMap)
   }
 }

--- a/slick/src/main/scala/slick/compiler/ForceOuterBinds.scala
+++ b/slick/src/main/scala/slick/compiler/ForceOuterBinds.scala
@@ -1,6 +1,7 @@
 package slick.compiler
 
 import slick.ast._
+import slick.util.ConstArray
 
 /** Ensure that all collection operations are wrapped in a Bind so that we
   * have a place for expanding references later. FilteredQueries are allowed
@@ -23,7 +24,7 @@ class ForceOuterBinds extends Phase {
     val gen = new AnonSymbol
     logger.debug("Introducing new Bind "+gen+" for "+n)
     n match {
-      case p: Pure => Bind(gen, Pure(ProductNode(Vector.empty)), p)
+      case p: Pure => Bind(gen, Pure(ProductNode(ConstArray.empty)), p)
       case _ => Bind(gen, n, Pure(Ref(gen)))
     }
   }

--- a/slick/src/main/scala/slick/compiler/InsertCompiler.scala
+++ b/slick/src/main/scala/slick/compiler/InsertCompiler.scala
@@ -3,7 +3,7 @@ package slick.compiler
 import slick.ast._
 import scala.collection.mutable.ArrayBuffer
 import slick.{SlickTreeException, SlickException}
-import slick.util.SlickLogger
+import slick.util.{ConstArray, SlickLogger}
 import org.slf4j.LoggerFactory
 import Util._
 
@@ -41,8 +41,8 @@ class InsertCompiler(val mode: InsertCompiler.Mode) extends Phase {
         val ch =
           if(mode(fs)) {
             cols += Select(tref, fs) :@ sel.nodeType
-            IndexedSeq(Select(rref, ElementSymbol(cols.size)) :@ sel.nodeType)
-          } else IndexedSeq.empty[Node]
+            ConstArray(Select(rref, ElementSymbol(cols.size)) :@ sel.nodeType)
+          } else ConstArray.empty
         InsertColumn(ch, fs, sel.nodeType).infer()
       case Ref(s) if s == expansionRef =>
         tr(tableExpansion.columns)
@@ -53,7 +53,7 @@ class InsertCompiler(val mode: InsertCompiler.Mode) extends Phase {
     }
     val tree2 = tr(tree).infer()
     if(tableExpansion eq null) throw new SlickException("No table to insert into")
-    val ins = Insert(tableSym, tableExpansion.table, ProductNode(cols)).infer()
+    val ins = Insert(tableSym, tableExpansion.table, ProductNode(ConstArray.from(cols))).infer()
     ResultSetMapping(linearSym, ins, tree2) :@ CollectionType(TypedCollectionTypeConstructor.seq, ins.nodeType)
   }
 }

--- a/slick/src/main/scala/slick/compiler/QueryCompiler.scala
+++ b/slick/src/main/scala/slick/compiler/QueryCompiler.scala
@@ -93,7 +93,7 @@ class QueryCompiler(val phases: Vector[Phase]) extends Logging {
   protected[this] def detectRebuiltLeafs(n1: Node, n2: Node): Set[RefId[Dumpable]] = {
     if(n1 eq n2) Set.empty else {
       val chres =
-        (n1.children, n2.children).zipped.map(detectRebuiltLeafs).foldLeft(Set.empty[RefId[Dumpable]])(_ ++ _)
+        n1.children.iterator.zip(n2.children.iterator).map { case (n1, n2) => detectRebuiltLeafs(n1, n2) }.foldLeft(Set.empty[RefId[Dumpable]])(_ ++ _)
       if(chres.isEmpty) Set(RefId(n2)) else chres
     }
   }

--- a/slick/src/main/scala/slick/compiler/RelabelUnions.scala
+++ b/slick/src/main/scala/slick/compiler/RelabelUnions.scala
@@ -11,7 +11,7 @@ class RelabelUnions extends Phase {
 
   def apply(state: CompilerState) = state.map(_.replace({
     case u @ Union(Bind(_, _, Pure(StructNode(ls), lts)), rb @ Bind(_, _, Pure(StructNode(rs), _)), _) =>
-      val rs2 = (ls, rs).zipped.map { case ((s, _), (_, n)) => (s, n) }
+      val rs2 = ls.zip(rs).map { case ((s, _), (_, n)) => (s, n) }
       u.copy(right = rb.copy(select = Pure(StructNode(rs2), lts))).infer()
   }, keepType = true, bottomUp = true))
 }

--- a/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
+++ b/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
@@ -11,7 +11,7 @@ class RemoveFieldNames extends Phase {
 
   def apply(state: CompilerState) = state.map { n => ClientSideOp.mapResultSetMapping(n, true) { rsm =>
     val CollectionType(_, NominalType(top, StructType(fdefs))) = rsm.from.nodeType
-    val indexes = fdefs.zipWithIndex.map { case ((s, _), i) => (s, ElementSymbol(i+1)) }.toMap
+    val indexes = fdefs.iterator.zipWithIndex.map { case ((s, _), i) => (s, ElementSymbol(i+1)) }.toMap
     val rsm2 = rsm.nodeMapServerSide(false, { n =>
       val refTSyms = n.collect[TypeSymbol] { case Select(_ :@ NominalType(s, _), _) => s }.toSet
       val allTSyms = n.collect[TypeSymbol] { case p: Pure => p.identity }.toSet

--- a/slick/src/main/scala/slick/compiler/RemoveTakeDrop.scala
+++ b/slick/src/main/scala/slick/compiler/RemoveTakeDrop.scala
@@ -42,7 +42,7 @@ class RemoveTakeDrop extends Phase {
         logger.debug(s"""Translated "drop $d, then take $t" to zipWithIndex operation:""", b2)
         val invalidate = fromRetyped.nodeType.collect { case NominalType(ts, _) => ts }
         logger.debug("Invalidating TypeSymbols: "+invalidate.mkString(", "))
-        invalid ++= invalidate
+        invalid ++= invalidate.toSeq
         b2
 
       case (n: Ref) if n.nodeType.containsSymbol(invalid) => n.untyped

--- a/slick/src/main/scala/slick/compiler/ReorderOperations.scala
+++ b/slick/src/main/scala/slick/compiler/ReorderOperations.scala
@@ -3,7 +3,7 @@ package slick.compiler
 import slick.ast._
 import slick.ast.Util._
 import slick.ast.TypeUtil._
-import slick.util.{Ellipsis, ??}
+import slick.util.{ConstArray, Ellipsis, ??}
 
 /** Reorder certain stream operations for more efficient merging in `mergeToComprehensions`. */
 class ReorderOperations extends Phase {
@@ -53,7 +53,7 @@ class ReorderOperations extends Phase {
     // If a Filter checks an upper bound of a ROWNUM, push it into the AboveRownum boundary
     case filter @ Filter(s1,
                 sq @ Subquery(bind @ Bind(bs1, from1, Pure(StructNode(defs1), ts1)), Subquery.AboveRownum),
-                Apply(Library.<= | Library.<, Seq(Select(Ref(rs), f1), v1)))
+                Apply(Library.<= | Library.<, ConstArray(Select(Ref(rs), f1), v1)))
         if rs == s1 && defs1.find {
           case (f, n) if f == f1 => isRownumCalculation(n)
           case _ => false
@@ -71,7 +71,7 @@ class ReorderOperations extends Phase {
     case n => n
   }
 
-  def isAliasingOrLiteral(base: TermSymbol, defs: IndexedSeq[(TermSymbol, Node)]) = {
+  def isAliasingOrLiteral(base: TermSymbol, defs: ConstArray[(TermSymbol, Node)]) = {
     val r = defs.iterator.map(_._2).forall {
       case FwdPath(s :: _) if s == base => true
       case _: LiteralNode => true

--- a/slick/src/main/scala/slick/compiler/ResolveZipJoins.scala
+++ b/slick/src/main/scala/slick/compiler/ResolveZipJoins.scala
@@ -3,6 +3,7 @@ package slick.compiler
 import slick.ast._
 import Util._
 import TypeUtil._
+import slick.util.ConstArray
 
 /** Rewrite zip joins into a form suitable for SQL using inner joins and RowNumber columns.
   *
@@ -45,7 +46,7 @@ class ResolveZipJoins(rownumStyle: Boolean = false) extends Phase {
     * into an equivalent mapping operation using `RowNum`. This method can be overridden in
     * subclasses to implement non-standard translations. */
   def transformZipWithIndex(s1: TermSymbol, ls: TermSymbol, from: Node,
-                            defs: IndexedSeq[(TermSymbol, Node)], offset: Long, p: Node): Node = {
+                            defs: ConstArray[(TermSymbol, Node)], offset: Long, p: Node): Node = {
     val idxSym = new AnonSymbol
     val idxExpr =
       if(offset == 1L) RowNumber()
@@ -62,10 +63,10 @@ class ResolveZipJoins(rownumStyle: Boolean = false) extends Phase {
     * into an equivalent mapping operation using `RowNum` by first transforming both sides of the
     * join into `zipWithIndex` and then using `transformZipWithIndex` on those. */
   def transformZip(s1: TermSymbol, jlsym: TermSymbol, jrsym: TermSymbol,
-                   l: Bind, ldefs: IndexedSeq[(TermSymbol, Node)],
-                   r: Bind, rdefs: IndexedSeq[(TermSymbol, Node)], sel: Node): Node = {
-    val lmap = ldefs.map(t => (t._1, new AnonSymbol)).toMap
-    val rmap = rdefs.map(t => (t._1, new AnonSymbol)).toMap
+                   l: Bind, ldefs: ConstArray[(TermSymbol, Node)],
+                   r: Bind, rdefs: ConstArray[(TermSymbol, Node)], sel: Node): Node = {
+    val lmap = ldefs.iterator.map(t => (t._1, new AnonSymbol)).toMap
+    val rmap = rdefs.iterator.map(t => (t._1, new AnonSymbol)).toMap
     val lisym, risym, l2sym, r2sym = new AnonSymbol
     val l2 = transformZipWithIndex(l2sym, l.generator, l.from, ldefs, 1L,
       Pure(StructNode(ldefs.map { case (f, _) =>

--- a/slick/src/main/scala/slick/compiler/SpecializeParameters.scala
+++ b/slick/src/main/scala/slick/compiler/SpecializeParameters.scala
@@ -3,6 +3,7 @@ package slick.compiler
 import slick.SlickException
 import slick.ast._
 import Util._
+import slick.util.ConstArray
 
 /** Specialize the AST for edge cases of query parameters. This is required for
   * compiling `take(0)` for some databases which do not allow `LIMIT 0`. */
@@ -19,7 +20,7 @@ class SpecializeParameters extends Phase {
       val compiledFetchParam = QueryParameter(fetch.extractor, ScalaBaseType.longType)
       val guarded = n.replace({ case c2: Comprehension if c2 == c => c2.copy(fetch = Some(LiteralNode(0L))) }, keepType = true)
       val fallback = n.replace({ case c2: Comprehension if c2 == c => c2.copy(fetch = Some(compiledFetchParam)) }, keepType = true)
-      ParameterSwitch(Vector(compare(fetch.extractor, 0L) -> guarded), fallback).infer()
+      ParameterSwitch(ConstArray(compare(fetch.extractor, 0L) -> guarded), fallback).infer()
     }
   }
 

--- a/slick/src/main/scala/slick/compiler/VerifySymbols.scala
+++ b/slick/src/main/scala/slick/compiler/VerifySymbols.scala
@@ -35,7 +35,7 @@ class VerifySymbols extends Phase {
         verifyScoping(f2, syms)
         verifyScoping(on, syms + s1 + s2)
       case n =>
-        n.children.foreach(ch => verifyScoping(ch, syms))
+        n.childrenForeach(ch => verifyScoping(ch, syms))
     }
     verifyScoping(n2, Set.empty)
     n2

--- a/slick/src/main/scala/slick/compiler/VerifyTypes.scala
+++ b/slick/src/main/scala/slick/compiler/VerifyTypes.scala
@@ -41,7 +41,7 @@ class VerifyTypes(after: Option[Phase] = None) extends Phase {
           errors += RefId(n1)
         }
       }
-      (n1.children, n2.children).zipped.map(compare)
+      n1.children.zip(n2.children).force.foreach { case (n1, n2) => compare(n1, n2) }
     }
     compare(tree, retyped)
 

--- a/slick/src/main/scala/slick/driver/HsqldbDriver.scala
+++ b/slick/src/main/scala/slick/driver/HsqldbDriver.scala
@@ -1,6 +1,8 @@
 package slick.driver
 
 import java.sql.Types
+import slick.util.ConstArray
+
 import scala.concurrent.ExecutionContext
 import slick.SlickException
 import slick.dbio._
@@ -94,7 +96,7 @@ trait HsqldbDriver extends JdbcDriver { driver =>
           val on3 = (on, on2) match {
             case (a, LiteralNode(true)) => a
             case (LiteralNode(true), b) => b
-            case (a, b) => Apply(Library.And, Vector(a, b))(UnassignedType)
+            case (a, b) => Apply(Library.And, ConstArray(a, b))(UnassignedType)
           }
           buildJoin(Join(rs, rs2, Join(ls, ls2, l, l2, JoinType.Inner, LiteralNode(true)), r2, JoinType.Inner, on3))
         case j => super.buildJoin(j)

--- a/slick/src/main/scala/slick/driver/MySQLDriver.scala
+++ b/slick/src/main/scala/slick/driver/MySQLDriver.scala
@@ -1,5 +1,7 @@
 package slick.driver
 
+import slick.util.ConstArray
+
 import scala.concurrent.ExecutionContext
 import slick.SlickException
 import slick.jdbc.{JdbcType, JdbcModelBuilder}
@@ -104,12 +106,12 @@ trait MySQLDriver extends JdbcDriver { driver =>
     // According to http://dev.mysql.com/doc/refman/5.0/en/user-variables.html this should not be
     // relied on but it is the generally accepted solution and there is no better way.
     override def transformZipWithIndex(s1: TermSymbol, ls: TermSymbol, from: Node,
-                                       defs: IndexedSeq[(TermSymbol, Node)], offset: Long, p: Node): Node = {
+                                       defs: ConstArray[(TermSymbol, Node)], offset: Long, p: Node): Node = {
       val countSym = new AnonSymbol
       val j = Join(new AnonSymbol, new AnonSymbol,
         Bind(ls, from, Pure(StructNode(defs))),
-        Bind(new AnonSymbol, Pure(StructNode(IndexedSeq.empty)),
-          Pure(StructNode(IndexedSeq(new AnonSymbol -> RowNumGen(countSym, offset-1))))),
+        Bind(new AnonSymbol, Pure(StructNode(ConstArray.empty)),
+          Pure(StructNode(ConstArray(new AnonSymbol -> RowNumGen(countSym, offset-1))))),
         JoinType.Inner, LiteralNode(true))
       var first = true
       Subquery(Bind(s1, j, p.replace {

--- a/slick/src/main/scala/slick/driver/PostgresDriver.scala
+++ b/slick/src/main/scala/slick/driver/PostgresDriver.scala
@@ -2,6 +2,8 @@ package slick.driver
 
 import java.util.UUID
 import java.sql.{PreparedStatement, ResultSet}
+import slick.util.ConstArray
+
 import scala.concurrent.ExecutionContext
 import slick.dbio._
 import slick.lifted._
@@ -153,10 +155,10 @@ trait PostgresDriver extends JdbcDriver { driver =>
       val nonAutoIncVars = nonAutoIncSyms.map(_ => "?").mkString(",")
       val cond = pkNames.map(n => s"$n=?").mkString(" and ")
       val insert = s"insert into $tableName ($nonAutoIncNames) select $nonAutoIncVars where not exists (select 1 from $tableName where $cond)"
-      new InsertBuilderResult(table, s"begin; $update; $insert; end", softSyms ++ pkSyms)
+      new InsertBuilderResult(table, s"begin; $update; $insert; end", ConstArray.from(softSyms ++ pkSyms))
     }
 
-    override def transformMapping(n: Node) = reorderColumns(n, softSyms ++ pkSyms ++ nonAutoIncSyms ++ pkSyms)
+    override def transformMapping(n: Node) = reorderColumns(n, softSyms ++ pkSyms ++ nonAutoIncSyms.toSeq ++ pkSyms)
   }
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {

--- a/slick/src/main/scala/slick/jdbc/JdbcMappingCompilerComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcMappingCompilerComponent.scala
@@ -30,7 +30,7 @@ trait JdbcMappingCompilerComponent { driver: JdbcDriver =>
     def createColumnConverter(n: Node, idx: Int, column: Option[FieldSymbol]): ResultConverter[JdbcResultConverterDomain, _] = {
       val JdbcType(ti, option) = n.nodeType.structural
       if(option) createOptionResultConverter(ti, idx)
-      else createBaseResultConverter(ti, column.fold(n.toString)(_.name), idx)
+      else createBaseResultConverter(ti, column.fold("<computed>")(_.name), idx)
     }
 
     override def createGetOrElseResultConverter[T](rc: ResultConverter[JdbcResultConverterDomain, Option[T]], default: () => T) = rc match {

--- a/slick/src/main/scala/slick/lifted/Constraint.scala
+++ b/slick/src/main/scala/slick/lifted/Constraint.scala
@@ -56,7 +56,7 @@ object ForeignKey {
     def f(n: Node): Unit = n match {
       case _: Select | _: Ref | _: TableNode => sels += n
       case _: ProductNode | _: OptionApply | _: GetOrElse | _: TypeMapping | _: ClientSideOp =>
-        n.children.foreach(f)
+        n.childrenForeach(f)
     }
     f(n)
     sels

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -1,5 +1,7 @@
 package slick.lifted
 
+import slick.util.ConstArray
+
 import scala.language.{implicitConversions, higherKinds}
 import slick.ast._
 import FunctionSymbolExtensionMethods._
@@ -43,10 +45,10 @@ trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
     om.column(Library.In, n, e.toNode)
   def inSet[R](seq: Traversable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
-    else om.column(Library.In, n, ProductNode(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) }.toVector))
+    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))
   def inSetBind[R](seq: Traversable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
-    else om.column(Library.In, n, ProductNode(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)).toVector))
+    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)))))
 
   def between[P2, P3, R](start: Rep[P2], end: Rep[P3])(implicit om: o#arg[B1, P2]#arg[B1, P3]#to[Boolean, R]) =
     om.column(Library.Between, n, start.toNode, end.toNode)
@@ -192,7 +194,7 @@ final class AnyOptionExtensionMethods[O <: Rep[_], P](val r: O) extends AnyVal {
     // fold(None, (v => if p(v) Some(v) else None))
     val gen = new AnonSymbol
     val pred = wt(p(OptionLift.baseValue[P, O](r, Ref(gen)))).toNode
-    val cond = IfThenElse(Vector(pred, OptionApply(Ref(gen)), LiteralNode.nullOption))
+    val cond = IfThenElse(ConstArray(pred, OptionApply(Ref(gen)), LiteralNode.nullOption))
     r.encodeRef(OptionFold(r.toNode, LiteralNode.nullOption, cond, gen)).asInstanceOf[O]
   }
 

--- a/slick/src/main/scala/slick/lifted/Query.scala
+++ b/slick/src/main/scala/slick/lifted/Query.scala
@@ -1,5 +1,7 @@
 package slick.lifted
 
+import slick.util.ConstArray
+
 import scala.language.higherKinds
 import scala.language.experimental.macros
 import scala.annotation.implicitNotFound
@@ -136,7 +138,7 @@ sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
   def sortBy[T <% Ordered](f: E => T): Query[E, U, C] = {
     val generator = new AnonSymbol
     val aliased = shaped.encodeRef(Ref(generator))
-    new WrappingQuery[E, U, C](SortBy(generator, toNode, f(aliased.value).columns), shaped)
+    new WrappingQuery[E, U, C](SortBy(generator, toNode, ConstArray.from(f(aliased.value).columns)), shaped)
   }
 
   /** Sort this query according to a the ordering of its elements. */

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -4,7 +4,7 @@ import scala.language.{existentials, implicitConversions, higherKinds}
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
 import slick.SlickException
-import slick.util.{ProductWrapper, TupleSupport}
+import slick.util.{ConstArray, ProductWrapper, TupleSupport}
 import slick.ast._
 import scala.reflect.ClassTag
 
@@ -64,7 +64,7 @@ object Shape extends ConstColumnShapeImplicits with AbstractTableShapeImplicits 
     def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] = this
     def buildParams(extract: Any => Unpacked) = ()
     def encodeRef(value: Mixed, path: Node) = ()
-    def toNode(value: Mixed) = ProductNode(Vector.empty)
+    def toNode(value: Mixed) = ProductNode(ConstArray.empty)
   }
 }
 
@@ -153,9 +153,9 @@ abstract class ProductNodeShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] 
     }
     buildValue(elems.toIndexedSeq)
   }
-  def toNode(value: Mixed): Node = ProductNode(shapes.iterator.zip(getIterator(value)).map {
+  def toNode(value: Mixed): Node = ProductNode(ConstArray.from(shapes.iterator.zip(getIterator(value)).map {
     case (p, f) => p.toNode(f.asInstanceOf[p.Mixed])
-  }.toVector)
+  }.toIterable))
 }
 
 /** Base class for ProductNodeShapes with a type mapping */

--- a/slick/src/main/scala/slick/lifted/SimpleFunction.scala
+++ b/slick/src/main/scala/slick/lifted/SimpleFunction.scala
@@ -22,8 +22,8 @@ object SimpleFunction {
     def build(params: IndexedSeq[Node]): SimpleFeatureNode[T] = new SimpleFeatureNode[T] with SimpleFunction {
       val name = fname
       override val scalar = fn
-      def children = params
-      protected[this] def rebuild(ch: IndexedSeq[Node]): Self = build(ch)
+      def children = ConstArray.from(params)
+      protected[this] def rebuild(ch: ConstArray[Node]): Self = build(ch.toSeq)
     }
     { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.map(_.toNode)(collection.breakOut))) }
   }
@@ -78,9 +78,9 @@ trait SimpleExpression extends Node {
 object SimpleExpression {
   def apply[T : TypedType](f: (Seq[Node], JdbcStatementBuilderComponent#QueryBuilder) => Unit): (Seq[Rep[_]] => Rep[T]) = {
     def build(params: IndexedSeq[Node]): SimpleFeatureNode[T] = new SimpleFeatureNode[T] with SimpleExpression {
-      def toSQL(qb: JdbcStatementBuilderComponent#QueryBuilder) = f(children, qb)
-      def children = params
-      protected[this] def rebuild(ch: IndexedSeq[Node]) = build(ch)
+      def toSQL(qb: JdbcStatementBuilderComponent#QueryBuilder) = f(children.toSeq, qb)
+      def children = ConstArray.from(params)
+      protected[this] def rebuild(ch: ConstArray[Node]) = build(ch.toSeq)
     }
     { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.map(_.toNode)(collection.breakOut))) }
   }

--- a/slick/src/main/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryQueryingProfile.scala
@@ -9,7 +9,7 @@ import slick.compiler._
 import slick.lifted._
 import slick.relational._
 import slick.profile.{BasicDriver, BasicProfile}
-import slick.util.??
+import slick.util.{??, ConstArray}
 import TypeUtil._
 
 /** The querying (read-only) part that can be shared between MemoryDriver and DistributedDriver. */
@@ -67,7 +67,7 @@ trait MemoryQueryingDriver extends BasicDriver with MemoryQueryingProfile { driv
     }
 
     def transformCountAll(gen: TermSymbol, n: Node): Node = n match {
-      case Apply(Library.CountAll, ch @ Seq(Bind(gen2, FwdPath(s :: _), Pure(ProductOfCommonPaths(s2, _), _)))) if s == gen && s2 == gen2 =>
+      case Apply(Library.CountAll, ch @ ConstArray(Bind(gen2, FwdPath(s :: _), Pure(ProductOfCommonPaths(s2, _), _)))) if s == gen && s2 == gen2 =>
         Apply(Library.Count, ch)(n.nodeType)
       case n => n.mapChildren(ch => transformCountAll(gen, ch), keepType = true)
     }
@@ -106,7 +106,7 @@ trait MemoryQueryingDriver extends BasicDriver with MemoryQueryingProfile { driv
 
   object ProductOfCommonPaths {
     def unapply(n: ProductNode): Option[(TermSymbol, Vector[List[TermSymbol]])] = if(n.children.isEmpty) None else
-      n.children.foldLeft(null: Option[(TermSymbol, Vector[List[TermSymbol]])]) {
+      n.children.iterator.foldLeft(null: Option[(TermSymbol, Vector[List[TermSymbol]])]) {
         case (None, _) => None
         case (null, FwdPath(sym :: rest)) => Some((sym, Vector(rest)))
         case (Some((sym0, v)), FwdPath(sym :: rest)) if sym == sym0 => Some((sym, v :+ rest))

--- a/slick/src/main/scala/slick/relational/ResultConverterCompiler.scala
+++ b/slick/src/main/scala/slick/relational/ResultConverterCompiler.scala
@@ -23,7 +23,7 @@ trait ResultConverterCompiler[Domain <: ResultConverterDomain] {
     case OptionApply(Select(_, ElementSymbol(idx))) => createColumnConverter(n, idx, None)
     case ProductNode(ch) =>
       if(ch.isEmpty) new UnitResultConverter
-      else new ProductResultConverter(ch.map(n => compile(n))(collection.breakOut): _*)
+      else new ProductResultConverter(ch.map(n => compile(n)): _*)
     case GetOrElse(ch, default) =>
       createGetOrElseResultConverter(compile(ch).asInstanceOf[ResultConverter[Domain, Option[Any]]], default)
     case TypeMapping(ch, mapper, _) =>

--- a/slick/src/main/scala/slick/relational/ResultConverterCompiler.scala
+++ b/slick/src/main/scala/slick/relational/ResultConverterCompiler.scala
@@ -13,17 +13,17 @@ trait ResultConverterCompiler[Domain <: ResultConverterDomain] {
   def compile(n: Node): ResultConverter[Domain, _] = n match {
     case InsertColumn(paths, fs, _) =>
       val pathConvs = paths.map { case Select(_, ElementSymbol(idx)) => createColumnConverter(n, idx, Some(fs)) }
-      if(pathConvs.length == 1) pathConvs.head else CompoundResultConverter(1, pathConvs: _*)
+      if(pathConvs.length == 1) pathConvs.head else CompoundResultConverter(1, pathConvs.toSeq: _*)
     case OptionApply(InsertColumn(paths, fs, _)) =>
       val pathConvs = paths.map { case Select(_, ElementSymbol(idx)) => createColumnConverter(n, idx, Some(fs)) }
-      if(pathConvs.length == 1) pathConvs.head else CompoundResultConverter(1, pathConvs: _*)
+      if(pathConvs.length == 1) pathConvs.head else CompoundResultConverter(1, pathConvs.toSeq: _*)
     case Select(_, ElementSymbol(idx)) => createColumnConverter(n, idx, None)
     case cast @ Library.SilentCast(sel @ Select(_, ElementSymbol(idx))) =>
       createColumnConverter(sel :@ cast.nodeType, idx, None)
     case OptionApply(Select(_, ElementSymbol(idx))) => createColumnConverter(n, idx, None)
     case ProductNode(ch) =>
       if(ch.isEmpty) new UnitResultConverter
-      else new ProductResultConverter(ch.map(n => compile(n)): _*)
+      else new ProductResultConverter(ch.map(n => compile(n)).toSeq: _*)
     case GetOrElse(ch, default) =>
       createGetOrElseResultConverter(compile(ch).asInstanceOf[ResultConverter[Domain, Option[Any]]], default)
     case TypeMapping(ch, mapper, _) =>

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -157,7 +157,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
     }
   }
 
-  private[this] def findIndex(f: T => Boolean): Int = {
+  def indexWhere(f: T => Boolean): Int = {
     var i = 0
     while(i < length) {
       if(f(a(i).asInstanceOf[T])) return i
@@ -167,11 +167,11 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
   }
 
   def find(f: T => Boolean): Option[T] = {
-    var idx = findIndex(f)
+    var idx = indexWhere(f)
     if(idx == -1) None else Some(a(idx).asInstanceOf[T])
   }
 
-  def exists(f: T => Boolean): Boolean = findIndex(f) >= 0
+  def exists(f: T => Boolean): Boolean = indexWhere(f) >= 0
 
   def forall(f: T => Boolean): Boolean = {
     var i = 0

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -1,0 +1,498 @@
+package slick.util
+
+import java.util.Arrays
+
+import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable
+import scala.reflect.ClassTag
+import scala.util.hashing.MurmurHash3
+
+/** An efficient immutable array implementation which is used in the AST. Semantics are generally
+  * the same as for Scala collections but for performance reasons it does not implement any
+  * standard collection traits. */
+final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extends Product { self =>
+  private def this(a: Array[Any]) = this(a, a.length)
+
+  def apply(i: Int): T =
+    if(i > length) throw new IndexOutOfBoundsException
+    else a(i).asInstanceOf[T]
+
+  def lengthCompare(n: Int): Int = length.compare(n)
+
+  def isEmpty = length == 0
+
+  def nonEmpty = length != 0
+
+  def foreach[R](f: T => R): Unit = {
+    var i = 0
+    while(i < length) {
+      f(a(i).asInstanceOf[T])
+      i += 1
+    }
+  }
+
+  def map[R](f: T => R): ConstArray[R] = {
+    var i = 0
+    val ar = new Array[Any](length)
+    while(i < length) {
+      ar(i) = f(a(i).asInstanceOf[T])
+      i += 1
+    }
+    new ConstArray[R](ar)
+  }
+
+  def flatMap[R](f: T => ConstArray[R]): ConstArray[R] = {
+    var len = 0
+    val buf = new Array[ConstArray[R]](length)
+    var i = 0
+    while(i < length) {
+      val r = f(a(i).asInstanceOf[T])
+      buf(i) = r
+      len += r.length
+      i += 1
+    }
+    if(len == 0) ConstArray.empty
+    else {
+      val ar = new Array[Any](len)
+      i = 0
+      var j = 0
+      while(i < length) {
+        val r = buf(i)
+        val l = r.length
+        r.copySliceTo(ar, 0, j, l)
+        j += l
+        i += 1
+      }
+      new ConstArray[R](ar)
+    }
+  }
+
+  def flatten[R](implicit ev: T <:< ConstArray[R]): ConstArray[R] = {
+    var len = 0
+    var i = 0
+    while(i < length) {
+      len += a(i).asInstanceOf[ConstArray[_]].length
+      i += 1
+    }
+    if(len == 0) ConstArray.empty
+    else {
+      val ar = new Array[Any](len)
+      i = 0
+      var j = 0
+      while(i < length) {
+        val r = a(i).asInstanceOf[ConstArray[_]]
+        val l = r.length
+        r.copySliceTo(ar, 0, j, l)
+        j += l
+        i += 1
+      }
+      new ConstArray[R](ar)
+    }
+  }
+
+  /** Perform a mapping operation that does not change the type. If all elements remain unchanged
+    * (as determined by object identity), return this ConstArray instead of building a new one. */
+  def endoMap(f: T => T @uncheckedVariance): ConstArray[T] = {
+    var i = 0
+    var changed = false
+    val ar = new Array[Any](length)
+    while(i < length) {
+      val n0 = a(i)
+      val n1 = f(n0.asInstanceOf[T])
+      ar(i) = n1
+      if(n1.asInstanceOf[AnyRef] ne n0.asInstanceOf[AnyRef]) changed = true
+      i += 1
+    }
+    if(changed) new ConstArray[T](ar) else this
+  }
+
+  def zipWithIndex: ConstArrayOp[(T, Int)] = new ConstArrayOp[(T, Int)] {
+    def map[R](f: ((T, Int)) => R): ConstArray[R] = {
+      var i = 0
+      self.map { v =>
+        val r = f(v, i)
+        i += 1
+        r
+      }
+    }
+    def foreach[R](f: ((T, Int)) => R): Unit = {
+      var i = 0
+      self.foreach { v =>
+        f(v, i)
+        i += 1
+      }
+    }
+  }
+
+  def zip[U](u: ConstArray[U]): ConstArrayOp[(T, U)] = new ConstArrayOp[(T, U)] {
+    def map[R](f: ((T, U)) => R): ConstArray[R] = {
+      var i = 0
+      val len = math.min(length, u.length)
+      var ar = new Array[Any](len)
+      while(i < len) {
+        ar(i) = f((a(i).asInstanceOf[T], u(i)))
+        i += 1
+      }
+      new ConstArray[R](ar)
+    }
+    def foreach[R](f: ((T, U)) => R): Unit = {
+      var i = 0
+      val len = math.min(length, u.length)
+      while(i < len) {
+        f((a(i).asInstanceOf[T], u(i)))
+        i += 1
+      }
+    }
+  }
+
+  override def toString = a.mkString("ConstArray(", ", ", ")")
+
+  def iterator: Iterator[T] = new Iterator[T] {
+    private[this] var pos = 0
+    def hasNext: Boolean = pos < self.length
+    def next(): T = {
+      var r = a(pos)
+      pos += 1
+      r.asInstanceOf[T]
+    }
+  }
+
+  private[this] def findIndex(f: T => Boolean): Int = {
+    var i = 0
+    while(i < length) {
+      if(f(a(i).asInstanceOf[T])) return i
+      i += 1
+    }
+    -1
+  }
+
+  def find(f: T => Boolean): Option[T] = {
+    var idx = findIndex(f)
+    if(idx == -1) None else Some(a(idx).asInstanceOf[T])
+  }
+
+  def exists(f: T => Boolean): Boolean = findIndex(f) >= 0
+
+  def forall(f: T => Boolean): Boolean = {
+    var i = 0
+    while(i < length) {
+      if(!f(a(i).asInstanceOf[T])) return false
+      i += 1
+    }
+    true
+  }
+
+  def filter(p: T => Boolean): ConstArray[T] = {
+    val ar = new Array[Any](length)
+    var i, ri = 0
+    while(i < length) {
+      val v = a(i)
+      if(p(v.asInstanceOf[T])) {
+        ar(ri) = v
+        ri += 1
+      }
+      i += 1
+    }
+    if(ri == length) this
+    else if(ri == 0) ConstArray.empty
+    else new ConstArray[T](ar, ri)
+  }
+
+  def withFilter(p: T => Boolean): ConstArrayOp[T] = new ConstArrayOp[T] {
+    def map[R](f: T => R): ConstArray[R] = {
+      val ar = new Array[Any](length)
+      var i, ri = 0
+      while(i < length) {
+        val v = a(i).asInstanceOf[T]
+        if(p(v)) {
+          ar(ri) = f(v)
+          ri += 1
+        }
+        i += 1
+      }
+      if(ri == 0) ConstArray.empty
+      else new ConstArray[R](ar, ri)
+    }
+    def foreach[R](f: T => R): Unit = {
+      var i = 0
+      while(i < length) {
+        val v = a(i).asInstanceOf[T]
+        if(p(v)) f(v)
+        i += 1
+      }
+    }
+  }
+
+  def mkString(sep: String) = iterator.mkString(sep)
+
+  def mkString(start: String, sep: String, end: String) = iterator.mkString(start, sep, end)
+
+  def foldLeft[B](z: B)(op: (B, T) => B): B = {
+    var v = z
+    var i = 0
+    while(i < length) {
+      v = op(v, a(i).asInstanceOf[T])
+      i += 1
+    }
+    v
+  }
+
+  def foldRight[B](z: B)(op: (T, B) => B): B = {
+    var v = z
+    var i = length - 1
+    while(i >= 0) {
+      v = op(a(i).asInstanceOf[T], v)
+      i -= 1
+    }
+    v
+  }
+
+  ///////////////////////////////////////////////////////// conversion
+
+  def toSeq: immutable.IndexedSeq[T] = new immutable.IndexedSeq[T] {
+    def apply(idx: Int) = self(idx)
+    def length = self.length
+  }
+
+  def toSet: immutable.HashSet[T @uncheckedVariance] = {
+    val b = immutable.HashSet.newBuilder[T]
+    var i = 0
+    while(i < length) {
+      b += a(i).asInstanceOf[T]
+      i += 1
+    }
+    b.result()
+  }
+
+  def toMap[R, U](implicit ev: T <:< (R, U)): immutable.HashMap[R, U] = {
+    val b = immutable.HashMap.newBuilder[R, U]
+    var i = 0
+    while(i < length) {
+      b += a(i).asInstanceOf[(R, U)]
+      i += 1
+    }
+    b.result()
+  }
+
+  def toArray[R >: T : ClassTag]: Array[R] = {
+    val ar = new Array[R](length)
+    System.arraycopy(a, 0, ar, 0, length)
+    ar
+  }
+
+  private[util] def copySliceTo(dest: Array[Any], srcPos: Int, destPos: Int, len: Int): Unit = {
+    if(len+srcPos > length) throw new IndexOutOfBoundsException
+    System.arraycopy(a, srcPos, dest, destPos, len)
+  }
+
+  ///////////////////////////////////////////////////////// concatenation
+
+  def :+ (v: T @uncheckedVariance): ConstArray[T] = {
+    val a2 = Arrays.copyOf[Any](a.asInstanceOf[Array[AnyRef]], length + 1).asInstanceOf[Array[Any]]
+    a2(length) = v
+    new ConstArray[T](a2)
+  }
+
+  def +: (v: T @uncheckedVariance): ConstArray[T] = {
+    val a2 = new Array[Any](length + 1)
+    a2(0) = v
+    System.arraycopy(a, 0, a2, 1, length)
+    new ConstArray[T](a2)
+  }
+
+  def ++ [U >: T](u: ConstArray[U]): ConstArray[U] = {
+    val len2 = u.length
+    val ar = new Array[Any](length + len2)
+    System.arraycopy(a, 0, ar, 0, length)
+    u.copySliceTo(ar, 0, length, len2)
+    new ConstArray[U](ar)
+  }
+
+  def ++ (o: Option[T] @uncheckedVariance): ConstArray[T] =
+    if(o.isDefined) this :+ o.get else this
+
+  ///////////////////////////////////////////////////////// slicing
+
+  def head: T = apply(0)
+
+  def last: T = apply(length-1)
+
+  def headOption: Option[T] = if(isEmpty) None else Some(head)
+
+  def lastOption: Option[T] = if(isEmpty) None else Some(last)
+
+  def slice(from: Int, until: Int): ConstArray[T] = {
+    if(from == 0) {
+      if(until == length) this
+      else new ConstArray(a, until)
+    } else new ConstArray(Arrays.copyOfRange[AnyRef](a.asInstanceOf[Array[AnyRef]], from, until).asInstanceOf[Array[Any]])
+  }
+
+  def tail = slice(1, length)
+
+  def init = slice(0, length-1)
+
+  def take(n: Int) = slice(0, math.min(n, length))
+
+  def drop(n: Int) =
+    if(n >= length) ConstArray.empty else slice(n, length-n)
+
+  ///////////////////////////////////////////////////////// Equals
+
+  def canEqual(that: Any): Boolean = that.isInstanceOf[ConstArray[_]]
+
+  private[this] var _hashCode: Int = 0
+
+  override def hashCode = {
+    if(_hashCode != 0) _hashCode
+    else {
+      val h = MurmurHash3.productHash(this)
+      _hashCode = h
+      h
+    }
+  }
+
+  override def equals(o: Any): Boolean = o match {
+    case o: ConstArray[_] =>
+      if(length != o.length) false
+      else {
+        var i = 0
+        while(i < length) {
+          if(a(i) != o(i)) return false
+          i += 1
+        }
+        true
+      }
+    case _ => false
+  }
+
+  ///////////////////////////////////////////////////////// Product
+
+  def productArity = length
+
+  def productElement(i: Int): Any = apply(i)
+
+  override def productPrefix = "ConstArray"
+}
+
+object ConstArray {
+  val empty: ConstArray[Nothing] = new ConstArray[Nothing](new Array[Any](0))
+
+  def apply[T](v0: T): ConstArray[T] = {
+    val a = new Array[Any](1)
+    a(0) = v0
+    new ConstArray(a)
+  }
+
+  def apply[T](v0: T, v1: T): ConstArray[T] = {
+    val a = new Array[Any](2)
+    a(0) = v0
+    a(1) = v1
+    new ConstArray(a)
+  }
+
+  def apply[T](v0: T, v1: T, v2: T): ConstArray[T] = {
+    val a = new Array[Any](3)
+    a(0) = v0
+    a(1) = v1
+    a(2) = v2
+    new ConstArray(a)
+  }
+
+  def from[T](values: Traversable[T]): ConstArray[T] = {
+    val a = new Array[Any](values.size)
+    var i = 0
+    values.foreach { v =>
+      a(i) = v
+      i += 1
+    }
+    new ConstArray[T](a)
+  }
+
+  def from[T](o: Option[T]): ConstArray[T] =
+    if(o.isDefined) apply(o.get) else empty
+
+  def unsafeWrap[T](values: Array[Any]): ConstArray[T] =
+    new ConstArray(values)
+
+  //def unapplySeq[T](a: ConstArray[T]) = new ConstArrayExtract[T](a) // Requires Scala 2.11
+  def unapplySeq[T](a: ConstArray[T]): Some[IndexedSeq[T]] = Some(a.toSeq)
+
+  def newBuilder[T](initialCapacity: Int = 16, growFactor: Double = 2.0): ConstArrayBuilder[T] =
+    new ConstArrayBuilder[T](initialCapacity, growFactor)
+}
+
+/** A lazy operation on a ConstArray, produced by `withFilter`, `zip`, `zipWithIndex` and
+  * `ConstArrayOp.from(Range)`. */
+trait ConstArrayOp[+T] extends Any {
+  def map[R](f: T => R): ConstArray[R]
+  def foreach[R](f: T => R): Unit
+  def force: ConstArray[T] = map(identity)
+}
+
+object ConstArrayOp {
+  def from(r: Range): RangeConstArrayOp = new RangeConstArrayOp(r)
+}
+
+final class RangeConstArrayOp(val r: Range) extends ConstArrayOp[Int] {
+  def map[R](f: Int => R): ConstArray[R] = {
+    val len = r.length
+    val a = new Array[Any](len)
+    var i = 0
+    var v = r.start
+    while(i < len) {
+      a(i) = f(v)
+      i += 1
+      v += r.step
+    }
+    ConstArray.unsafeWrap[R](a)
+  }
+  def foreach[R](f: Int => R): Unit = r.foreach(f)
+}
+
+/*final class ConstArrayExtract[T](val ca: ConstArray[T]) extends AnyVal {
+  def isEmpty = ca eq null
+  def get = ca
+}*/
+
+/** A mutable builder for ConstArrays. */
+final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double = 2.0) { self =>
+  private[this] var a: Array[Any] = new Array[Any](initialCapacity)
+  private[this] var len: Int = 0
+
+  def result: ConstArray[T] =
+    if(len == 0) ConstArray.empty
+    else new ConstArray[T](a, len)
+
+  def += (v: T): Unit = {
+    ensure(1)
+    a(len) = v
+    len += 1
+  }
+
+  def ++= (vs: ConstArray[T]): Unit = {
+    val vslen = vs.length
+    ensure(vslen)
+    vs.copySliceTo(a, 0, len, vslen)
+    len += vslen
+  }
+
+  def ++= (vs: TraversableOnce[T]): Unit = {
+    if(vs.isInstanceOf[IndexedSeq[_]]) ensure(vs.size)
+    vs.foreach(self += _)
+  }
+
+  def ++= (vs: Option[T]): Unit =
+    if(vs.isDefined) this += vs.get
+
+  private[this] def ensure(i: Int): Unit = {
+    val total = len + i
+    if(a.length < total)
+      a = Arrays.copyOf[Any](a.asInstanceOf[Array[AnyRef]], math.max((a.length * growFactor).toInt, total)).asInstanceOf[Array[Any]]
+  }
+
+  def + (v: T): this.type = { this += v; this }
+  def ++ (vs: ConstArray[T]): this.type = { this ++= vs; this }
+  def ++ (vs: TraversableOnce[T]): this.type = { this ++= vs; this }
+  def ++ (vs: Option[T]): this.type = { this ++= vs; this }
+}

--- a/slick/src/main/scala/slick/util/SQLBuilder.scala
+++ b/slick/src/main/scala/slick/util/SQLBuilder.scala
@@ -24,6 +24,14 @@ final class SQLBuilder { self =>
     }
   }
 
+  def sep[T](sequence: ConstArray[T], separator: String)(f: T => Unit) {
+    var first = true
+    for(x <- sequence) {
+      if(first) first = false else self += separator
+      f(x)
+    }
+  }
+
   def build = Result(sb.toString, { (p: PreparedStatement, idx: Int, param: Any) =>
     var i = idx
     for(s <- setters) {


### PR DESCRIPTION
Some micro-optimizations, including a custom collection implementation provide a further significant performance improvement. The query compiler is now more than twice as fast as it was in 3.0.