### PR TITLE
Make poolName configurable again to support JMX

### DIFF
--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -44,7 +44,7 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
     val numThreads = c.getIntOr("numThreads", 20)
     hconf.setMaximumPoolSize(c.getIntOr("maxConnections", numThreads * 5))
     hconf.setMinimumIdle(c.getIntOr("minConnections", numThreads))
-    hconf.setPoolName(name)
+    hconf.setPoolName(c.getStringOr("poolName", name))
     hconf.setRegisterMbeans(c.getBooleanOr("registerMbeans", false))
 
     // Equivalent of ConnectionPreparer

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -190,6 +190,9 @@ trait JdbcBackend extends RelationalBackend {
       *     pool will "fail fast" if the pool cannot be seeded with initial connections
       *     successfully. If connections cannot be created at pool startup time, a RuntimeException
       *     will be thrown. This property has no effect if `minConnections` is 0.</li>
+      *   <li>`poolName` (String, optional): A user-defined name for the connection pool in logging
+      *     and JMX management consoles to identify pools and pool configurations. This defaults to
+      *     the config path.</li>
       *   <li>`leakDetectionThreshold` (Duration, optional, default: 0): The amount of time that a
       *     connection can be out of the pool before a message is logged indicating a possible
       *     connection leak. A value of 0 means leak detection is disabled. Lowest acceptable value


### PR DESCRIPTION
This is a fix for https://github.com/slick/slick/issues/1326