### PR TITLE
Add support for running DBIOActions with user supplied session

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import de.johoop.testngplugin.TestNGPlugin._
 
 object SlickBuild extends Build {
 
-  val slickVersion = "3.0.3"
+  val slickVersion = "3.0.4-SNAPSHOT"
   val slickExtensionsVersion = "3.0.0" // Slick extensions version for links in the manual
   val binaryCompatSlickVersion = "3.0.0" // Slick base version for binary compatibility checks
   val scalaVersions = Seq("2.10.5", "2.11.6")

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -76,7 +76,14 @@ trait JdbcBackend extends RelationalBackend {
       * down. If this object represents a connection pool managed directly by Slick, it is also
       * closed. */
     def close: Unit = try executor.close() finally source.close()
-   }
+
+    override protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean, _session: Session): JdbcActionContext = {
+      new JdbcActionContext {
+        val useSameThread = _useSameThread
+        override val session = _session
+      }
+    }
+  }
 
   trait DatabaseFactoryDef extends super.DatabaseFactoryDef {
     /** Create a Database based on a [[JdbcDataSource]]. */

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -52,6 +52,13 @@ trait DistributedBackend extends RelationalBackend with Logging {
 
     override def shutdown: Future[Unit] = Future.successful(())
     def close: Unit = ()
+
+    override protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean, _session: Session): BasicActionContext = {
+      new BasicActionContext {
+        val useSameThread = _useSameThread
+        override val session = _session
+      }
+    }
   }
 
   class DatabaseFactoryDef extends super.DatabaseFactoryDef {

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -56,6 +56,13 @@ trait HeapBackend extends RelationalBackend with Logging {
     def getTables: IndexedSeq[HeapTable] = synchronized {
       tables.values.toVector
     }
+
+    override protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean, _session: Session): BasicActionContext = {
+      new BasicActionContext {
+        val useSameThread = _useSameThread
+        override val session = _session
+      }
+    }
   }
 
   def createEmptyDatabase: Database = {


### PR DESCRIPTION
It seems to work, though I'm not sure if I covered all use cases.

Here is an example usage: https://github.com/pbatko/slick3-migration-playground

    def invokeAction[R, S <: slick.dbio.NoStream, E <: slick.dbio.Effect](action: DBIOAction[R, S, E])
                                                                       (implicit session: Session): R = {
        val db = session.database
        Await.result(db.runWithSession(action, session), queryTimeout)
    }
In the example usage project I had some trouble with importing the session. The import I was usually using was getting me a type projection whereas `runWithSession` expects a path-dependent type. I solved it by shuffling the imports like this:

    //Following import causes an error:
    /*
    [error]  found   : slick.driver.PostgresDriver.api.Session
    [error]     (which expands to)  slick.jdbc.JdbcBackend#SessionDef
    [error]  required: _13.SessionDef where val _13: slick.jdbc.JdbcBackend
    [error]     Await.result(db.runWithSession(action, session), queryTimeout)
     */
    //import slick.driver.PostgresDriver.api._
    
    //This works
    import slick.driver.PostgresDriver.api.{Session => _, _}
    import slick.driver.PostgresDriver.backend.Session

Does this feature have chances of getting merged into Slick?