### PR TITLE
Add `countDefined` operator:

### DIFF
--- a/slick/src/main/scala/slick/compiler/OptimizeScalar.scala
+++ b/slick/src/main/scala/slick/compiler/OptimizeScalar.scala
@@ -26,6 +26,10 @@ class OptimizeScalar extends Phase {
         if v == v2 && (z == null || z == None) =>
       v
 
+    // if(!false) v else _
+    case n @ IfThenElse(ConstArray(Library.Not(LiteralNode(false)), v, _)) =>
+      v
+
     // Redundant cast to non-nullable within OptionApply
     case o @ OptionApply(Library.SilentCast(n)) if o.nodeType == n.nodeType => n
 

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -155,10 +155,21 @@ final class AnyExtensionMethods(val n: Node) extends AnyVal {
 /** Extension methods for Queries of a single column */
 final class SingleColumnQueryExtensionMethods[B1, P1, C[_]](val q: Query[Rep[P1], _, C]) extends AnyVal {
   type OptionTM =  TypedType[Option[B1]]
+
+  /** Compute the minimum value of a single-column Query, or `None` if the Query is empty */
   def min(implicit tm: OptionTM) = Library.Min.column[Option[B1]](q.toNode)
+
+  /** Compute the maximum value of a single-column Query, or `None` if the Query is empty */
   def max(implicit tm: OptionTM) = Library.Max.column[Option[B1]](q.toNode)
+
+  /** Compute the average of a single-column Query, or `None` if the Query is empty */
   def avg(implicit tm: OptionTM) = Library.Avg.column[Option[B1]](q.toNode)
+
+  /** Compute the sum of a single-column Query, or `None` if the Query is empty */
   def sum(implicit tm: OptionTM) = Library.Sum.column[Option[B1]](q.toNode)
+
+  /** Count the number of `Some` elements of a single-column Query. */
+  def countDefined(implicit ev: P1 <:< Option[_]) = Library.Count.column[Int](q.toNode)
 }
 
 /** Extension methods for Options of single- and multi-column values */

--- a/slick/src/sphinx/upgrade.rst
+++ b/slick/src/sphinx/upgrade.rst
@@ -58,13 +58,18 @@ was moved from package ``slick.jdbc`` to ``slick.jdbc.hikaricp``.
 Counting Option columns
 -----------------------
 
-Counting any multi-column collection with `.length` now ignores nullability of the columns. The previous
-approach of picking a random column led to inconsistent results. This is particularly relevant when you
-try to count one side of an outer join. Up to Slick 3.0 the goal (although not achieved in all cases due
-to a design problem) was not to include non-matching rows in the total (equivalent to counting the
-discriminator column only). This does not make sense anymore for the new outer join operators (introduced
-in 3.0) with correct `Option` types. The new semantics are identical to those of Scala collections.
-Semantics for counts of single columns remain unchanged.
+Counting collection-valued queries with ``.length`` now ignores nullability of the columns, i.e. it
+is equivalent to ``COUNT(*)`` in SQL, no matter what is being counted. The previous approach of
+picking a random column led to inconsistent results. This is particularly relevant when you try to
+count one side of an outer join. Up to Slick 3.0 the goal (although not achieved in all cases due
+to a design problem) was not to include non-matching rows in the total (equivalent to counting only
+the discriminator column). This does not make sense anymore for the new outer join operators
+(introduced in 3.0) with correct ``Option`` types. The new semantics are identical to those of
+Scala collections.
+
+There is a new operator ``.countDefined`` for counting only the defined / matching (i.e. non-NULL
+in SQL) rows. To avoid any ambiguities in the definition, it is only available for
+collection-valued queries of a single column with an ``Option`` type.
 
 Default String type on MySQL
 ----------------------------


### PR DESCRIPTION
Following on from #1239, which actually changed `.length` semantics for
all queries, not only those of a single column as documented, we add a
new `.countDefined` operator that performs a count of a single column,
omitting NULL rows.

As revealed by the new test cases, 3VL semantics for aggregation
operators were broken in QueryInterpreter. This is fixed, too.

Tests in AggregateTest. Fixes #1285.