### PR TITLE
Create correct syntax for casts on MySQL

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMiscTest.scala
@@ -109,19 +109,22 @@ class RelationalMiscTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testCast = {
-    class T1(tag: Tag) extends Table[(String, Int)](tag, "t1_4") {
+    class T1(tag: Tag) extends Table[(String, Int, Double)](tag, "t1_4") {
       def a = column[String]("a")
       def b = column[Int]("b")
-      def * = (a, b)
+      def c = column[Double]("c")
+      def * = (a, b, c)
     }
     val t1s = TableQuery[T1]
 
     for {
       _ <- t1s.schema.create
-      _ <- t1s ++= Seq(("foo", 1), ("bar", 2))
+      _ <- t1s ++= Seq(("foo", 1, 2.0), ("bar", 2, 2.0))
 
       q1 = t1s.map(t1 => t1.a ++ t1.b.asColumnOf[String])
       _ <- q1.to[Set].result.map(_ shouldBe Set("foo1", "bar2"))
+      q2 = t1s.map(t1 => t1.c * t1.b.asColumnOf[Double])
+      _ <- q2.to[Set].result.map(_ shouldBe Set(2.0, 4.0))
     } yield ()
   }
 

--- a/slick/src/main/scala/slick/driver/MySQLDriver.scala
+++ b/slick/src/main/scala/slick/driver/MySQLDriver.scala
@@ -142,7 +142,7 @@ trait MySQLDriver extends JdbcDriver { driver =>
     override def expr(n: Node, skipParens: Boolean = false): Unit = n match {
       case Library.Cast(ch) :@ JdbcType(ti, _) =>
         val tn = if(ti == columnTypes.stringJdbcType) "VARCHAR" else ti.sqlTypeName(None)
-        b"{fn convert(!${ch},$tn)}"
+        b"\({fn convert(!${ch},$tn)}\)"
       case Library.NextValue(SequenceNode(name)) => b"`${name + "_nextval"}()"
       case Library.CurrentValue(SequenceNode(name)) => b"`${name + "_currval"}()"
       case RowNum(sym, true) => b"(@`$sym := @`$sym + 1)"


### PR DESCRIPTION
Slick actually creates `{fn convert}` calls but the MySQL JDBC driver
translates them in a way that messes up operator precedence, so we now
wrap them in parentheses to be on the safe side.

Fixes #1102. Test in RelationalMiscTest.testCast.