### PR TITLE
Add an example of using a subselect in a delete.

### DIFF
--- a/slick/src/sphinx/code/LiftedEmbedding.scala
+++ b/slick/src/sphinx/code/LiftedEmbedding.scala
@@ -266,12 +266,27 @@ object LiftedEmbedding extends App {
         Await.result(result, Duration.Inf)
       }
       {
-        //#delete
+        //#delete1
         val q = coffees.filter(_.supID === 15)
         val action = q.delete
         val affectedRowsCount: Future[Int] = db.run(action)
         val sql = action.statements.head
-        //#delete
+        //#delete1
+        Await.result(affectedRowsCount, Duration.Inf)
+      }
+      {
+        //#delete2
+        //
+        val q = coffees filter { coffee =>
+          // You can do any subquery here - this example uses the foreign key relation in coffees.
+          coffee.supID in (
+            coffee.supplier filter { _.name === "Delete Me" } map { _.id }
+          )
+        }
+        val action = q.delete
+        val affectedRowsCount: Future[Int] = db.run(action)
+        val sql = action.statements.head
+        //#delete2
         Await.result(affectedRowsCount, Duration.Inf)
       }
     }

--- a/slick/src/sphinx/queries.rst
+++ b/slick/src/sphinx/queries.rst
@@ -221,10 +221,14 @@ Deleting
 Deleting works very similarly to querying. You write a query which selects the
 rows to delete and then get an Action by calling the ``delete`` method on it:
 
-.. includecode:: code/LiftedEmbedding.scala#delete
+.. includecode:: code/LiftedEmbedding.scala#delete1
 
-A query for deleting must only select from a single table. Any projection is
-ignored (it always deletes full rows).
+A query for deleting must only use a single table - no joins are allowed (Slick does not yet support
+the ``USING`` keyword for deletes). Any projection is ignored (it always deletes full rows).
+
+If you need to perform a join, you can ``filter`` based on another ``Query``:
+
+.. includecode:: code/LiftedEmbedding.scala#delete2
 
 .. index:: insert, +=, ++=, InsertInvoker, insertStatement
 


### PR DESCRIPTION
Addresses [comment](https://github.com/slick/slick/issues/684#issuecomment-61398631) on issue #684. Tracking down how to do this type of delete took a long time.

I ran `testkit/doctest:test` to verify the sample code; I think that's how this is run, yes?

I'd like to verify the site formatting, but I'm not sure how to run that part of the build.