### PR TITLE
Use correct discriminator checks under three-valued logic

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -306,4 +306,29 @@ class JoinTest extends AsyncTest[RelationalTestDB] {
       q3.result.named("q3").map(_.toSet shouldBe Set((1,1), (2,2)))
     )
   }
+
+  def testDiscriminatorCheck = {
+    class A(tag: Tag) extends Table[Int](tag, "a_joinfiltering") {
+      def id = column[Int]("id")
+      def * = id
+    }
+    lazy val as = TableQuery[A]
+
+    class B(tag: Tag) extends Table[Option[Int]](tag, "b_joinfiltering") {
+      def id = column[Option[Int]]("id")
+      def * = id
+    }
+    lazy val bs = TableQuery[B]
+
+    val q = for {
+      (a, b) <- as joinLeft bs on (_.id.? === _.id) if (b.isEmpty)
+    } yield (a.id)
+
+    DBIO.seq(
+      (as.schema ++ bs.schema).create,
+      as ++= Seq(1,2,3),
+      bs ++= Seq(1,2,4,5).map(Some.apply _),
+      q.result.map(_.toSet shouldBe Set(3))
+    )
+  }
 }


### PR DESCRIPTION
`expandSums` used to generate discriminator checks of the form
`disc == 1` which do not compose correctly when the discriminator is
null, so we now use `disc is not null` instead.

Fixes #1156. Test in JoinTest.testDiscriminatorCheck.