### PR TITLE
Allow illegal length CHAR defaults to be ignored in JdbcModelBuilder

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
@@ -223,7 +223,6 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
             v.length match {
               case 1 => v(0)
               case 3 => v(1) // quoted character
-              case n => throw new SlickException(s"""Default value "$v" for Char column "$name" has wrong size""")
             }
           case (v,"String") if meta.typeName == "CHAR" => v.head // FIXME: check length
           case (v,"scala.math.BigDecimal") => v // FIXME: probably we shouldn't use a string here


### PR DESCRIPTION
With `ignoreInvalidDefaults = true` all illegal defaults should be
ignored. This was counteracted by throwing a `SlickException` when an
illegal length was detected in `default`. Removing this case makes the
`MatchError` bubble up so it can be either ignored or translated to a
`SlickException` in `convenientDefault`.

Fixes #1104.