### PR TITLE
Make FailureAction typed on the kind of exception it holds instead of Nothing.

### DIFF
--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -144,7 +144,7 @@ object DBIOAction {
   def successful[R](v: R): DBIOAction[R, NoStream, Effect] = SuccessAction[R](v)
 
   /** Create a [[DBIOAction]] that always fails. */
-  def failed(t: Throwable): DBIOAction[Nothing, NoStream, Effect] = FailureAction(t)
+  def failed[E <: Throwable](t: E): DBIOAction[E, NoStream, Effect] = FailureAction[E](t)
 
   private[this] def groupBySynchronicity[R, E <: Effect](in: TraversableOnce[DBIOAction[R, NoStream, E]]): Vector[Vector[DBIOAction[R, NoStream, E]]] = {
     var state = 0 // no current = 0, sync = 1, async = 2
@@ -302,7 +302,7 @@ case class SuccessAction[+R](value: R) extends SynchronousDatabaseAction[R, NoSt
 }
 
 /** A DBIOAction that fails. */
-case class FailureAction(t: Throwable) extends SynchronousDatabaseAction[Nothing, NoStream, BasicBackend, Effect] {
+case class FailureAction[E <: Throwable](t: E) extends SynchronousDatabaseAction[E, NoStream, BasicBackend, Effect] {
   def getDumpInfo = DumpInfo("failure", String.valueOf(t))
   def run(ctx: BasicBackend#Context): Nothing = throw t
 }


### PR DESCRIPTION
Currently when trying to chain an always failing flatMap (e.g. `.flatMap(_ => DBIO.failed(new IllegalStateException()`) with a `.transactionally` followed by more chaining (e.g. `.asTry.map`), the compiler gets confused unless if you break up the query into multiple parts. See [this Gist by @xevix](https://gist.github.com/xevix/f888187a73cf4da0cc69).

I think this is caused by the fact that `.failed` used to create a `DBIOAction[Nothing, NoStream, Effect]`, and the `Nothing` type along with the implicit conversion caused by `.transactionally` is making it hard for the compiler to resolve types (admittedly my understanding here is fuzzy).

There are probably just a handful of reasons for why you would do this (always failing flatMap and this much chaining), but it's still good to get this consistent with the way the library behaves without `.transactionally`.