### PR TITLE
Actually pass the typeName to JdbcModelBuilder.jdbcTypeToScala from ColumnBuilder

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
@@ -178,7 +178,7 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
     /** Regex matcher to extract string out ouf surrounding '' */
     final val StringPattern = """^'(.*)'$""".r
     /** Scala type this column is mapped to */
-    def tpe = jdbcTypeToScala(meta.sqlType).toString match {
+    def tpe = jdbcTypeToScala(meta.sqlType, meta.typeName).toString match {
       case "java.lang.String" => if(meta.size == Some(1)) "Char" else "String"
       case t => t
     }


### PR DESCRIPTION
@tminglei added this parameter in #1226, but ColumnBuilder never passes the argument even if it's available. This broke codegen for custom Postgres types.