### PR TITLE
Some bug fixes concerning Option types:

### DIFF
--- a/slick/src/main/scala/slick/compiler/InsertCompiler.scala
+++ b/slick/src/main/scala/slick/compiler/InsertCompiler.scala
@@ -34,6 +34,7 @@ class InsertCompiler(val mode: InsertCompiler.Mode) extends Phase {
 
     def tr(n: Node): Node = n match {
       case _: OptionApply | _: GetOrElse | _: ProductNode | _: TypeMapping => n.mapChildren(tr, keepType = true)
+      case OptionFold(from, _, Ref(s2), s1) if s1 == s2 => tr(GetOrElse(from, null).infer())
       case te @ TableExpansion(_, _, expansion) =>
         setTable(te)
         tr(expansion)

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -103,7 +103,7 @@ final class BooleanColumnExtensionMethods[P1](val c: Rep[P1]) extends AnyVal wit
     om.column(Library.And, n, b.toNode)
   def ||[P2, R](b: Rep[P2])(implicit om: o#arg[Boolean, P2]#to[Boolean, R]) =
     om.column(Library.Or, n, b.toNode)
-  def unary_! = Library.Not.column[Boolean](n)
+  def unary_! = Library.Not.column[P1](n)
 }
 
 /** Extension methods for Rep[String] and Rep[Option[String]] */

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -417,6 +417,8 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
       replace(args(1)._2.asInstanceOf[String], args(2)._2.asInstanceOf[String])
     case Library.Reverse => args(0)._2.asInstanceOf[String].reverse
     case Library.IndexOf => args(0)._2.asInstanceOf[String].indexOf(args(1)._2.asInstanceOf[String])
+    case Library.StartsWith => args(0)._2.asInstanceOf[String].startsWith(args(1)._2.asInstanceOf[String])
+    case Library.EndsWith => args(0)._2.asInstanceOf[String].endsWith(args(1)._2.asInstanceOf[String])
   }
 
   def unwrapSingleColumn(coll: Coll, tpe: Type): (Iterator[Any], Type) = tpe.asCollectionType.elementType match {


### PR DESCRIPTION
- Allow `GetOrElse`-equivalent `OptionFold` in insert operations. This
  is required for using `getOrElse` calls in inserts, which was
  supported before 2.1 when they were always encoded as `GetOrElse`.

- Produce the correct Option-mapped type for the `unary_!` operator.
  It used to return `Boolean` instead of `Option[Boolean]` when applied
  to an operand of type `Option[Boolean]`.

- Implement `Library.StartsWith` and `Library.EndsWith` in
  `QueryInterpreter`.

Test in NestingTest.testGetOrElse. Fixes the remaining issues of #1018.
The main problem was already fixed in the Option improvements in 2.1 and
the new query compiler back-end in 3.1.