### PR TITLE
UNION regressions

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
@@ -107,4 +107,54 @@ class UnionTest extends AsyncTest[RelationalTestDB] {
       q3.result.map(r => r.toSet shouldBe Set((10L, 1L), (20L, 2L), (30L, 3L), (100L, 1L), (200L, 2L), (300L, 3L)))
     )
   }
+
+  def testCountWithUnion = {
+    case class Delivery(id: Long, dname: String, messageId: Long, sentAt: Long)
+
+    case class Message(id: Long, mname: String, mbody: String)
+
+    class Deliveries(tag: Tag) extends Table[Delivery](tag, "d2") {
+      val id = column[Long]("delivery_id")
+      val dname = column[String]("dname")
+      val messageId = column[Long]("message_id")
+      val sentAt = column[Long]("sent_at")
+
+      def * = (id, dname, messageId, sentAt) <> (Delivery.tupled, Delivery.unapply)
+    }
+
+    class Messages(tag: Tag) extends Table[Message](tag, "m2") {
+      val id = column[Long]("message_id")
+      val mname = column[String]("mname")
+      val mbody = column[String]("mbody")
+
+      def * = (id, mname, mbody) <> (Message.tupled, Message.unapply)
+    }
+
+
+    def leftSide = {
+      (for {
+        d <- TableQuery[Deliveries]
+        m <- TableQuery[Messages] if d.messageId === m.id
+      } yield (d, m))
+        .filter { case (d, m) => d.sentAt >= 1400000000L }
+    }
+
+    def rightSide = {
+      (for {
+        d <- TableQuery[Deliveries]
+        m <- TableQuery[Messages] if d.messageId === m.id
+      } yield (d, m))
+        .filter { case (d, m) => d.sentAt < 1400000000L }
+    }
+
+    val query =
+      leftSide.union(rightSide).length
+
+    DBIO.seq(
+      TableQuery[Deliveries].schema.create,
+      TableQuery[Messages].schema.create,
+      mark("q", query.result).map(_ shouldBe 0)
+    )
+  }
+
 }

--- a/slick/src/main/scala/slick/compiler/RelabelUnions.scala
+++ b/slick/src/main/scala/slick/compiler/RelabelUnions.scala
@@ -12,6 +12,7 @@ class RelabelUnions extends Phase {
   def apply(state: CompilerState) = state.map(_.replace({
     case u @ Union(Bind(_, _, Pure(StructNode(ls), lts)), rb @ Bind(_, _, Pure(StructNode(rs), rts)), _) =>
       val rs2 = ls.zip(rs).map { case ((s, _), (_, n)) => (s, n) }
-      u.copy(right = rb.copy(select = Pure(StructNode(rs2), rts))).infer()
+      val unifiedTs = lts // Use same type symbol on both sides of the Union
+      u.copy(right = rb.copy(select = Pure(StructNode(rs2), unifiedTs))).infer()
   }, keepType = true, bottomUp = true))
 }

--- a/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
+++ b/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
@@ -14,11 +14,11 @@ class RemoveFieldNames(val alwaysKeepSubqueryNames: Boolean = false) extends Pha
     val CollectionType(_, NominalType(top, StructType(fdefs))) = rsm.from.nodeType
     val indexes = fdefs.iterator.zipWithIndex.map { case ((s, _), i) => (s, ElementSymbol(i+1)) }.toMap
     val rsm2 = rsm.nodeMapServerSide(false, { n =>
-      val refTSyms = n.collect[ConstArray[TypeSymbol]] {
-        case Select(_ :@ NominalType(s, _), _) => ConstArray(s)
-        case Union(_ :@ CollectionType(_, NominalType(s1, _)), _ :@ CollectionType(_, NominalType(s2, _)), _) => ConstArray(s1, s2)
-        case Comprehension(_, _ :@ CollectionType(_, NominalType(s, _)), _, _, _, _, _, _, _, _) if alwaysKeepSubqueryNames => ConstArray(s)
-      }.flatten.toSet
+      val refTSyms = n.collect[TypeSymbol] {
+        case Select(_ :@ NominalType(s, _), _) => s
+        case Union(_, _ :@ CollectionType(_, NominalType(s, _)), _) => s
+        case Comprehension(_, _ :@ CollectionType(_, NominalType(s, _)), _, _, _, _, _, _, _, _) if alwaysKeepSubqueryNames => s
+      }.toSet
       val allTSyms = n.collect[TypeSymbol] { case p: Pure => p.identity }.toSet
       val unrefTSyms = allTSyms -- refTSyms
       n.replaceInvalidate {

--- a/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
+++ b/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
@@ -14,11 +14,11 @@ class RemoveFieldNames(val alwaysKeepSubqueryNames: Boolean = false) extends Pha
     val CollectionType(_, NominalType(top, StructType(fdefs))) = rsm.from.nodeType
     val indexes = fdefs.iterator.zipWithIndex.map { case ((s, _), i) => (s, ElementSymbol(i+1)) }.toMap
     val rsm2 = rsm.nodeMapServerSide(false, { n =>
-      val refTSyms = n.collect[TypeSymbol] {
-        case Select(_ :@ NominalType(s, _), _) => s
-        case Union(_, _ :@ CollectionType(_, NominalType(s, _)), _) => s
-        case Comprehension(_, _ :@ CollectionType(_, NominalType(s, _)), _, _, _, _, _, _, _, _) if alwaysKeepSubqueryNames => s
-      }.toSet
+      val refTSyms = n.collect[ConstArray[TypeSymbol]] {
+        case Select(_ :@ NominalType(s, _), _) => ConstArray(s)
+        case Union(_ :@ CollectionType(_, NominalType(s1, _)), _ :@ CollectionType(_, NominalType(s2, _)), _) => ConstArray(s1, s2)
+        case Comprehension(_, _ :@ CollectionType(_, NominalType(s, _)), _, _, _, _, _, _, _, _) if alwaysKeepSubqueryNames => ConstArray(s)
+      }.flatten.toSet
       val allTSyms = n.collect[TypeSymbol] { case p: Pure => p.identity }.toSet
       val unrefTSyms = allTSyms -- refTSyms
       n.replaceInvalidate {


### PR DESCRIPTION
Field names were not preserved on the left side of the union, resulting in incorrect SQL.

Demonstrated in #1344.