### PR TITLE
Fill typing holes in hoistClientOps

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
@@ -105,4 +105,29 @@ class UnionTest extends AsyncTest[RelationalTestDB] {
       q3.result.map(r => r.toSet shouldBe Set((10L, 1L), (20L, 2L), (30L, 3L), (100L, 1L), (200L, 2L), (300L, 3L)))
     )
   }
+
+  def testOptionUnion = {
+    case class Article(id: String, name: String)
+    class ArticleTable(tag: Tag) extends Table[Article](tag, "testOptionUnion") {
+      def id = column[String]("id")
+      def name = column[String]("name")
+
+      def * = (id, name) <> (Article.tupled, Article.unapply)
+    }
+    val table = TableQuery[ArticleTable]
+
+    val q1 = for {
+      t <- table
+    } yield (t, t.id.?)
+
+    val q2 = for {
+      t <- table
+    } yield (t, t.id.?)
+
+    val q3 = q1.unionAll(q2)
+    DBIO.seq(
+      table.schema.create,
+      q3.result
+    )
+  }
 }

--- a/slick/src/main/scala/slick/compiler/HoistClientOps.scala
+++ b/slick/src/main/scala/slick/compiler/HoistClientOps.scala
@@ -20,7 +20,7 @@ class HoistClientOps extends Phase {
       val base = new AnonSymbol
       val proj = ProductNode(ch.map { case (sym, _) => Select(Ref(base), sym) })
       val t2 = ResultSetMapping(base, withStruct, proj)
-      val t3 = hoist(t2)
+      val t3 = hoist(t2).nodeWithComputedType(typeChildren = true)
       val (rsmFrom, rsmProj) =
         if(t3 eq t2) {
           // Use original ProductNode form


### PR DESCRIPTION
Fixes #1170. Test in UnionTest.testOptionUnion.

This fix is only needed in 3.0. The query compiler handles this situation differently in 3.1, which also fixes the bug.