### PR TITLE
Fix double transaction entrance for postgres upsert

### DIFF
--- a/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
@@ -173,7 +173,7 @@ trait PostgresProfile extends JdbcProfile {
       val nonAutoIncVars = nonAutoIncSyms.map(_ => "?").mkString(",")
       val cond = pkNames.map(n => s"$n=?").mkString(" and ")
       val insert = s"insert into $tableName ($nonAutoIncNames) select $nonAutoIncVars where not exists (select 1 from $tableName where $cond)"
-      new InsertBuilderResult(table, s"begin; $update; $insert; end", ConstArray.from(softSyms ++ pkSyms))
+      new InsertBuilderResult(table, s"$update; $insert", ConstArray.from(softSyms ++ pkSyms))
     }
 
     override def transformMapping(n: Node) = reorderColumns(n, softSyms ++ pkSyms ++ nonAutoIncSyms.toSeq ++ pkSyms)


### PR DESCRIPTION
The `InsertOrUpdate` action for postgres will generate ` WARNING:  there is already a transaction in progress` on database log because it enter the transaction in another transaction.
The `override protected lazy val useTransactionForUpsert = true` in L117 cause slick to invoke following SQL in database (logged by postgres):
```
LOG:  execute <unnamed>: BEGIN
LOG:  execute <unnamed>: begin
WARNING:  there is already a transaction in progress
LOG:  execute <unnamed>:  update "test" set _
DETAIL:  parameters: $1 = _ $2 = _
LOG:  execute <unnamed>:  insert into "test" (_) select $1,$2 where not exists (_ where _)
DETAIL:  parameters: $1 = _, $2 = _
LOG:  execute <unnamed>:  end
```