### PR TITLE
Remove duplicate reactive-streams bundle from osgitests/osgiBundleFiles

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -339,7 +339,7 @@ object SlickBuild extends Build {
       ),
       osgiBundleFiles := Seq((OsgiKeys.bundle in slickProject).value),
       osgiBundleFiles ++= (dependencyClasspath in Compile in slickProject).value.map(_.data).filterNot(_.isDirectory),
-      osgiBundleFiles ++= (dependencyClasspath in Test).value.map(_.data).filter(f => f.name.contains("logback-") || f.name.contains("h2") || f.name.contains("reactive-streams")),
+      osgiBundleFiles ++= (dependencyClasspath in Test).value.map(_.data).filter(f => f.name.contains("logback-") || f.name.contains("h2")),
       publishArtifact := false
     )
     dependsOn(slickProject % "test")


### PR DESCRIPTION
This causes a test failure in the Scala community build
(https://github.com/scala/community-builds/issues/12) even though it
does not affect the OSGi tests in the Slick project directly.