### PR TITLE
fix some spelling/grammar errors in the docs

### DIFF
--- a/slick/src/sphinx/gettingstarted.rst
+++ b/slick/src/sphinx/gettingstarted.rst
@@ -69,7 +69,7 @@ Quick Introduction
 ==================
 
 .. note::
-   The rest of this chapter is based on the `Hello Slick template`_. The prefered
+   The rest of this chapter is based on the `Hello Slick template`_. The preferred
    way of reading this introduction is in Activator_, where you can edit and run the code
    directly while reading the tutorial.
 
@@ -82,7 +82,7 @@ from Slick's ``H2Profile``. A profile's ``api`` object contains all commonly
 needed imports from the profile and other parts of Slick such as
 :doc:`database handling <database>`.
 
-Slick's API is fully asynchronous and runs database call in a separate thread pool. For running
+Slick's API is fully asynchronous and runs database calls in a separate thread pool. For running
 user code in composition of ``DBIOAction`` and ``Future`` values, we import the global
 ``ExecutionContext``. When using Slick as part of a larger application (e.g. with Play_ or
 Akka_) the framework may provide a better alternative to this default ``ExecutionContext``.
@@ -183,7 +183,7 @@ the ``map`` method or a *for comprehension*:
 
 .. includecode:: code/FirstExample.scala#projection
 
-The output will be the same: For each row of the table, all columns get
+The output will be the same: for each row of the table, all columns get
 converted to strings and concatenated into one tab-separated string. The
 difference is that all of this now happens inside the database engine, and
 only the resulting concatenated string is shipped to the client. Note that we

--- a/slick/src/sphinx/introduction.rst
+++ b/slick/src/sphinx/introduction.rst
@@ -11,7 +11,7 @@ What is Slick?
 Slick ("Scala Language-Integrated Connection Kit") is `Typesafe <http://www.typesafe.com>`_'s
 Functional Relational Mapping (FRM) library for Scala that makes it easy to work with relational
 databases. It allows you to work with stored data almost as if you were using Scala collections
-while at the same time giving you full control over when a database access happens and which data
+while at the same time giving you full control over when database access happens and which data
 is transferred. You can also use SQL directly. Execution of database actions is done
 asynchronously, making Slick a perfect fit for your reactive applications based on Play_ and Akka_.
 
@@ -53,7 +53,7 @@ Some of the key benefits of Slick's FRM approach for functional programming incl
 
 * Efficiency with Pre-Optimization
 
-FRM is more efficient way to connect; unlike ORM it has the ability to pre-optimize its
+FRM is a more efficient way to connect; unlike ORM it has the ability to pre-optimize its
 communication with the database - and with FRM you get this out of the box. The road to making an
 app faster is much shorter with FRM than ORM.
 
@@ -123,7 +123,7 @@ The Scala-based query API for Slick allows you to write database queries like qu
 Scala collections. Please see :doc:`gettingstarted` for an introduction. Most of this
 user manual focuses on this API.
 
-If you want to write your own SQL statements and still execute them asynchronously like a
+If you want to write your own SQL statements and still execute them asynchronously like
 normal Slick queries, you can use the :doc:`Plain SQL<sql>` API:
 
 .. includecode:: code/GettingStartedOverview.scala#what-is-slick-micro-example-plainsql

--- a/slick/src/sphinx/orm-to-slick.rst
+++ b/slick/src/sphinx/orm-to-slick.rst
@@ -7,7 +7,7 @@ Slick is not an object-relational mapper (ORM) like Hibernate or other JPA_-base
 
 A good term to describe Slick is functional-relational mapper. Slick allows working with relational data much like with immutable collections and focuses on flexible query composition and strongly controlled side-effects. ORMs usually expose mutable object-graphs, use side-effects like read- and write-caches and hard-code support for anticipated use-cases like inheritance or relationships via association tables. Slick focuses on getting the best out of accessing a relational data store. ORMs focus on persisting an object-graph.
 
-ORMs are a natural approach when using databases from object-oriented languages. They try to allow working with persisted object-graphs partly as if they were completely in memory. Objects can be modified, associations can be changed and the object graph can be traversed. In practice this is not exactly easy to achieve due to the so called object-relational impedance mismatch. It makes ORMs hard to implement and often complicated to use for more than simple cases and if performance matters. Slick in contrast does not expose an object-graph. It is inspired by SQL and the relational model and mostly just maps their concepts to the most closely corresponding, type-safe Scala features. Database queries are expressed using a restricted, immutable, purely-functional subset of Scala much like collections. Slick also offer :doc:`first-class SQL support <sql>` as an alternative.
+ORMs are a natural approach when using databases from object-oriented languages. They try to allow working with persisted object-graphs partly as if they were completely in memory. Objects can be modified, associations can be changed and the object graph can be traversed. In practice this is not exactly easy to achieve due to the so called object-relational impedance mismatch. It makes ORMs hard to implement and often complicated to use for more than simple cases and if performance matters. Slick in contrast does not expose an object-graph. It is inspired by SQL and the relational model and mostly just maps their concepts to the most closely corresponding, type-safe Scala features. Database queries are expressed using a restricted, immutable, purely-functional subset of Scala much like collections. Slick also offers :doc:`first-class SQL support <sql>` as an alternative.
 
 In practice, ORMs often suffer from conceptual problems of what they try to achieve, from mere problems of the implementations and from mis-use, because of their complexity. In the following we look at many features of ORMs and what you would use with Slick instead. We'll first look at how to work with the object graph. We then look at a series of particular features and use cases and how to handle them with Slick.
 
@@ -53,7 +53,7 @@ Slick works differently. To do the same in Slick you would write the following. 
 
 As we can see it looks very much like collection operations but the values we get are of type ``Query``. They do not
 store results, only a plan of the operations that are needed to create a SQL query that produces the results when
-needed. No database round trips happen at all in our example. To actually fetch results, we can have to compile the
+needed. No database round trips happen at all in our example. To actually fetch results, we have to compile the
 query to a :doc:`database Action <database>` with ``.result`` and then ``run`` it on the Database.
 
 .. includecode:: code/OrmToSlick.scala#slickExecution
@@ -114,7 +114,7 @@ As already mentioned, we are working with placeholder values, merely describing 
 
 It is important to note that Scala allows to be very type-safe here. E.g. Slick supports a method ``.substring`` for ``Rep[String]`` but not for ``Rep[Int]``. This is impossible in Java and Java APIs like Criteria Queries, but possible in Scala using type-parameter based method extensions via implicits. This allows tools like the Scala compiler and IDEs to understand the code much more precisely and offer better checking and support.
 
-A nice property of a Slick-like query language is, that it can be used with Scala's comprehension syntax, which is just Scala-builtin syntactic sugar for collections operations. The above example can alternatively be written as
+A nice property of a Slick-like query language is that it can be used with Scala's comprehension syntax, which is just Scala-builtin syntactic sugar for collections operations. The above example can alternatively be written as
 
 .. includecode:: code/OrmToSlick.scala#slickForComprehension
 
@@ -124,7 +124,7 @@ Scala's comprehension syntax looks much like SQL or ORM query languages. It howe
 
 Despite the syntactic limitations, the comprehension syntax is convenient when dealing with multiple inner joins.
 
-It is important to note that the problems of method-based query apis like Criteria Queries described above are not a conceptual limitation of ORM query languages but merely an artifact of many ORMs being Java frameworks. In principle, a Scala ORMs could offer a query language just like Slick's and they should. Comfortably compositional queries allow for a high degree of code re-use. They seem to be Slick's favorite feature for many developers.
+It is important to note that the problems of method-based query APIs like Criteria Queries described above are not a conceptual limitation of ORM query languages but merely an artifact of many ORMs being Java frameworks. In principle, Scala ORMs could offer a query language just like Slick's and they should. Comfortably compositional queries allow for a high degree of code re-use. They seem to be Slick's favorite feature for many developers.
 
 Macro-based embeddings
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,13 +172,13 @@ For inserts, we insert into the query, that resembles the whole table and can se
 
 Relationships
 --------------------
-ORMs usually provide built-in, hard-coded support for 1-to-many and many-to-many relationships. They can be set up centrally in the configuration. In SQL on the other hand you would specify them using joins in every single query. You have a lot of flexibility what you join and how. With Slick you get the best of both worlds. Slick queries are as flexible as SQL, but also compositional. You can store fragements like join conditions in central places and use language-level abstraction. Relationships of any sort are just one thing you can naturally abstract over like in any Scala code. There is no need for Slick to hard-code support for certain use cases. You can easily implement arbitrary use cases yourself, e.g. the common 1-n or n-n relationships or even relationships spanning over multiple tables, relationships with additional discriminators, polymorphic relationships, etc.
+ORMs usually provide built-in, hard-coded support for 1-to-many and many-to-many relationships. They can be set up centrally in the configuration. In SQL on the other hand you would specify them using joins in every single query. You have a lot of flexibility what you join and how. With Slick you get the best of both worlds. Slick queries are as flexible as SQL, but also compositional. You can store fragments like join conditions in central places and use language-level abstraction. Relationships of any sort are just one thing you can naturally abstract over like in any Scala code. There is no need for Slick to hard-code support for certain use cases. You can easily implement arbitrary use cases yourself, e.g. the common 1-n or n-n relationships or even relationships spanning over multiple tables, relationships with additional discriminators, polymorphic relationships, etc.
 
 Here is an example for person and addresses.
 
 .. includecode:: code/OrmToSlick.scala#slickRelationships
 
-A common question for new Slick users is how they can follow a relationships on a result. In an ORM you could do something like this:
+A common question for new Slick users is how they can follow a relationship on a result. In an ORM you could do something like this:
 
 .. includecode:: code/OrmToSlick.scala#relationshipNavigation
 
@@ -192,7 +192,7 @@ A variant of this question Slick new comers often ask is how they can do somethi
 
 .. includecode:: code/OrmToSlick.scala#relationshipNavigation2
 
-The problem is that this hard-codes that a Person requires an Address. It can not be loaded without it. This does't fit to Slick's philosophy of giving you fine-grained control over what you load exactly. With Slick it is advised to map one table to a tuple or case class without them having object references to related objects. Instead you can write a function that joins two tables and returns them as a tuple or association case class instance, providing an association externally, not strongly tied one of the classes.
+The problem is that this hard-codes that a Person requires an Address. It cannot be loaded without it. This doesn't fit to Slick's philosophy of giving you fine-grained control over what you load exactly. With Slick it is advised to map one table to a tuple or case class without them having object references to related objects. Instead you can write a function that joins two tables and returns them as a tuple or association case class instance, providing an association externally, not strongly tied one of the classes.
 
 .. includecode:: code/OrmToSlick.scala#associationTuple
 
@@ -200,11 +200,11 @@ An alternative approach is giving your classes Option-typed members referring to
 
 Modifying relationships
 ________________________
-When manipulating relationships with ORMs you usually work on mutable collections of associated objects and inserts or remove related objects. Changes are written to the database immediately or recorded in a write cache and commited later. To avoid stateful caches and mutability, Slick handles relationship manipulations just like SQL - using foreign keys. Changing relationships means updating foreign key fields to new ids, just like updating any other field. As a bonus this allows establishing and removing associations with objects that have not been loaded into memory. Having their ids is sufficient.
+When manipulating relationships with ORMs you usually work on mutable collections of associated objects and inserts or remove related objects. Changes are written to the database immediately or recorded in a write cache and committed later. To avoid stateful caches and mutability, Slick handles relationship manipulations just like SQL - using foreign keys. Changing relationships means updating foreign key fields to new ids, just like updating any other field. As a bonus this allows establishing and removing associations with objects that have not been loaded into memory. Having their ids is sufficient.
 
 Inheritance
 -----------------
-Slick does not persist arbitrary object-graphs. It rather exposes the relational data model nicely integrated into Scala. As the relational schema doesn't contain inheritance so doesn't Slick. This can be unfamiliar at first. Usually inheritance can be simply replaced by relationalships thinking along the lines of roles. Instead of foo is a bar think foo has role bar. As Slick allows query composition and abstraction, inheritance-like query-snippets can be easily implemented and put into functions for re-use. Slick doesn't provide any out of the box but allows you to flexibly come up with the ones that match your problem and use them in your queries.
+Slick does not persist arbitrary object-graphs. It rather exposes the relational data model nicely integrated into Scala. As the relational schema doesn't contain inheritance so doesn't Slick. This can be unfamiliar at first. Usually inheritance can be simply replaced by relationships thinking along the lines of roles. Instead of foo is a bar think foo has role bar. As Slick allows query composition and abstraction, inheritance-like query-snippets can be easily implemented and put into functions for re-use. Slick doesn't provide any out of the box but allows you to flexibly come up with the ones that match your problem and use them in your queries.
 
 Code-generation
 -----------------

--- a/slick/src/sphinx/sql-to-slick.rst
+++ b/slick/src/sphinx/sql-to-slick.rst
@@ -39,7 +39,7 @@ A JDBC query with error handling could look like this:
 
 .. includecode:: code/SqlToSlick.scala#jdbc
 
-Slick gives us two choices how to write queries. One is SQL strings just like JDBC. The other are type-safe, composable queries.
+Slick gives us two choices how to write queries. One is SQL strings just like JDBC. The other is type-safe, composable queries.
 
 Slick Plain SQL queries
 _________________________
@@ -56,7 +56,7 @@ management optimized for asynchronous execution, looks like this:
 Slick type-safe, composable queries
 ________________________________________
 
-Slick's key feature are type-safe, composable queries. Slick comes with a Scala-to-SQL compiler, which allows a (purely functional) sub-set of the Scala language to be compiled to SQL queries. Also available are a subset of the standard library and some extensions, e.g. for joins. The familiarity allows Scala developers to instantly write many queries against all supported relational databases with little learning required and without knowing SQL or remembering the particular dialect. Such Slick queries are composable, which means that you can write and re-use fragments and functions to avoid repetitive code like join conditions in a much more practical way than concatenating SQL strings. The fact that such queries are type-safe not only catches many mistakes early at compile time, but also eliminates the risk of SQL injection vulnerabilities.
+Slick's key feature is type-safe, composable queries. Slick comes with a Scala-to-SQL compiler, which allows a (purely functional) sub-set of the Scala language to be compiled to SQL queries. Also available are a subset of the standard library and some extensions, e.g. for joins. The familiarity allows Scala developers to instantly write many queries against all supported relational databases with little learning required and without knowing SQL or remembering the particular dialect. Such Slick queries are composable, which means that you can write and re-use fragments and functions to avoid repetitive code like join conditions in a much more practical way than concatenating SQL strings. The fact that such queries are type-safe not only catches many mistakes early at compile time, but also eliminates the risk of SQL injection vulnerabilities.
 
 The same query written as a type-safe Slick query looks like this:
 
@@ -76,7 +76,7 @@ Main obstacle: Semantic API differences
 Some methods of the Scala collections work a bit differently than their SQL counter parts. This seems to be one of the
 main causes of confusion for people newly coming from SQL to Slick. Especially `groupBy`_ seems to be tricky.
 
-The best approach to write queries using Slick's type-safe api is thinking in terms of Scala collections. What would the code be if you had a Seq of tuples or case classes instead of a Slick TableQuery object. Use that exact code. If needed adapt it with workarounds where a Scala library feature is currently not supported by Slick or if Slick is slightly different. Some operations are more strongly typed in Slick than in Scala for example. Arithmetic operation in different types require explicit casts using ``.asColumnOf[T]``. Also Slick uses 3-valued logic for Option inference.
+The best approach to write queries using Slick's type-safe API is thinking in terms of Scala collections. What would the code be if you had a Seq of tuples or case classes instead of a Slick TableQuery object. Use that exact code. If needed adapt it with workarounds where a Scala library feature is currently not supported by Slick or if Slick is slightly different. Some operations are more strongly typed in Slick than in Scala for example. Arithmetic operation in different types require explicit casts using ``.asColumnOf[T]``. Also Slick uses 3-valued logic for Option inference.
 
 Scala-to-SQL compilation during runtime
 ---------------------------------------------------------
@@ -109,7 +109,7 @@ If you need a fundamental operator, which is not supported out-of-the-box you ca
 
 More information can be found in the chapter about :ref:`Scalar database functions <scalar-db-functions>`.
 
-You can however not add operators operating on queries using database functions. The Slick Scala-to-SQL compiler requires knowledge about the structure of the query in order to compile it to the most simple SQL query it can produce. It currently couldn't handle custom query operators in that context. (There are some ideas how this restriction can be somewhat lifted in the future, but it needs more investigation). An example for such operator is a MySQL index hint, which is not supported by Slick's type-safe api and it cannot be added by users. If you require such an operator you have to write your whole query using Plain SQL. If the operator does not change the return type of the query you could alternatively use the workaround described in the following section.
+You can however not add operators operating on queries using database functions. The Slick Scala-to-SQL compiler requires knowledge about the structure of the query in order to compile it to the simplest SQL query it can produce. It currently couldn't handle custom query operators in that context. (There are some ideas how this restriction can be somewhat lifted in the future, but it needs more investigation). An example for such operator is a MySQL index hint, which is not supported by Slick's type-safe API and it cannot be added by users. If you require such an operator you have to write your whole query using Plain SQL. If the operator does not change the return type of the query you could alternatively use the workaround described in the following section.
 
 Non-optimal SQL code
 ________________________________________________________
@@ -155,7 +155,7 @@ SQL
 
 Slick
 ^^^^^^
-Scala's equivalent for ``SELECT`` is ``map``. Columns can be referenced similarly and functions operating on columns can be accessed using their Scala eqivalents (but allowing only ``++`` for String concatenation, not ``+``).
+Scala's equivalent for ``SELECT`` is ``map``. Columns can be referenced similarly and functions operating on columns can be accessed using their Scala equivalents (but allowing only ``++`` for String concatenation, not ``+``).
 
 .. includecode:: code/SqlToSlick.scala#slickQueryProjection
 
@@ -188,7 +188,7 @@ SQL
 
 Slick
 ^^^^^^
-Scala's equivalent for ``ORDER BY`` is ``sortBy``. Provide a tuple to sort by multiple columns. Slick's ``.asc`` and ``.desc`` methods allow to affect the ordering. Be aware that a single ``ORDER BY`` with multiple columns is not equivalent to multiple ``.sortBy`` calls but to a single ``.sortBy`` call passing a tuple.
+Scala's equivalent for ``ORDER BY`` is ``sortBy``. Provide a tuple to sort by multiple columns. Slick's ``.asc`` and ``.desc`` methods affect the ordering. Be aware that a single ``ORDER BY`` with multiple columns is not equivalent to multiple ``.sortBy`` calls but to a single ``.sortBy`` call passing a tuple.
 
 .. includecode:: code/SqlToSlick.scala#slickQueryOrderBy
 
@@ -217,7 +217,7 @@ Aggregations are collection methods in Scala. In SQL they are called on a column
 GROUP BY
 ____________
 
-People coming from SQL often seem to have trouble understanding Scala's and Slick's ``groupBy``, because of the different signatures involved. SQL's ``GROUP BY`` can be seen as an operation that turns all columns that weren't part of the grouping key into collections of all the elements in a group. SQL requires the use of it's aggregation operations like ``avg`` to compute single values out of these collections.
+People coming from SQL often seem to have trouble understanding Scala's and Slick's ``groupBy``, because of the different signatures involved. SQL's ``GROUP BY`` can be seen as an operation that turns all columns that weren't part of the grouping key into collections of all the elements in a group. SQL requires the use of its aggregation operations like ``avg`` to compute single values out of these collections.
 
 SQL
 ^^^
@@ -232,7 +232,7 @@ Scala's groupBy returns a Map of grouping keys to Lists of the rows for each gro
 
 .. includecode:: code/SqlToSlick.scala#slickQueryGroupBy
 
-SQL requires to aggregate grouped values. We require the same in Slick for now. This means a ``groupBy`` call must be followed by a ``map`` call or will fail with an Exception. This makes Slick's grouping syntax a bit more complicated than SQL's.
+SQL requires aggregation of grouped values. We require the same in Slick for now. This means a ``groupBy`` call must be followed by a ``map`` call or will fail with an Exception. This makes Slick's grouping syntax a bit more complicated than SQL's.
 
 .. index:: HAVING
 
@@ -304,7 +304,7 @@ Outer joins are done using Slick's explicit join DSL. Be aware that in case of a
 outer joined, non-nullable columns into nullable columns. In order to represent this in a clean way even in the
 presence of mapped types, Slick lifts the whole side of the join into an ``Option``. This goes a bit further than the
 SQL semantics because it allows you to distinguish a row which was not matched in the join from a row that was
-matched but already contained nothign but NULL values.
+matched but already contained nothing but NULL values.
 
 .. includecode:: code/SqlToSlick.scala#slickQueryLeftJoin
 

--- a/slick/src/sphinx/sql.rst
+++ b/slick/src/sphinx/sql.rst
@@ -10,7 +10,7 @@ nicer Scala-based API.
 
 .. note::
    The rest of this chapter is based on the `Slick Plain SQL Queries template`_.
-   The prefered way of reading this introduction is in Activator_, where you can edit and
+   The preferred way of reading this introduction is in Activator_, where you can edit and
    run the code directly while reading the tutorial.
 
 
@@ -74,7 +74,7 @@ actions. It is used here to sum up the affected row counts of all inserts.
 Result Sets
 -----------
 
-The following code uses tbe ``sql`` interpolator which returns a result set produced by a
+The following code uses the ``sql`` interpolator which returns a result set produced by a
 statement. The interpolator by itself does not produce a ``DBIO`` value. It needs to be
 followed by a call to ``.as`` to define the row type:
 
@@ -92,7 +92,7 @@ return types you have to define your own converters:
 ``Supplier`` uses the explicit ``PositionedResult`` methods ``getInt`` and ``getString`` to read
 the next ``Int`` or ``String`` value in the current row. The second one uses the shortcut method
 ``<<`` which returns a value of whatever type is expected at this place. (Of course you can only
-use it when the type is actually known like in this constructor call.
+use it when the type is actually known like in this constructor call.)
 
 Splicing Literal Values
 -----------------------
@@ -128,13 +128,13 @@ annotation::
     @StaticDatabaseConfig("file:src/main/resources/application.conf#tsql")
 
 In this case it points to the path "tsql" in a local ``application.conf`` file, which must contain
-an appropriate configiration for a :api:`slick.basic.StaticDatabaseConfig` object, not just a
+an appropriate configuration for a :api:`slick.basic.StaticDatabaseConfig` object, not just a
 ``Database``.
 
 .. note::
    You can get ``application.conf`` resolved via the classpath (as usual) by omitting the path and
    only specifying a fragment in the URL, or you can use a ``resource:`` URL scheme for referencing
-   an arbitrary classpath resouce, but in both cases, they have to be on the *compiler's* own
+   an arbitrary classpath resource, but in both cases, they have to be on the *compiler's* own
    classpath, not just the source path or the runtime classpath. Depending on the build tool this
    may not be possible, so it's usually better to use a relative ``file:`` URL.
 

--- a/slick/src/sphinx/testkit.rst
+++ b/slick/src/sphinx/testkit.rst
@@ -7,7 +7,7 @@ Slick TestKit
 
 .. note::
    This chapter is based on the `Slick TestKit Example template`_.
-   The prefered way of reading this introduction is in Activator_, where you can
+   The preferred way of reading this introduction is in Activator_, where you can
    edit and run the code directly while reading the tutorial.
 
 When you write your own database profile for Slick, you need a way to run all

--- a/slick/src/sphinx/upgrade.rst
+++ b/slick/src/sphinx/upgrade.rst
@@ -17,7 +17,7 @@ Slick version numbers consist of an epoch, a major and minor version, and possib
 
 For release versions (i.e. versions without a qualifier), backward binary compatibility is
 guaranteed between releases with the same epoch and major version (e.g. you could use 2.1.2 as a
-drop-in relacement for 2.1.0 but not for 2.0.0). :doc:`Slick Extensions <extensions>` requires at
+drop-in replacement for 2.1.0 but not for 2.0.0). :doc:`Slick Extensions <extensions>` requires at
 least the same minor version of Slick (e.g. Slick Extensions 2.1.2 can be used with Slick 2.1.2 but
 not with Slick 2.1.1). Binary compatibility is not preserved for `slick-codegen`, which is generally
 used at compile-time.


### PR DESCRIPTION
Some of the changes don't show up well in the diff preview here on GitHub. Here are the changes made where it's hard to see:

In orm-to-slick.rst:

- Line 10: "Slick also offer" to "Slick also offers" in the last sentence
- Line 175: "fragements" to "fragments" in "You can store fragments like join conditions..."
- Line 195: "can not" to "cannot" in the second sentence
- Line 203: "commited" to "committed"
- Line 207: "relationalships" to "relationships"

In sql-to-slick.rst:

- Line 59: "are" to "is" in the first sentence
- Line 79: "api" to "API" in the first sentence
- Line 112: "most simple" to "simplest"