### PR TITLE
Allow insert operations with no columns to insert.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -40,6 +40,20 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     ))
   }
 
+  def testEmptyInsert = {
+    class A(tag: Tag) extends Table[Int](tag, "A_EMPTYINSERT") {
+      def id = column[Int]("id", O.AutoInc, O.PrimaryKey)
+      def * = id
+    }
+    val as = TableQuery[A]
+
+    DBIO.seq(
+      as.schema.create,
+      as += 42,
+      as.result.map(_ shouldBe Seq(1))
+    )
+  }
+
   def testReturning = ifCap(jcap.returnInsertKey) {
     class A(tag: Tag) extends Table[(Int, String, String)](tag, "A") {
       def id = column[Int]("ID", O.PrimaryKey, O.AutoInc)

--- a/slick/src/main/scala/slick/ast/Insert.scala
+++ b/slick/src/main/scala/slick/ast/Insert.scala
@@ -3,7 +3,7 @@ package slick.ast
 import slick.util.ConstArray
 
 /** Represents an Insert operation. */
-final case class Insert(tableSym: TermSymbol, table: Node, linear: Node) extends BinaryNode with DefNode {
+final case class Insert(tableSym: TermSymbol, table: Node, linear: Node, allFields: ConstArray[FieldSymbol]) extends BinaryNode with DefNode {
   type Self = Insert
   def left = table
   def right = linear
@@ -16,7 +16,7 @@ final case class Insert(tableSym: TermSymbol, table: Node, linear: Node) extends
     val lin2 = linear.infer(scope + (tableSym -> table2.nodeType), typeChildren)
     withChildren(ConstArray[Node](table2, lin2)) :@ (if(!hasType) lin2.nodeType else nodeType)
   }
-  override def getDumpInfo = super.getDumpInfo.copy(mainInfo = "")
+  override def getDumpInfo = super.getDumpInfo.copy(mainInfo = allFields.mkString("allFields=[", ", ", "]"))
 }
 
 /** A column in an Insert operation. */

--- a/slick/src/main/scala/slick/driver/SQLiteDriver.scala
+++ b/slick/src/main/scala/slick/driver/SQLiteDriver.scala
@@ -126,7 +126,8 @@ trait SQLiteDriver extends JdbcDriver { driver =>
 
   override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
-  override def createUpsertBuilder(node: Insert): InsertBuilder = new UpsertBuilder(node)
+  override def createUpsertBuilder(node: Insert): super.InsertBuilder = new UpsertBuilder(node)
+  override def createInsertBuilder(node: Insert): super.InsertBuilder = new InsertBuilder(node)
   override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new TableDDLBuilder(table)
   override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder = new ColumnDDLBuilder(column)
   override def createInsertActionExtensionMethods[T](compiled: CompiledInsert): InsertActionExtensionMethods[T] =
@@ -178,6 +179,10 @@ trait SQLiteDriver extends JdbcDriver { driver =>
   /* Extending super.InsertBuilder here instead of super.UpsertBuilder. INSERT OR REPLACE is almost identical to INSERT. */
   class UpsertBuilder(ins: Insert) extends super.InsertBuilder(ins) {
     override protected def buildInsertStart = allNames.mkString(s"insert or replace into $tableName (", ",", ") ")
+  }
+
+  class InsertBuilder(ins: Insert) extends super.InsertBuilder(ins) {
+    override protected def emptyInsert: String = s"insert into $tableName default values"
   }
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -85,7 +85,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { drive
     createInterpreter(session.database, param).run(tree).asInstanceOf[R]
 
   class InsertInvokerDef[T](tree: Node) {
-    protected[this] val ResultSetMapping(_, Insert(_, table: TableNode, _), CompiledMapping(converter, _)) = tree
+    protected[this] val ResultSetMapping(_, Insert(_, table: TableNode, _, _), CompiledMapping(converter, _)) = tree
 
     type SingleInsertResult = Unit
     type MultiInsertResult = Unit
@@ -196,7 +196,7 @@ trait MemoryDriver extends RelationalDriver with MemoryQueryingDriver with Memor
   override def computeQueryCompiler = super.computeQueryCompiler ++ QueryCompiler.interpreterPhases
 
   class InsertMappingCompiler(insert: Insert) extends ResultConverterCompiler[MemoryResultConverterDomain] {
-    val Insert(_, table: TableNode, ProductNode(cols)) = insert
+    val Insert(_, table: TableNode, ProductNode(cols), _) = insert
     val tableColumnIdxs = table.driverTable.asInstanceOf[Table[_]].create_*.zipWithIndex.toMap
 
     def createColumnConverter(n: Node, idx: Int, column: Option[FieldSymbol]): ResultConverter[MemoryResultConverterDomain, _] =

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -481,6 +481,8 @@ final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double =
   private[this] var a: Array[Any] = new Array[Any](initialCapacity)
   private[this] var len: Int = 0
 
+  def length = len
+
   def result: ConstArray[T] =
     if(len == 0) ConstArray.empty
     else new ConstArray[T](a, len)


### PR DESCRIPTION
This can occur when performing a soft insert into an auto-increment
column where all data is computed on the server side.

Fixes #1221. Test in InsertTest.testEmptyInsert.