### PR TITLE
Support 'java.time' classes as JDBC types

### DIFF
--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -1,5 +1,8 @@
 package slick.jdbc
 
+import java.sql.{ResultSet, PreparedStatement}
+import java.time.{Instant, LocalDateTime, LocalTime}
+
 import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
@@ -278,24 +281,34 @@ trait MySQLProfile extends JdbcProfile { profile =>
   }
 
   class JdbcTypes extends super.JdbcTypes {
+
+    @inline
+    private[this] def stringToMySqlString(value : String) : String = {
+      value match {
+        case null => "NULL"
+        case _ =>
+          val sb = new StringBuilder
+          sb append '\''
+          for(c <- value) c match {
+            case '\'' => sb append "\\'"
+            case '"' => sb append "\\\""
+            case 0 => sb append "\\0"
+            case 26 => sb append "\\Z"
+            case '\b' => sb append "\\b"
+            case '\n' => sb append "\\n"
+            case '\r' => sb append "\\r"
+            case '\t' => sb append "\\t"
+            case '\\' => sb append "\\\\"
+            case _ => sb append c
+          }
+          sb append '\''
+          sb.toString
+      }
+    }
+
     override val stringJdbcType = new StringJdbcType {
-      override def valueToSQLLiteral(value: String) = if(value eq null) "NULL" else {
-        val sb = new StringBuilder
-        sb append '\''
-        for(c <- value) c match {
-          case '\'' => sb append "\\'"
-          case '"' => sb append "\\\""
-          case 0 => sb append "\\0"
-          case 26 => sb append "\\Z"
-          case '\b' => sb append "\\b"
-          case '\n' => sb append "\\n"
-          case '\r' => sb append "\\r"
-          case '\t' => sb append "\\t"
-          case '\\' => sb append "\\\\"
-          case _ => sb append c
-        }
-        sb append '\''
-        sb.toString
+      override def valueToSQLLiteral(value: String) : String = {
+        stringToMySqlString(value)
       }
     }
 
@@ -307,6 +320,58 @@ trait MySQLProfile extends JdbcProfile { profile =>
 
       override def valueToSQLLiteral(value: UUID): String =
         "x'"+value.toString.replace("-", "")+"'"
+    }
+
+    override val instantType : InstantJdbcType = new InstantJdbcType {
+      override def sqlType : Int = {
+        /**
+         * [[Instant]] will be persisted as a [[java.sql.Types.VARCHAR]] in order to
+         * avoid losing precision, because MySQL stores [[java.sql.Types.TIMESTAMP]] with
+         * second precision, while [[Instant]] stores it with a millisecond one.
+         */
+        java.sql.Types.VARCHAR
+      }
+      override def setValue(v: Instant, p: PreparedStatement, idx: Int) : Unit = {
+        p.setString(idx, if (v == null) null else v.toString)
+      }
+      override def getValue(r: ResultSet, idx: Int) : Instant = {
+        r.getString(idx) match {
+          case null => null
+          case iso8601String => Instant.parse(iso8601String)
+        }
+      }
+      override def updateValue(v: Instant, r: ResultSet, idx: Int) = {
+        r.updateString(idx, if (v == null) null else v.toString)
+      }
+      override def valueToSQLLiteral(value: Instant) : String = {
+        stringToMySqlString(value.toString)
+      }
+    }
+
+    override val localDateTimeType : LocalDateTimeJdbcType = new LocalDateTimeJdbcType {
+      override def sqlType : Int = {
+        /**
+         * [[LocalDateTime]] will be persisted as a [[java.sql.Types.VARCHAR]] in order to
+         * avoid losing precision, because MySQL stores [[java.sql.Types.TIMESTAMP]] with
+         * second precision, while [[LocalDateTime]] stores it with a millisecond one.
+         */
+        java.sql.Types.VARCHAR
+      }
+      override def setValue(v: LocalDateTime, p: PreparedStatement, idx: Int) : Unit = {
+        p.setString(idx, if (v == null) null else v.toString)
+      }
+      override def getValue(r: ResultSet, idx: Int) : LocalDateTime = {
+        r.getString(idx) match {
+          case null => null
+          case iso8601String => LocalDateTime.parse(iso8601String)
+        }
+      }
+      override def updateValue(v: LocalDateTime, r: ResultSet, idx: Int) = {
+        r.updateString(idx, if (v == null) null else v.toString)
+      }
+      override def valueToSQLLiteral(value: LocalDateTime) : String = {
+        stringToMySqlString(value.toString)
+      }
     }
   }
 }

--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -1,10 +1,11 @@
 package slick.jdbc
 
-import java.util.UUID
+import java.time.format.DateTimeFormatter
+import java.time._
+import java.util.{IllegalFormatException, UUID}
 
 import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
-
 import java.sql.{Array => _, _}
 
 import slick.SlickException
@@ -15,10 +16,12 @@ import slick.dbio._
 import slick.jdbc.meta.{MColumn, MTable}
 import slick.lifted._
 import slick.model.{ForeignKeyAction, Model}
-import slick.relational.{RelationalCapabilities, ResultConverter, RelationalProfile}
+import slick.relational.{RelationalCapabilities, RelationalProfile, ResultConverter}
 import slick.basic.Capability
 import slick.util.ConstArray
 import slick.util.MacroSupport.macroSupportInterpolation
+
+import scala.annotation.tailrec
 
 /** Slick profile for Oracle.
   *
@@ -264,6 +267,12 @@ trait OracleProfile extends JdbcProfile {
     override val stringJdbcType = new StringJdbcType
     override val timeJdbcType = new TimeJdbcType
     override val uuidJdbcType = new UUIDJdbcType
+    override val localDateType = new LocalDateJdbcType
+    override val localDateTimeType = new LocalDateTimeJdbcType
+    override val instantType = new InstantJdbcType
+    override val offsetTimeType = new OffsetTimeJdbcType
+    override val offsetDateTimeType = new OffsetDateTimeJdbcType
+    override val zonedDateType = new ZonedDateTimeJdbcType
 
     /* Oracle does not have a proper BOOLEAN type. The suggested workaround is
      * a constrained CHAR with constants 1 and 0 for TRUE and FALSE. */
@@ -325,6 +334,10 @@ trait OracleProfile extends JdbcProfile {
       override def valueToSQLLiteral(value: Time) = "{ts '"+(new Timestamp(value.getTime).toString)+"'}"
     }
 
+    class InstantJdbcType extends super.InstantJdbcType {
+      override def valueToSQLLiteral(value: Instant) = s"{ts '${Timestamp.from(value)}'}"
+    }
+
     class UUIDJdbcType extends super.UUIDJdbcType {
       override def sqlTypeName(sym: Option[FieldSymbol]) = "RAW(32)"
       override def valueToSQLLiteral(value: UUID) = {
@@ -333,6 +346,153 @@ trait OracleProfile extends JdbcProfile {
       }
       override def hasLiteralForm = true
     }
+
+    class LocalDateJdbcType extends super.LocalDateJdbcType {
+      override def hasLiteralForm: Boolean = true
+      override def valueToSQLLiteral(value: LocalDate) : String = {
+        s"TO_DATE('${value.toString}', 'SYYYY-MM-DD')"
+      }
+      override def getValue(r: ResultSet, idx: Int): LocalDate = {
+        LocalDate.parse(r.getString(idx).substring(0, 10))
+      }
+    }
+
+    class LocalTimeJdbcType extends super.LocalTimeJdbcType {
+      @inline private[this] def timestampFromLocalTime(localTime : LocalTime) : Timestamp = {
+        Timestamp.valueOf(LocalDateTime.of(LocalDate.MIN, localTime))
+      }
+      override def sqlType = java.sql.Types.TIMESTAMP
+      override def setValue(v: LocalTime, p: PreparedStatement, idx: Int) = {
+        p.setTimestamp(idx, timestampFromLocalTime(v))
+      }
+      override def getValue(r: ResultSet, idx: Int) : LocalTime = {
+        r.getTimestamp(idx) match {
+          case null => null
+          case timestamp => timestamp.toLocalDateTime.toLocalTime
+        }
+      }
+      override def updateValue(v: LocalTime, r: ResultSet, idx: Int) = {
+        r.updateTimestamp(idx, timestampFromLocalTime(v))
+      }
+      override def valueToSQLLiteral(value: LocalTime) : String = {
+        s"{ts '${timestampFromLocalTime(value).toString}'}"
+      }
+    }
+
+    /**
+      * TODO: This class is not implemented natively, it should be implemented as an Oracle 'TIMESTAMP'
+      */
+    class LocalDateTimeJdbcType extends super.LocalDateTimeJdbcType {
+      override def sqlType : Int = java.sql.Types.VARCHAR
+
+      override def setValue(v: LocalDateTime, p: PreparedStatement, idx: Int) : Unit = {
+        p.setString(idx, if (v == null) null else v.toString)
+      }
+      override def getValue(r: ResultSet, idx: Int) : LocalDateTime = {
+        r.getString(idx) match {
+          case null => null
+          case iso8601String => LocalDateTime.parse(iso8601String)
+        }
+      }
+      override def updateValue(v: LocalDateTime, r: ResultSet, idx: Int) = {
+        r.updateString(idx, if (v == null) null else v.toString)
+      }
+      override def valueToSQLLiteral(value: LocalDateTime) : String = {
+        s"'${value.toString}'"
+      }
+    }
+
+    // The following JDBC types native implementation do not work as expected yet,
+    // they still have some pending bugs when running the application in non-UTC Oracle
+    // machines.
+    /*
+    class LocalDateTimeJdbcType extends super.LocalDateTimeJdbcType {
+      private[this] val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
+      @tailrec
+      private[this] def deserializeTimeString(oracleVarchar : String) : LocalDateTime = {
+        oracleVarchar match {
+          case time if time.length == 26 =>
+            LocalDateTime.parse(time, formatter)
+          case time if time.length == 19 =>
+            LocalDateTime.parse(s"$time.000000", formatter)
+          case time if time.length > 19 && time.length < 26 =>
+            deserializeTimeString(s"${time}0")
+          case _ =>
+            throw new IllegalArgumentException(s"$oracleVarchar does not correspond to a valid LocalDateTime String.")
+        }
+      }
+      override def sqlType = java.sql.Types.OTHER
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "TIMESTAMP(6)"
+      override def valueToSQLLiteral(value: LocalDateTime) : String = {
+        s"TO_TIMESTAMP('${formatter.format(value)}','SYYYY-MM-DD HH24:MI:SS.FMFF6')"
+      }
+      override def hasLiteralForm: Boolean = true
+      override def getValue(r: ResultSet, idx: Int): LocalDateTime = {
+        deserializeTimeString(r.getString(idx))
+      }
+    }
+
+    // No Oracle time type without date component. Add LocalDate.ofEpochDay(0), but ignore it.
+    class OffsetTimeJdbcType extends super.OffsetTimeJdbcType {
+      private[this] val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS x")
+      private[this] def serializeTime(v : OffsetTime) : String = formatter.format(v.atDate(LocalDate.ofEpochDay(0)))
+      override def sqlType = java.sql.Types.TIMESTAMP_WITH_TIMEZONE
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "TIMESTAMP(6) WITH TIME ZONE"
+      override def setValue(v: OffsetTime, p: PreparedStatement, idx: Int) = {
+        p.setObject(idx, TimestamptzConverter.offsetTimeToTimestamptz(v), -101)
+      }
+      override def updateValue(v: OffsetTime, r: ResultSet, idx: Int) = {
+        r.updateString(idx, serializeTime(v))
+      }
+      override def getValue(r: ResultSet, idx: Int): OffsetTime = {
+        TimestamptzConverter.timestamptzToOffsetTime(r.getObject(idx))
+      }
+      override def hasLiteralForm: Boolean = true
+      override def valueToSQLLiteral(value: OffsetTime) = {
+        s"TO_TIMESTAMP_TZ('${serializeTime(value)}', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH')"
+      }
+    }
+
+    class OffsetDateTimeJdbcType extends super.OffsetDateTimeJdbcType {
+      private[this] val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS x")
+      private[this] def serializeTime(v : OffsetDateTime) : String = formatter.format(v)
+      override def sqlType = java.sql.Types.TIMESTAMP_WITH_TIMEZONE
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "TIMESTAMP(6) WITH TIME ZONE"
+      override def setValue(v: OffsetDateTime, p: PreparedStatement, idx: Int) = {
+        p.setObject(idx, TimestamptzConverter.offsetDateTimeToTimestamptz(v), -101)
+      }
+      override def updateValue(v: OffsetDateTime, r: ResultSet, idx: Int) = {
+        r.updateString(idx, serializeTime(v))
+      }
+      override def getValue(r: ResultSet, idx: Int): OffsetDateTime = {
+        TimestamptzConverter.timestamptzToOffsetDateTime(r.getObject(idx))
+      }
+      override def hasLiteralForm: Boolean = true
+      override def valueToSQLLiteral(value: OffsetDateTime) = {
+        s"TO_TIMESTAMP_TZ('${serializeTime(value)}', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH')"
+      }
+    }
+
+    class ZonedDateTimeJdbcType extends super.ZonedDateTimeJdbcType {
+      private[this] val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS VV")
+      private[this] def serializeTime(v : ZonedDateTime) : String = formatter.format(v)
+      override def sqlType = java.sql.Types.TIMESTAMP_WITH_TIMEZONE
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "TIMESTAMP(6) WITH TIME ZONE"
+      override def setValue(v: ZonedDateTime, p: PreparedStatement, idx: Int) = {
+        p.setObject(idx, TimestamptzConverter.zonedDateTimeToTimestamptz(v), -101)
+      }
+      override def updateValue(v: ZonedDateTime, r: ResultSet, idx: Int) = {
+        r.updateString(idx, serializeTime(v))
+      }
+      override def getValue(r: ResultSet, idx: Int): ZonedDateTime = {
+        TimestamptzConverter.timestamptzToZonedDateTime(r.getObject(idx))
+      }
+      override def hasLiteralForm: Boolean = true
+      override def valueToSQLLiteral(value: ZonedDateTime) = {
+        s"TO_TIMESTAMP_TZ('${serializeTime(value)}', 'YYYY-MM-DD HH24:MI:SS.FF3 TZR')"
+      }
+    }
+    */
   }
 
   /* Oracle throws an exception if you try to refer to a :new column in a
@@ -406,3 +566,169 @@ object OracleProfile extends OracleProfile {
     case class AutoIncTriggerName(name: String) extends ColumnOption[Nothing]
   }
 }
+
+
+/* The following code will be used when the native implementation of
+    java.time.OffsetDateTime, java.time.OffsetTime and java.time.ZonedDateTime
+    are natively implemented.
+/**
+  * Converts between {@link TIMESTAMPTZ} and java.time times and back.
+  * Oracle jar not on path at compile time (but must be a run time)
+  * Use reflection to get access to TIMESTAMPTZ class
+  */
+object TimestamptzConverter {
+  val timestampTZClass = Class.forName("oracle.sql.TIMESTAMPTZ")
+  val timestampTZCtor = timestampTZClass.getConstructor(classOf[Array[Byte]])
+  val timestampTZToBytes = timestampTZClass.getMethod("toBytes")
+  val zoneIdClass = Class.forName("oracle.sql.ZONEIDMAP")
+  val zoneIdgetId = zoneIdClass.getMethod("getID", classOf[String])
+  val zoneIdgetRegion = zoneIdClass.getMethod("getRegion", classOf[Int])
+
+  val REGIONIDBIT = Integer.parseInt("10000000",2)
+
+  // Byte 0: Century, offset is 100 (value - 100 is century)
+  // Byte 1: Decade, offset is 100 (value - 100 is decade)
+  // Byte 2: Month UTC
+  // Byte 3: Day UTC
+  // Byte 4: Hour UTC, offset is 1 (value-1 is UTC hour)
+  // Byte 5: Minute UTC, offset is 1 (value-1 is UTC Minute)
+  // Byte 6: Second, offset is 1 (value-1 is seconds)
+  // Byte 7: nanoseconds (most significant bit)
+  // Byte 8: nanoseconds
+  // Byte 9: nanoseconds
+  // Byte 10: nanoseconds (least significant bit)
+  // Byte 11: Hour UTC-offset of Timezone, offset is 20 (value-20 is UTC-hour offset)
+  // Byte 12: Minute UTC-offset of Timezone, offset is 60 (value-60 is UTC-minute offset)
+
+  def offsetDateTimeToTimestamptz(attribute: OffsetDateTime ) = {
+    val bytes = newTIMESTAMPTZBuffer()
+    val utc = attribute.atZoneSameInstant(java.time.ZoneOffset.UTC)
+    writeDateTime(bytes, utc)
+    val offset = attribute.getOffset
+    writeZoneOffset(bytes, offset)
+
+    timestampTZCtor.newInstance(bytes)
+  }
+
+  def timestamptzToOffsetDateTime(dbData: Object) = {
+    val bytes = timestampTZToBytes.invoke(dbData).asInstanceOf[Array[Byte]]
+    val utc = extractUtc(bytes)
+    if (isFixedOffset(bytes)) {
+      val offset = extractOffset(bytes)
+      utc.withOffsetSameInstant(offset)
+    } else {
+      val zoneId = extractZoneId(bytes)
+      utc.atZoneSameInstant(zoneId).toOffsetDateTime
+    }
+  }
+
+  def offsetTimeToTimestamptz(attribute: OffsetTime ) = {
+    val bytes = newTIMESTAMPTZBuffer()
+    val utc = attribute.atDate(LocalDate.ofEpochDay(0)).atZoneSameInstant(java.time.ZoneOffset.UTC)
+    writeDateTime(bytes, utc)
+    val offset = attribute.getOffset
+    writeZoneOffset(bytes, offset)
+
+    timestampTZCtor.newInstance(bytes)
+  }
+
+  def timestamptzToOffsetTime(dbData: Object) = {
+    val bytes = timestampTZToBytes.invoke(dbData).asInstanceOf[Array[Byte]]
+    val utc = extractUtc(bytes)
+    if (isFixedOffset(bytes)) {
+      val offset = extractOffset(bytes)
+      utc.withOffsetSameInstant(offset).toOffsetTime
+    } else {
+      val zoneId = extractZoneId(bytes)
+      utc.atZoneSameInstant(zoneId).toOffsetDateTime.toOffsetTime
+    }
+  }
+
+  def zonedDateTimeToTimestamptz(attribute: ZonedDateTime) = {
+    val bytes = newTIMESTAMPTZBuffer()
+    val utc = attribute.withZoneSameInstant(java.time.ZoneOffset.UTC)
+    writeDateTime(bytes, utc)
+
+    val zoneId = attribute.getZone().getId
+    val regionCode = zoneIdgetId.invoke(null, zoneId).asInstanceOf[Integer]
+
+    if (regionCode != -1) {
+      // -1 is invalid
+      writeZoneId(bytes, regionCode)
+    } else {
+      writeZoneOffset(bytes, attribute.getOffset)
+    }
+    timestampTZCtor.newInstance(bytes)
+  }
+
+  def timestamptzToZonedDateTime(dbData: Object) = {
+    val bytes = timestampTZToBytes.invoke(dbData).asInstanceOf[Array[Byte]]
+    val utc = extractUtc(bytes)
+    if (isFixedOffset(bytes)) {
+      val offset = extractOffset(bytes)
+      utc.atZoneSameInstant(offset)
+    } else {
+      val zoneId = extractZoneId(bytes)
+      utc.atZoneSameInstant(zoneId)
+    }
+  }
+
+  def extractUtc(bytes: Array[Byte]) = {
+    val year = ((bytes(0).toInt - 100) * 100) + (bytes(1).toInt - 100)
+    val month = bytes(2)
+    val dayOfMonth = bytes(3)
+    val hour = bytes(4) - 1
+    val minute = bytes(5) - 1
+    val second = bytes(6) - 1
+    val nanoOfSecond = ((bytes(7) & 0xFF) << 24) |
+      ((bytes(8) & 0xFF) << 16) |
+      ((bytes(9) & 0xFF) << 8) |
+      bytes(10) & 0xFF
+    OffsetDateTime.of(year, month, dayOfMonth, hour, minute, second, nanoOfSecond, java.time.ZoneOffset.UTC)
+  }
+
+  def isFixedOffset(bytes: Array[Byte]) = (bytes(11) & REGIONIDBIT) == 0
+
+  def newTIMESTAMPTZBuffer() = new Array[Byte](13)
+
+  def writeDateTime(bytes: Array[Byte], utc: ZonedDateTime ): Unit = {
+    val year = utc.getYear
+    bytes(0) = (year / 100 + 100).toByte
+    bytes(1) = (year % 100 + 100).toByte
+
+    bytes(2) = utc.getMonthValue.toByte
+    bytes(3) = utc.getDayOfMonth.toByte
+    bytes(4) = (utc.getHour + 1).toByte
+    bytes(5) = (utc.getMinute + 1).toByte
+    bytes(6) = (utc.getSecond + 1).toByte
+
+    val nano = utc.getNano
+    val ba = BigInt(nano).toByteArray
+    ba.zipWithIndex.foreach{ case (b,i) => bytes(11-ba.length + i) = b }
+  }
+
+  val OFFSET_HOUR = 20
+  val OFFSET_MINUTE = 60
+  def extractOffset(bytes: Array[Byte]) = ZoneOffset.ofHoursMinutes(bytes(11) - OFFSET_HOUR, bytes(12) - OFFSET_MINUTE)
+  def writeZoneOffset(bytes: Array[Byte], offset: ZoneOffset ): Unit = {
+    val totalMinutes = offset.getTotalSeconds / 60
+    bytes(11) = ((totalMinutes / 60) + OFFSET_HOUR).toByte
+    bytes(12) = ((totalMinutes % 60) + OFFSET_MINUTE).toByte
+  }
+
+  val highBits = Integer.parseInt("1111111", 2)
+  val lowBits = Integer.parseInt("11111100", 2)
+  def extractZoneId(bytes: Array[Byte]) = {
+    // high order bits
+    val regionCode: Integer = ((bytes(11) & highBits) << 6) + ((bytes(12) & lowBits) >> 2)
+    val regionName = zoneIdgetRegion.invoke(null, regionCode).asInstanceOf[String]
+    ZoneId.of(regionName)
+  }
+  val msb = Integer.parseInt("1111111000000", 2)
+  val lsb = Integer.parseInt("111111", 2)
+  def writeZoneId(bytes: Array[Byte], regionCode: Int): Unit = {
+    bytes(11) = (REGIONIDBIT | ((regionCode & msb) >>> 6)).toByte
+    bytes(12) = ((regionCode & lsb) << 2).toByte
+  }
+}
+*/

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -284,7 +284,7 @@ trait SQLServerProfile extends JdbcProfile {
               Time.valueOf(serializedTime).toLocalTime
             } else {
               val t: Time = Time.valueOf(serializedTime.substring(0, sep))
-              val millis = (("0." + serializedTime.substring(sep + 1)).toDouble * 1000.0).toInt
+              val millis = (s"0.${serializedTime.substring(sep + 1)}".toDouble * 1000.0).toInt
               t.setTime(t.getTime + millis)
               t.toLocalTime
             }
@@ -308,13 +308,13 @@ trait SQLServerProfile extends JdbcProfile {
         new DateTimeFormatterBuilder()
           .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
           .optionalStart()
-          .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, true)
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
           .optionalEnd()
           .toFormatter()
       }
       /* TIMESTAMP in SQL Server is a data type for sequence numbers. What we
        * want here is DATETIME. */
-      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME2(3)"
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME2(6)"
       override def getValue(r: ResultSet, idx: Int): LocalDateTime = {
         r.getTimestamp(idx) match {
           case null =>
@@ -328,7 +328,7 @@ trait SQLServerProfile extends JdbcProfile {
           case null =>
             "NULL"
           case _ =>
-            s"(convert(datetime2(3), {ts '${formatter.format(value)}'}))"
+            s"(convert(datetime2(6), {ts '${formatter.format(value)}'}))"
         }
       }
     }
@@ -337,7 +337,7 @@ trait SQLServerProfile extends JdbcProfile {
         new DateTimeFormatterBuilder()
           .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
           .optionalStart()
-          .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, true)
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
           .optionalEnd()
           .toFormatter()
       }
@@ -348,7 +348,7 @@ trait SQLServerProfile extends JdbcProfile {
       }
       /* TIMESTAMP in SQL Server is a data type for sequence numbers. What we
        * want here is DATETIME. */
-      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME2(3)"
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME2(6)"
       override def getValue(r: ResultSet, idx: Int): Instant = {
         r.getTimestamp(idx) match {
           case null =>
@@ -362,20 +362,20 @@ trait SQLServerProfile extends JdbcProfile {
           case null =>
             "NULL"
           case _ =>
-            s"(convert(datetime2(3), {ts '${serializeInstantValue(value)}'}))"
+            s"(convert(datetime2(6), {ts '${serializeInstantValue(value)}'}))"
         }
       }
     }
     class OffsetDateTimeJdbcType extends super.OffsetDateTimeJdbcType {
       override def sqlType = java.sql.Types.OTHER
       override val hasLiteralForm: Boolean = false
-      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIMEOFFSET(3)"
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIMEOFFSET(6)"
 
       private[this] val formatter: DateTimeFormatter = {
         new DateTimeFormatterBuilder()
           .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
           .optionalStart()
-          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 3, true)
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
           .optionalEnd()
           .appendLiteral(' ')
           .appendOffsetId()
@@ -394,7 +394,7 @@ trait SQLServerProfile extends JdbcProfile {
           case null =>
             "NULL"
           case _ =>
-            s"(convert(DATETIMEOFFSET(3), {ts '${formatter.format(value)}'}))"
+            s"(convert(DATETIMEOFFSET(6), {ts '${formatter.format(value)}'}))"
         }
       }
     }

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -1,11 +1,12 @@
 package slick.jdbc
 
 import scala.concurrent.ExecutionContext
-
-import java.sql.{Timestamp, Date, Time, ResultSet}
+import java.time._
+import java.sql.{Date, ResultSet, Time, Timestamp}
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
 
 import com.typesafe.config.Config
-
 import slick.ast._
 import slick.ast.Util._
 import slick.basic.Capability
@@ -16,7 +17,7 @@ import slick.lifted._
 import slick.model.Model
 import slick.relational.RelationalProfile
 import slick.sql.SqlCapabilities
-import slick.util.{SlickLogger, ConstArray, GlobalConfig}
+import slick.util.{ConstArray, GlobalConfig, SlickLogger}
 import slick.util.MacroSupport.macroSupportInterpolation
 import slick.util.ConfigExtensionMethods._
 
@@ -229,7 +230,11 @@ trait SQLServerProfile extends JdbcProfile {
     override val byteArrayJdbcType = new ByteArrayJdbcType
     override val dateJdbcType = new DateJdbcType
     override val timeJdbcType = new TimeJdbcType
+    override val localTimeType = new LocalTimeJdbcType
     override val timestampJdbcType = new TimestampJdbcType
+    override val localDateTimeType = new LocalDateTimeJdbcType
+    override val instantType = new InstantJdbcType
+    override val offsetDateTimeType = new OffsetDateTimeJdbcType
     override val uuidJdbcType = new UUIDJdbcType {
       override def sqlTypeName(sym: Option[FieldSymbol]) = "UNIQUEIDENTIFIER"
     }
@@ -259,11 +264,139 @@ trait SQLServerProfile extends JdbcProfile {
         }
       }
     }
+    class LocalTimeJdbcType extends super.LocalTimeJdbcType {
+      private[this] val formatter : DateTimeFormatter = {
+        new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ofPattern("HH:mm:ss"))
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+          .optionalEnd()
+          .toFormatter()
+      }
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "TIME(6)"
+      override def getValue(r: ResultSet, idx: Int) = {
+        r.getString(idx) match {
+          case null => null
+          case serializedTime =>
+            LocalTime.parse(serializedTime, formatter)
+            val sep = serializedTime.indexOf('.')
+            if (sep == -1) {
+              Time.valueOf(serializedTime).toLocalTime
+            } else {
+              val t: Time = Time.valueOf(serializedTime.substring(0, sep))
+              val millis = (("0." + serializedTime.substring(sep + 1)).toDouble * 1000.0).toInt
+              t.setTime(t.getTime + millis)
+              t.toLocalTime
+            }
+        }
+      }
+      override def valueToSQLLiteral(value: LocalTime) = {
+        value match {
+          case null => "NULL"
+          case _ => s"(convert(time(6), {t '$value'}))"
+        }
+      }
+    }
     class TimestampJdbcType extends super.TimestampJdbcType {
       /* TIMESTAMP in SQL Server is a data type for sequence numbers. What we
        * want here is DATETIME. */
       override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME"
       override def valueToSQLLiteral(value: Timestamp) = "(convert(datetime, {ts '" + value + "'}))"
+    }
+    class LocalDateTimeJdbcType extends super.LocalDateTimeJdbcType {
+      private[this] val formatter : DateTimeFormatter = {
+        new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, true)
+          .optionalEnd()
+          .toFormatter()
+      }
+      /* TIMESTAMP in SQL Server is a data type for sequence numbers. What we
+       * want here is DATETIME. */
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME2(3)"
+      override def getValue(r: ResultSet, idx: Int): LocalDateTime = {
+        r.getTimestamp(idx) match {
+          case null =>
+            null
+          case timestamp =>
+            timestamp.toLocalDateTime
+        }
+      }
+      override def valueToSQLLiteral(value: LocalDateTime) = {
+        value match {
+          case null =>
+            "NULL"
+          case _ =>
+            s"(convert(datetime2(3), {ts '${formatter.format(value)}'}))"
+        }
+      }
+    }
+    class InstantJdbcType extends super.InstantJdbcType {
+      private[this] val formatter : DateTimeFormatter = {
+        new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, true)
+          .optionalEnd()
+          .toFormatter()
+      }
+      private[this] def serializeInstantValue(value : Instant) : String = {
+        formatter.format(
+          LocalDateTime.ofInstant(value, ZoneOffset.UTC)
+        )
+      }
+      /* TIMESTAMP in SQL Server is a data type for sequence numbers. What we
+       * want here is DATETIME. */
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIME2(3)"
+      override def getValue(r: ResultSet, idx: Int): Instant = {
+        r.getTimestamp(idx) match {
+          case null =>
+            null
+          case timestamp =>
+            timestamp.toLocalDateTime.toInstant(ZoneOffset.UTC)
+        }
+      }
+      override def valueToSQLLiteral(value: Instant) = {
+        value match {
+          case null =>
+            "NULL"
+          case _ =>
+            s"(convert(datetime2(3), {ts '${serializeInstantValue(value)}'}))"
+        }
+      }
+    }
+    class OffsetDateTimeJdbcType extends super.OffsetDateTimeJdbcType {
+      override def sqlType = java.sql.Types.OTHER
+      override val hasLiteralForm: Boolean = false
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "DATETIMEOFFSET(3)"
+
+      private[this] val formatter: DateTimeFormatter = {
+        new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 3, true)
+          .optionalEnd()
+          .appendLiteral(' ')
+          .appendOffsetId()
+          .toFormatter()
+      }
+      override def getValue(r: ResultSet, idx: Int): OffsetDateTime = {
+        r.getString(idx) match {
+          case null =>
+            null
+          case timestamp =>
+            OffsetDateTime.parse(timestamp, formatter)
+        }
+      }
+      override def valueToSQLLiteral(value: OffsetDateTime) = {
+        value match {
+          case null =>
+            "NULL"
+          case _ =>
+            s"(convert(DATETIMEOFFSET(3), {ts '${formatter.format(value)}'}))"
+        }
+      }
     }
     /* SQL Server's TINYINT is unsigned, so we use SMALLINT instead to store a signed byte value.
      * The JDBC driver also does not treat signed values correctly when reading bytes from result

--- a/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
@@ -1,6 +1,7 @@
 package slick.jdbc
 
 import java.sql.{Timestamp, Time, Date}
+import java.time.{LocalDate, LocalDateTime, Instant}
 import slick.relational.RelationalCapabilities
 import slick.sql.SqlCapabilities
 
@@ -233,6 +234,9 @@ trait SQLiteProfile extends JdbcProfile {
   class JdbcTypes extends super.JdbcTypes {
     override val booleanJdbcType = new BooleanJdbcType
     override val dateJdbcType = new DateJdbcType
+    override val localDateType = new LocalDateJdbcType
+    override val localDateTimeType = new LocalDateTimeJdbcType
+    override val instantType = new InstantJdbcType
     override val timeJdbcType = new TimeJdbcType
     override val timestampJdbcType = new TimestampJdbcType
     override val uuidJdbcType = new UUIDJdbcType
@@ -247,7 +251,24 @@ trait SQLiteProfile extends JdbcProfile {
      * date/time/timestamp literals. SQLite expects these values as milliseconds
      * since epoch. */
     class DateJdbcType extends super.DateJdbcType {
-      override def valueToSQLLiteral(value: Date) = value.getTime.toString
+      override def valueToSQLLiteral(value: Date) = {
+        value.getTime.toString
+      }
+    }
+    class LocalDateJdbcType extends super.LocalDateJdbcType {
+      override def valueToSQLLiteral(value: LocalDate) = {
+        Date.valueOf(value).getTime.toString
+      }
+    }
+    class InstantJdbcType extends super.InstantJdbcType {
+      override def valueToSQLLiteral(value: Instant) = {
+        value.toEpochMilli.toString
+      }
+    }
+    class LocalDateTimeJdbcType extends super.LocalDateTimeJdbcType {
+      override def valueToSQLLiteral(value: LocalDateTime) = {
+        Timestamp.valueOf(value).getTime.toString
+      }
     }
     class TimeJdbcType extends super.TimeJdbcType {
       override def valueToSQLLiteral(value: Time) = value.getTime.toString


### PR DESCRIPTION
- Add support as JDBC types for the following classes:
  - java.time.OffsetDateTime
  - java.time.ZonedDateTime
  - java.time.LocalDate
  - java.time.LocalTime
  - java.time.LocalDateTime
  - java.time.Instant
  - java.time.OffsetTime
- The following classes are implemented natively on all databases:
  - java.time.Instant
  - java.time.LocalDate
  - java.time.LocalDateTime
- The following are implemented storing the data as VARCHAR because the
  data type ‘TIMESTAMP WITH TIMEZONE’ are not available in most
  databases. Future commits will add native support in databases like
  ‘MySQL’ and ‘PostgreSQL’.
  - OffsetTime
  - OffsetDateTime
  - ZonedDateTime
- LocalTime is currently persisted as a VARCHAR, because not all SQL
  ‘TIME’ implementations stores the values on the same way.
  For example: Microsoft SQL: “HH:MM:SS:nnnnnn” - MySQL: “HH:MM:SS”
