### PR TITLE
Remove dependent types for `.delete` and `.findby` extension methods.

### DIFF
--- a/slick/src/main/scala/slick/driver/JdbcProfile.scala
+++ b/slick/src/main/scala/slick/driver/JdbcProfile.scala
@@ -9,7 +9,7 @@ import slick.ast._
 import slick.compiler.{Phase, QueryCompiler, InsertCompiler}
 import slick.lifted._
 import slick.jdbc._
-import slick.profile.{SqlDriver, SqlProfile, Capability}
+import slick.profile.{RelationalProfile, SqlDriver, SqlProfile, Capability}
 
 /** A profile for accessing SQL databases via JDBC. All drivers for JDBC-based databases
   * implement this profile. */
@@ -52,7 +52,7 @@ trait JdbcProfile extends SqlProfile with JdbcActionComponent
 
     implicit def jdbcFastPathExtensionMethods[T, P](mp: MappedProjection[T, P]) = new JdbcFastPathExtensionMethods[T, P](mp)
 
-    implicit def queryDeleteActionExtensionMethods[C[_]](q: Query[_ <: Table[_], _, C]): DeleteActionExtensionMethods =
+    implicit def queryDeleteActionExtensionMethods[C[_]](q: Query[_ <: RelationalProfile#Table[_], _, C]): DeleteActionExtensionMethods =
       createDeleteActionExtensionMethods(deleteCompiler.run(q.toNode).tree, ())
     implicit def runnableCompiledDeleteActionExtensionMethods[RU, C[_]](c: RunnableCompiled[_ <: Query[_, _, C], C[RU]]): DeleteActionExtensionMethods =
       createDeleteActionExtensionMethods(c.compiledDelete, c.param)

--- a/slick/src/main/scala/slick/profile/RelationalProfile.scala
+++ b/slick/src/main/scala/slick/profile/RelationalProfile.scala
@@ -35,7 +35,7 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
     implicit def columnToOptionColumn[T : BaseTypedType](c: Rep[T]): Rep[Option[T]] = c.?
     implicit def valueToConstColumn[T : TypedType](v: T) = new LiteralColumn[T](v)
     implicit def columnToOrdered[T : TypedType](c: Rep[T]): ColumnOrdered[T] = ColumnOrdered[T](c, Ordering())
-    implicit def tableQueryToTableQueryExtensionMethods[T <: Table[_], U](q: Query[T, U, Seq] with TableQuery[T]) =
+    implicit def tableQueryToTableQueryExtensionMethods[T <: RelationalProfile#Table[_], U](q: Query[T, U, Seq] with TableQuery[T]) =
       new TableQueryExtensionMethods[T, U](q)
 
     implicit def streamableCompiledInsertActionExtensionMethods[EU](c: StreamableCompiled[_, _, EU]): InsertActionExtensionMethods[EU] = createInsertActionExtensionMethods[EU](c.compiledInsert.asInstanceOf[CompiledInsert])
@@ -57,9 +57,9 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
     else base.addBefore(new EmulateOuterJoins(canJoinLeft, canJoinRight), Phase.expandRecords)
   }
 
-  class TableQueryExtensionMethods[T <: Table[_], U](val q: Query[T, U, Seq] with TableQuery[T]) {
+  class TableQueryExtensionMethods[T <: RelationalProfile#Table[_], U](val q: Query[T, U, Seq] with TableQuery[T]) {
     /** Get the schema description (DDL) for this table. */
-    def schema: SchemaDescription = buildTableSchemaDescription(q.shaped.value)
+    def schema: SchemaDescription = buildTableSchemaDescription(q.shaped.value.asInstanceOf[Table[_]])
 
     /** Create a `Compiled` query which selects all rows where the specified
       * key matches the parameter value. */


### PR DESCRIPTION
While these types are correct, most other extension methods cannot
impose similar restrictions anyway, and not enforcing them makes the API
easier to use.

Fixes #1253.