### PR TITLE
Fix typing bug in `rewriteJoins`:

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -18,6 +18,7 @@ class JoinTest extends AsyncTest[RelationalTestDB] {
       def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
       def title = column[String]("title")
       def category = column[Int]("category")
+      def withCategory = Query(this) join categories
       def * = (id, title, category)
     }
     val posts = TableQuery[Posts]
@@ -48,6 +49,8 @@ class JoinTest extends AsyncTest[RelationalTestDB] {
         (c,p) <- categories join posts on (_.id === _.category)
       } yield (p.id, c.id, c.name, p.title)).sortBy(_._1)
       _ <- q2.map(p => (p._1, p._2)).result.map(_ shouldBe List((2,1), (3,2), (4,3), (5,2)))
+      q3 = posts.flatMap(_.withCategory)
+      _ <- mark("q3", q3.result).map(_ should (_.length == 20))
     } yield ()
   }
 

--- a/slick/src/main/scala/slick/compiler/RewriteJoins.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteJoins.scala
@@ -60,7 +60,7 @@ class RewriteJoins extends Phase {
       val oj4 = rearrangeJoinConditions(oj3)
       val sel3 = if(m.isEmpty) sel2 else sel2.replace {
         case p @ FwdPath(r1 :: rest) if r1 == sn && m.contains(rest) => m(rest)
-        case r @ Ref(s) if (oj4 ne oj3) && s == sn => r.untyped // Structural expansion may have changed
+        case r @ Ref(s) if (oj4 ne oj2) && s == sn => r.untyped // Structural expansion may have changed
       }
       val res = Bind(sn, oj4, sel3.untypeReferences(invalid)).infer()
       logger.debug("Hoisted flatMapped Join in:", Ellipsis(res, List(0, 0)))


### PR DESCRIPTION
Not only `rearrangeJoinConditions` can invalidate types produced by a
Join but also `eliminateIllegalRefs`, so we have to retype references
if either one changes the AST.

Test in JoinTest.testJoin. Fixes #737.