### PR TITLE
Add `Query.distinct` and `Query.distinctOn` operators

### DIFF
--- a/common-test-resources/logback.xml
+++ b/common-test-resources/logback.xml
@@ -34,6 +34,7 @@
     <logger name="slick.compiler.OptimizeScalar"            level="${log.qcomp.optimizeScalar:-inherited}" />
     <logger name="slick.compiler.FixRowNumberOrdering"      level="${log.qcomp.fixRowNumberOrdering:-inherited}" />
     <logger name="slick.compiler.PruneProjections"          level="${log.qcomp.pruneProjections:-inherited}" />
+    <logger name="slick.compiler.RewriteDistinct"           level="${log.qcomp.rewriteDistinct:-inherited}" />
     <logger name="slick.compiler.RewriteBooleans"           level="${log.qcomp.rewriteBooleans:-inherited}" />
     <logger name="slick.compiler.SpecializeParameters"      level="${log.qcomp.specializeParameters:-inherited}" />
     <logger name="slick.compiler.CodeGen"                   level="${log.qcomp.codeGen:-inherited}" />

--- a/slick-testkit/src/doctest/resources/logback.xml
+++ b/slick-testkit/src/doctest/resources/logback.xml
@@ -34,6 +34,7 @@
     <logger name="slick.compiler.OptimizeScalar"            level="${log.qcomp.optimizeScalar:-inherited}" />
     <logger name="slick.compiler.FixRowNumberOrdering"      level="${log.qcomp.fixRowNumberOrdering:-inherited}" />
     <logger name="slick.compiler.PruneProjections"          level="${log.qcomp.pruneProjections:-inherited}" />
+    <logger name="slick.compiler.RewriteDistinct"           level="${log.qcomp.rewriteDistinct:-inherited}" />
     <logger name="slick.compiler.RewriteBooleans"           level="${log.qcomp.rewriteBooleans:-inherited}" />
     <logger name="slick.compiler.SpecializeParameters"      level="${log.qcomp.specializeParameters:-inherited}" />
     <logger name="slick.compiler.CodeGen"                   level="${log.qcomp.codeGen:-inherited}" />

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala
@@ -1,9 +1,7 @@
 package com.typesafe.slick.testkit.tests
 
-import slick.SlickTreeException
 import slick.driver.H2Driver
 
-import scala.language.higherKinds
 import com.typesafe.slick.testkit.util.{RelationalTestDB, AsyncTest}
 
 class NewQuerySemanticsTest extends AsyncTest[RelationalTestDB] {
@@ -568,17 +566,5 @@ class NewQuerySemanticsTest extends AsyncTest[RelationalTestDB] {
       _ <- mark("q18", q18.result).map(_ shouldBe Seq(Some((3, "c", "b"))))
       _ <- mark("q19", q19.result).map(_.toSet shouldBe Set(Some((1,"a","a")), Some((2,"a","b")), Some((3,"c","b"))))
     } yield ()
-  }
-
-  def assertNesting(q: Rep[_], exp: Int): Unit = {
-    import slick.compiler.QueryCompiler
-    import slick.ast._
-    import slick.ast.Util._
-    val qc = new QueryCompiler(tdb.driver.queryCompiler.phases.takeWhile(_.name != "codeGen"))
-    val cs = qc.run(q.toNode)
-    val found = cs.tree.collect { case c: Comprehension => c }.length
-    if(found != exp)
-      throw cs.symbolNamer.use(new SlickTreeException(s"Found $found Comprehension nodes, should be $exp",
-        cs.tree, mark = (_.isInstanceOf[Comprehension]), removeUnmarked = false))
   }
 }

--- a/slick/src/main/scala/slick/ast/Comprehension.scala
+++ b/slick/src/main/scala/slick/ast/Comprehension.scala
@@ -8,15 +8,17 @@ import slick.util.ConstArray
 final case class Comprehension(sym: TermSymbol, from: Node, select: Node, where: Option[Node] = None,
                                groupBy: Option[Node] = None, orderBy: ConstArray[(Node, Ordering)] = ConstArray.empty,
                                having: Option[Node] = None,
+                               distinct: Option[Node] = None,
                                fetch: Option[Node] = None, offset: Option[Node] = None) extends DefNode {
   type Self = Comprehension
-  lazy val children = (ConstArray.newBuilder() + from + select ++ where ++ groupBy ++ orderBy.map(_._1) ++ having ++ fetch ++ offset).result
+  lazy val children = (ConstArray.newBuilder() + from + select ++ where ++ groupBy ++ orderBy.map(_._1) ++ having ++ distinct ++ fetch ++ offset).result
   override def childNames =
     Seq("from "+sym, "select") ++
     where.map(_ => "where") ++
     groupBy.map(_ => "groupBy") ++
     orderBy.map("orderBy " + _._2).toSeq ++
     having.map(_ => "having") ++
+    distinct.map(_ => "distinct") ++
     fetch.map(_ => "fetch") ++
     offset.map(_ => "offset")
   protected[this] def rebuild(ch: ConstArray[Node]) = {
@@ -30,7 +32,9 @@ final case class Comprehension(sym: TermSymbol, from: Node, select: Node, where:
     val newOrderBy = ch.slice(orderByOffset, orderByOffset + orderBy.length)
     val havingOffset = orderByOffset + newOrderBy.length
     val newHaving = ch.slice(havingOffset, havingOffset + having.productArity)
-    val fetchOffset = havingOffset + newHaving.length
+    val distinctOffset = havingOffset + newHaving.length
+    val newDistinct = ch.slice(distinctOffset, distinctOffset + distinct.productArity)
+    val fetchOffset = distinctOffset + newDistinct.length
     val newFetch = ch.slice(fetchOffset, fetchOffset + fetch.productArity)
     val offsetOffset = fetchOffset + newFetch.length
     val newOffset = ch.slice(offsetOffset, offsetOffset + offset.productArity)
@@ -41,28 +45,30 @@ final case class Comprehension(sym: TermSymbol, from: Node, select: Node, where:
       groupBy = newGroupBy.headOption,
       orderBy = orderBy.zip(newOrderBy).map { case ((_, o), n) => (n, o) },
       having = newHaving.headOption,
+      distinct = newDistinct.headOption,
       fetch = newFetch.headOption,
       offset = newOffset.headOption
     )
   }
   def generators = ConstArray((sym, from))
-  override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
   protected[this] def rebuildWithSymbols(gen: ConstArray[TermSymbol]) = copy(sym = gen.head)
   def withInferredType(scope: Type.Scope, typeChildren: Boolean): Self = {
     // Assign type to "from" Node and compute the resulting scope
     val f2 = from.infer(scope, typeChildren)
     val genScope = scope + (sym -> f2.nodeType.asCollectionType.elementType)
-    // Assign types to "select", "where", "groupBy", "orderBy", "having", "fetch" and "offset" Nodes
+    // Assign types to "select", "where", "groupBy", "orderBy", "having", "distinct", "fetch" and "offset" Nodes
     val s2 = select.infer(genScope, typeChildren)
     val w2 = mapOrNone(where)(_.infer(genScope, typeChildren))
     val g2 = mapOrNone(groupBy)(_.infer(genScope, typeChildren))
     val o = orderBy.map(_._1)
     val o2 = o.endoMap(_.infer(genScope, typeChildren))
     val h2 = mapOrNone(having)(_.infer(genScope, typeChildren))
+    val distinct2 = mapOrNone(distinct)(_.infer(genScope, typeChildren))
     val fetch2 = mapOrNone(fetch)(_.infer(genScope, typeChildren))
     val offset2 = mapOrNone(offset)(_.infer(genScope, typeChildren))
     // Check if the nodes changed
-    val same = (f2 eq from) && (s2 eq select) && w2.isEmpty && g2.isEmpty && (o2 eq o) && h2.isEmpty && fetch2.isEmpty && offset2.isEmpty
+    val same = (f2 eq from) && (s2 eq select) && w2.isEmpty && g2.isEmpty && (o2 eq o) && h2.isEmpty &&
+      distinct2.isEmpty && fetch2.isEmpty && offset2.isEmpty
     val newType =
       if(!hasType) CollectionType(f2.nodeType.asCollectionType.cons, s2.nodeType.asCollectionType.elementType)
       else nodeType
@@ -74,6 +80,7 @@ final case class Comprehension(sym: TermSymbol, from: Node, select: Node, where:
         groupBy = g2.orElse(groupBy),
         orderBy = if(o2 eq o) orderBy else orderBy.zip(o2).map { case ((_, o), n) => (n, o) },
         having = h2.orElse(having),
+        distinct = distinct2.orElse(distinct),
         fetch = fetch2.orElse(fetch),
         offset = offset2.orElse(offset)
       ) :@ newType

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -305,13 +305,18 @@ class TypeUtil(val tpe: Type) extends AnyVal {
     b.result
   }
 
-  def containsSymbol(tss: scala.collection.Set[TypeSymbol]): Boolean = {
+  def existsType(f: Type => Boolean): Boolean =
+    if(f(tpe)) true else tpe match {
+      case t: AtomicType => false
+      case t => t.children.exists(_.existsType(f))
+    }
+
+  def containsSymbol(tss: scala.collection.Set[TypeSymbol]): Boolean =
     if(tss.isEmpty) false else tpe match {
       case NominalType(ts, exp) => tss.contains(ts) || exp.containsSymbol(tss)
       case t: AtomicType => false
       case t => t.children.exists(_.containsSymbol(tss))
     }
-  }
 }
 
 object TypeUtil {

--- a/slick/src/main/scala/slick/compiler/ForceOuterBinds.scala
+++ b/slick/src/main/scala/slick/compiler/ForceOuterBinds.scala
@@ -6,7 +6,7 @@ import slick.util.ConstArray
 /** Ensure that all collection operations are wrapped in a Bind so that we
   * have a place for expanding references later. FilteredQueries are allowed
   * on top of collection operations without a Bind in between, unless that
-  * operation is a Join or a Pure node. */
+  * operation is a Join, Pure or Distinct node. */
 class ForceOuterBinds extends Phase {
   val name = "forceOuterBinds"
 
@@ -39,7 +39,7 @@ class ForceOuterBinds extends Phase {
   def nowrap(n: Node): Node = n match {
     case u: Union => u.mapChildren(wrap)
     case f: FilteredQuery => f.mapChildren { ch =>
-      if((ch eq f.from) && !(ch.isInstanceOf[Join] || ch.isInstanceOf[Pure])) nowrap(ch) else maybewrap(ch)
+      if((ch eq f.from) && !(ch.isInstanceOf[Join] || ch.isInstanceOf[Distinct] || ch.isInstanceOf[Pure])) nowrap(ch) else maybewrap(ch)
     }
     case b: Bind => b.mapChildren { ch =>
       if((ch eq b.from) || ch.isInstanceOf[Pure]) nowrap(ch)

--- a/slick/src/main/scala/slick/compiler/QueryCompiler.scala
+++ b/slick/src/main/scala/slick/compiler/QueryCompiler.scala
@@ -128,6 +128,7 @@ object QueryCompiler {
     Phase.createAggregates,
     Phase.resolveZipJoins,
     Phase.pruneProjections,
+    Phase.rewriteDistinct,
     Phase.createResultSetMapping,
     Phase.hoistClientOps,
     Phase.reorderOperations,
@@ -190,6 +191,7 @@ object Phase {
   val optimizeScalar = new OptimizeScalar
   val fixRowNumberOrdering = new FixRowNumberOrdering
   val pruneProjections = new PruneProjections
+  val rewriteDistinct = new RewriteDistinct
   val removeFieldNames = new RemoveFieldNames
 
   /* Extra phases that are not enabled by default */

--- a/slick/src/main/scala/slick/compiler/RewriteBooleans.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteBooleans.scala
@@ -36,7 +36,7 @@ class RewriteBooleans extends Phase {
     case Apply(sym, ch) :@ tpe if isBooleanLike(tpe) =>
       toFake(Apply(sym, ch)(n.nodeType).infer())
     // Where clauses, join conditions and case clauses need real boolean predicates
-    case n @ Comprehension(_, _, _, where, _, _, having, _, _) =>
+    case n @ Comprehension(_, _, _, where, _, _, having, _, _, _) =>
       n.copy(where = where.map(toReal), having = having.map(toReal)) :@ n.nodeType
     case n @ Join(_, _, _, _, _, on) =>
       n.copy(on = toReal(on)) :@ n.nodeType

--- a/slick/src/main/scala/slick/compiler/RewriteDistinct.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteDistinct.scala
@@ -1,0 +1,58 @@
+package slick.compiler
+
+import slick.ast.Library.AggregateFunctionSymbol
+import slick.ast.TypeUtil._
+import slick.ast.Util._
+import slick.ast._
+import slick.util.{Ellipsis, ConstArray}
+
+/** Rewrite "distinct on" to "distinct" or "group by" */
+class RewriteDistinct extends Phase {
+  val name = "rewriteDistinct"
+
+  def apply(state: CompilerState) = state.map(_.replace({
+
+    case n @ Bind(s1, Distinct(s2, from1, on1), Pure(sel1, ts1))  =>
+      logger.debug("Rewriting Distinct:", Ellipsis(n, List(0, 0)))
+      val refFields = sel1.collect[TermSymbol] {
+        case Select(Ref(s), f) if s == s1 => f
+      }.toSet
+      logger.debug("Referenced fields: " + refFields.mkString(", "))
+      val onFlat = ProductNode(ConstArray(on1)).flatten
+      val onNodes = onFlat.children.toSet
+      val onFieldPos = onNodes.iterator.zipWithIndex.collect[(TermSymbol, Int)] {
+        case (Select(Ref(s), f), idx) if s == s2 => (f, idx)
+      }.toMap
+      logger.debug("Fields used directly in 'on' clause: " + onFieldPos.keySet.mkString(", "))
+      if((refFields -- onFieldPos.keys).isEmpty) {
+        // Only distinct fields referenced -> Create subquery and remove 'on' clause
+        val onDefs = ConstArray.from(onNodes).map((new AnonSymbol, _))
+        val onLookup = onDefs.iterator.collect[(TermSymbol, AnonSymbol)] {
+          case (a, Select(Ref(s), f)) if s == s2 => (f, a)
+        }.toMap
+        val inner = Bind(s2, Distinct(new AnonSymbol, from1, ProductNode(ConstArray.empty)), Pure(StructNode(onDefs)))
+        val sel2 = sel1.replace {
+          case Select(Ref(s), f) if s == s1 => Select(Ref(s), onLookup(f))
+        }
+        val ret = Bind(s1, Subquery(inner, Subquery.AboveDistinct), Pure(sel2, ts1)).infer()
+        logger.debug("Removed 'on' clause from Distinct:", Ellipsis(ret, List(0, 0, 0, 0)))
+        ret
+      } else {
+        val sel2 = sel1.replace {
+          case Select(Ref(s), f) :@ tpe if s == s1 =>
+            onFieldPos.get(f) match {
+              case Some(idx) =>
+                Select(Select(Ref(s), ElementSymbol(1)), ElementSymbol(idx+1))
+              case None =>
+                val as = new AnonSymbol
+                Aggregate(as, Select(Ref(s), ElementSymbol(2)),
+                  Library.Min.typed(tpe, Select(Ref(as), f)))
+            }
+        }
+        val ret = Bind(s1, GroupBy(s2, from1, onFlat), Pure(sel2, ts1)).infer()
+        logger.debug("Transformed Distinct to GroupBy:", Ellipsis(ret, List(0, 0)))
+        ret
+      }
+
+  }, keepType = true, bottomUp = true))
+}

--- a/slick/src/main/scala/slick/compiler/SpecializeParameters.scala
+++ b/slick/src/main/scala/slick/compiler/SpecializeParameters.scala
@@ -14,9 +14,9 @@ class SpecializeParameters extends Phase {
     state.map(ClientSideOp.mapServerSide(_, keepType = true)(transformServerSide))
 
   def transformServerSide(n: Node): Node = {
-    val cs = n.collect { case c @ Comprehension(_, _, _, _, _, _, _, Some(_: QueryParameter), _) => c }
+    val cs = n.collect { case c @ Comprehension(_, _, _, _, _, _, _, _, Some(_: QueryParameter), _) => c }
     logger.debug("Affected fetch clauses in: "+cs.mkString(", "))
-    cs.foldLeft(n) { case (n, c @ Comprehension(_, _, _, _, _, _, _, Some(fetch: QueryParameter), _)) =>
+    cs.foldLeft(n) { case (n, c @ Comprehension(_, _, _, _, _, _, _, _, Some(fetch: QueryParameter), _)) =>
       val compiledFetchParam = QueryParameter(fetch.extractor, ScalaBaseType.longType)
       val guarded = n.replace({ case c2: Comprehension if c2 == c => c2.copy(fetch = Some(LiteralNode(0L))) }, keepType = true)
       val fallback = n.replace({ case c2: Comprehension if c2 == c => c2.copy(fetch = Some(compiledFetchParam)) }, keepType = true)

--- a/slick/src/main/scala/slick/compiler/VerifySymbols.scala
+++ b/slick/src/main/scala/slick/compiler/VerifySymbols.scala
@@ -23,7 +23,7 @@ class VerifySymbols extends Phase {
         verifyScoping(sel, syms + s)
       case b @ Bind(s, _, sel) =>
         throw new SlickTreeException("Unresolved monadic join: Non-Pure select clause in Bind "+s, b, mark = (_ eq sel))
-      case f: FilteredQuery =>
+      case f: ComplexFilteredQuery =>
         verifyScoping(f.from, syms)
         val chSyms = syms + f.generators.head._1
         f.children.tail.foreach(ch => verifyScoping(ch, chSyms))

--- a/slick/src/main/scala/slick/driver/MySQLDriver.scala
+++ b/slick/src/main/scala/slick/driver/MySQLDriver.scala
@@ -130,7 +130,7 @@ trait MySQLDriver extends JdbcDriver { driver =>
           first = false
           r
         case r @ Ref(s) if s == s1 => r.untyped
-      }), Subquery.Always).infer()
+      }), Subquery.Default).infer()
     }
   }
 

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -41,6 +41,27 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
     new ConstArray[R](ar)
   }
 
+  def collect[R](f: PartialFunction[T, R]): ConstArray[R] = {
+    var i, j = 0
+    var matched = true
+    def d(x: T): R = {
+      matched = false
+      null.asInstanceOf[R]
+    }
+    val ar = new Array[Any](length)
+    while(i < length) {
+      matched = true
+      val v = f.applyOrElse(a(i).asInstanceOf[T], d)
+      if(matched) {
+        ar(j) = v
+        j += 1
+      }
+      i += 1
+    }
+    if(j == 0) ConstArray.empty
+    else new ConstArray[R](ar, j)
+  }
+
   def flatMap[R](f: T => ConstArray[R]): ConstArray[R] = {
     var len = 0
     val buf = new Array[ConstArray[R]](length)

--- a/slick/src/main/scala/slick/util/SQLBuilder.scala
+++ b/slick/src/main/scala/slick/util/SQLBuilder.scala
@@ -25,10 +25,11 @@ final class SQLBuilder { self =>
   }
 
   def sep[T](sequence: ConstArray[T], separator: String)(f: T => Unit) {
-    var first = true
-    for(x <- sequence) {
-      if(first) first = false else self += separator
-      f(x)
+    var i = 0
+    while(i < sequence.length) {
+      if(i != 0) self += separator
+      f(sequence(i))
+      i += 1
     }
   }
 


### PR DESCRIPTION
- `distinctOn` is encoded in a new `Distinct` node type in the AST.
  `q.distinct` is equivalent to `q.distinctOn(identity)`.

- `Comprehension` gets a new field for an optional “distinct on” Node.
  A plain “distinct” is encoded as “distinct on ()” (an empty
  ProductNode).

- In `forceOuterBinds` all `Distinct` nodes are wrapped (like `Join`
  and `Pure`).

- In `expandTables` table types are expanded into their star projections
  in “distinct on” clauses so that distinctness is defined the same way
  as it would be if the operation was performed in Scala after getting
  the non-distinct results.

- A new phase `rewriteDistinct` after `pruneProjections` removes
  “distinct on” and replaces it by a simple “distinct” (with an extra
  subquery where necessary) or falls back to a “group by” aggregation
  when “distinct” is not possible.

- In `reorderOperations` only distinctness-preserving aliasing Binds can
  be pushed down into `Subquery.AboveDistinct` boundaries. Mappings are
  recognized as distinctness-preserving if they are purely aliasing and
  do not drop any fields from the original type.

- In `mergeToComprehensions` the new `Distinct` nodes are merged. This
  complicates things somewhat because the rules when something can be
  merged are not static anymore. We merge Distinct together with SortBy
  but enforce (both in `mergeSortBy` and in `mergeCommon`) that DISTINCT
  is not created on top of an existing DISTINCT or HAVING and that
  WHERE and HAVING are not created on top of an existing DISTINCT.

- JdbcStatementBuilderComponent produces the default SQL syntax for
  “distinct” and the PostgreSQL syntax for “distinct on”.

- `PostgresDriver` omits the `rewriteDistinct` phase, using a local
  optimization in the code generator instead to emit “on” clauses where
  possible without the risk of creating extra subqueries.

- Add support for `Distinct` to `QueryInterpreter`.

Fixes #96. Tests in AggregateTest.testDistinct.