### PR TITLE
Update the example data url

### DIFF
--- a/slick/src/sphinx/code/FirstExample.scala
+++ b/slick/src/sphinx/code/FirstExample.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable.ArrayBuffer
 /**
  * A simple example that uses statically typed queries against an in-memory
  * H2 database. The example data comes from Oracle's JDBC tutorial at
- * http://download.oracle.com/javase/tutorial/jdbc/basics/tables.html.
+ * http://docs.oracle.com/javase/tutorial/jdbc/basics/tables.html.
  */
 object FirstExample extends App {
   val lines = new ArrayBuffer[Any]()

--- a/slick/src/sphinx/code/GettingStartedOverview.scala
+++ b/slick/src/sphinx/code/GettingStartedOverview.scala
@@ -11,7 +11,7 @@ import slick.jdbc.H2Profile.api._
 /**
  * A simple example that uses statically typed queries against an in-memory
  * H2 database. The example data comes from Oracle's JDBC tutorial at
- * http://download.oracle.com/javase/tutorial/jdbc/basics/tables.html.
+ * http://docs.oracle.com/javase/tutorial/jdbc/basics/tables.html.
  */
 object GettingStartedOverview extends App {
 //#quick-imports

--- a/slick/src/sphinx/code/PlainSQL.scala
+++ b/slick/src/sphinx/code/PlainSQL.scala
@@ -14,7 +14,7 @@ import slick.basic.{DatabaseConfig, StaticDatabaseConfig}
 
 /** A simple example that uses plain SQL queries against an in-memory
   * H2 database. The example data comes from Oracle's JDBC tutorial at
-  * http://download.oracle.com/javase/tutorial/jdbc/basics/tables.html. */
+  * http://docs.oracle.com/javase/tutorial/jdbc/basics/tables.html. */
 object PlainSQL extends App {
   var out = new ArrayBuffer[String]()
   def println(s: String): Unit = out += s


### PR DESCRIPTION
Update the Oracle's JDBC tutorial URL from http://download.oracle.com/javase/tutorial/jdbc/basics/tables.html to 
http://docs.oracle.com/javase/tutorial/jdbc/basics/tables.html