### PR TITLE
Prevent retry of lazy Connection acquisition attempt in BaseSession:

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -394,7 +394,12 @@ trait JdbcBackend extends RelationalBackend {
     def isOpen = open
     def isInTransaction = inTransactionally > 0
 
-    lazy val conn = { open = true; database.source.createConnection }
+    lazy val conn = {
+      val c = database.source.createConnection
+      open = true
+      c
+    }
+
     lazy val metaData = conn.getMetaData()
 
     def capabilities = {


### PR DESCRIPTION
We used to mark the Session as open as soon as `conn` is accessed. If
the actual initialization (i.e. getting a JDBC Connection from the pool)
fails, an attempt to `close()` the Session would trigger another
initialization attempt. This change marks the Session as open only after
initialization has succeeded.

Fixes #1181. Cherry-picked from #1261 