### PR TITLE
codegen: schema: Handle case of no tables

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -29,8 +29,10 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
       (
         if(tables.length > 5)
           "\nlazy val schema: profile.SchemaDescription = Array(" + tables.map(_.TableValue.name + ".schema").mkString(", ") + ").reduceLeft(_ ++ _)"
-        else
+        else if(tables.nonEmpty)
           "\nlazy val schema: profile.SchemaDescription = " + tables.map(_.TableValue.name + ".schema").mkString(" ++ ")
+        else
+          "\nlazy val schema: profile.SchemaDescription = profile.DDL(Nil, Nil)"
       ) +
       "\n@deprecated(\"Use .schema instead of .ddl\", \"3.0\")"+
       "\ndef ddl = schema" +

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateMainSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateMainSources.scala
@@ -105,7 +105,8 @@ val  SimpleA = CustomTyping.SimpleA
           |  ).transactionally
         """.stripMargin
     },
-    new UUIDConfig("Postgres2", StandardTestDBs.Postgres, "Postgres", Seq("/dbs/uuid.sql"))
+    new UUIDConfig("Postgres2", StandardTestDBs.Postgres, "Postgres", Seq("/dbs/uuid.sql")),
+    new Config("EmptyDB", StandardTestDBs.H2Mem, "H2Mem", Nil)
   )
 
   //Unified UUID config

--- a/slick-testkit/src/test/scala/slick/test/codegen/GeneratedCodeTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/codegen/GeneratedCodeTest.scala
@@ -135,6 +135,8 @@ object GeneratedCodeTest {
     )
   }
 
+  def testEmptyDB = slick.dbio.DBIO.successful(())
+
   def tableName( node:Node ) : String = {
     import slick.ast._
     node match {


### PR DESCRIPTION
Currently when there are no tables and schema generation is enabled (the default), codegen will ouput

```scala
lazy val schema: profile.SchemaDescription = 
```

which is of course invalid syntax. (the next line is the `@deprecated` annotation)

This is to fix that.
