### PR TITLE
DBType doesn't work at slick 3.1

### DIFF
--- a/slick/src/sphinx/schemas.rst
+++ b/slick/src/sphinx/schemas.rst
@@ -62,9 +62,9 @@ object. The following ones are defined for ``JdbcProfile``:
 
 .. index:: type
 
-``DBType(dbType: String)``
+``SqlType(typeName: String)``
    Use a non-standard database-specific type for the DDL statements (e.g.
-   ``DBType("VARCHAR(20)")`` for a ``String`` column).
+   ``SqlType("VARCHAR(20)")`` for a ``String`` column).
 
 .. index:: AutoInc, generated, identity
 


### PR DESCRIPTION
I found O.DBType doesn't exist in MySql Driver, and it could be SqlType instead.