### PR TITLE
Sphinx documentation

### DIFF
--- a/slick/src/sphinx/index.rst
+++ b/slick/src/sphinx/index.rst
@@ -40,3 +40,4 @@ ________
    :maxdepth: 3
 
    testkit
+   sphinx-documentation

--- a/slick/src/sphinx/links.txt
+++ b/slick/src/sphinx/links.txt
@@ -12,6 +12,7 @@
 .. _Play: https://playframework.com/
 .. _Akka: http://akka.io/
 .. _Akka Streams: http://akka.io/docs/
+.. _Akka Sphinx: http://doc.akka.io/docs/akka/2.4.0/dev/documentation.html
 .. _About Pool Sizing: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
 .. _Reactive Streams: http://www.reactive-streams.org/
 .. _JPA: http://en.wikipedia.org/wiki/Java_Persistence_API

--- a/slick/src/sphinx/sphinx-documentation.rst
+++ b/slick/src/sphinx/sphinx-documentation.rst
@@ -1,0 +1,14 @@
+Sphinx Documentation
+====================
+
+Building
+--------
+
+Slick documentation is written in reStructuredText and is compiled by Sphinx via the sbt-site plugin.
+
+.. code-block:: bash
+
+  # Generate HTML documentation in slick/target/sphinx/html/
+  sbt sphinx:generateHtml
+
+For more details on Sphinx installation and usage in Scala projects, see the `Akka Sphinx`_ documentation.

--- a/slick/src/sphinx/testkit.rst
+++ b/slick/src/sphinx/testkit.rst
@@ -48,7 +48,7 @@ There is a copy of Slick's logback configuration in
 framework if you prefer a different one.
 
 Profile
-------
+-------
 
 The actual profile implementation can be found under ``src/main/scala``.
 


### PR DESCRIPTION
Added a few lines on building Sphinx documentation, linked to Akka's docs for further information. Also fixed a slight reStructuredText warning.

Related Issue: https://github.com/slick/slick/issues/1084#issuecomment-158447982