### PR TITLE
Fix two typing issues in `Case` expressions:

### DIFF
--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -662,7 +662,7 @@ final case class IfThenElse(clauses: ConstArray[Node]) extends SimplyTypedNode {
     clauses.iterator.grouped(2).withPartial(false).map { case List(i, t) => (i, t) }
   def elseClause = clauses.last
   /** Return a null-extended version of a single-column IfThenElse expression */
-  def nullExtend: IfThenElse = {
+  def nullExtend: IfThenElse = { //TODO 3.2: Remove this method. It is only preserved for binary compatibility in 3.1.1
     def isOpt(n: Node) = n match {
       case LiteralNode(null) => true
       case _ :@ OptionType(_) => true

--- a/slick/src/main/scala/slick/lifted/OptionMapper.scala
+++ b/slick/src/main/scala/slick/lifted/OptionMapper.scala
@@ -63,8 +63,7 @@ object OptionMapper3 {
 
 object OptionMapperDSL {
   type arg[B1, P1] = {
-    type to[BR, PR] = OptionMapper2[B1, B1, BR, P1, P1, PR]
-    type toSame = OptionMapper2[B1, B1, B1, P1, P1, P1]
+    type to[BR, PR] = OptionMapper2[Boolean, B1, BR, Boolean, P1, PR]
     type arg[B2, P2] = {
       type to[BR, PR] = OptionMapper2[B1, B2, BR, P1, P2, PR]
       type arg[B3, P3] = {


### PR DESCRIPTION
- One-argument OptionMappers (as implemented by OptionMapper2) were not
  always inferred correctly. Setting the first base and mapped type to
  `Boolean` instead of asking for the desired type twice helps the type
  inferencer find the correct OptionMapper2.

- `IfThenElse.nullExtend` was broken by design. We cannot reply on AST
  types in the Lifted Embedding DSL. Null-extending is now performed
  directly in `TypedCase` based on the embedding types. It also turns
  out to be much simpler than originally implemented in `nullExtend`
  because the typing rules of `Case` allow only three cases: Explicit
  `Else` clause -> use original types; missing `Else` and base type is
  an `Option` -> use original types; missing `Else` and base type is not
  an `Option` -> wrap *all* `Then` clauses in `OptionApply`.

Fixes #1364. Test in RelationalMiscTest.testConditional.