### PR TITLE
Add DB2,Oracle into travis build and add Appveyor build for SQLServer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "suegithub"]
+	path = travis/ZNonPublicDeps
+	url = https://github.com/smootoo/ZNonPublicDeps.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
-sudo: false
 language: scala
-script: sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf +testAll
+sudo: required
+before_install:
+# TZ needed for Oracle driver!
+- export TZ=Asia/Kamchatka
+- sh -v ./travis/extractNonPublicDeps
+- docker version
+- sh -v travis/runcontainer.sh oracle db2
+- docker ps
 jdk:
   - oraclejdk8
 notifications:
@@ -9,11 +15,15 @@ notifications:
 services:
   - mysql
   - postgresql
+  - docker
 addons:
   apt:
     packages:
     - graphviz
     - python-sphinx
+    - mysql-server
+script:
+- sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf clean +testAll
 cache:
   directories:
     - $HOME/.sbt

--- a/README.md
+++ b/README.md
@@ -11,17 +11,21 @@ instead of SQL, thus profiting from the static checking, compile-time safety
 and compositionality of Scala. Slick features an extensible query compiler
 which can generate code for different backends.
 
-The following database systems are directly supported for type-safe queries:
+The following database systems are directly supported for type-safe queries.
+These are the databases and driver versions that have explicit automated tests.
 
-- Derby/JavaDB
-- H2
-- HSQLDB/HyperSQL
-- MySQL
-- PostgreSQL
-- SQLite
-- Oracle 11g
-- IBM DB2 LUW 10
-- Microsoft SQL Server 2008
+|Database|JDBC Driver|Build status|
+|--------|-----------|-----------:|
+|SQLServer 2008, 2012, 2014|[jtds:1.2.8](http://sourceforge.net/projects/jtds/files/jtds/) and [msjdbc:4.2](https://www.microsoft.com/en-gb/download/details.aspx?id=11774)|[![Build status](https://ci.appveyor.com/api/projects/status/mdrfd7o7067c5vcm?svg=true&branch=master)](https://ci.appveyor.com/project/slick/slick)|
+|Oracle 11g|[ojdbc7:12.1.0.2](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|DB2 10.5|[db2jcc4:4.19.20](http://www-01.ibm.com/support/docview.wss?uid=swg21363866)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|MySQL|mysql-connector-java:5.1.23|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|PostgreSQL|postgresql:9.1-901.jdbc4|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|SQLite|sqlite-jdbc:3.8.7|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|Derby/JavaDB|derby:10.9.1.0|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|HSQLDB/HyperSQL|hsqldb:2.2.8|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|H2|com.h2database.h2:1.4.187|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+
 
 Accessing other database systems is possible, with a reduced feature set.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,60 @@
+install:
+  - git submodule update --init --recursive
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\sbt" )) {
+        (new-object System.Net.WebClient).DownloadFile(
+          'https://dl.bintray.com/sbt/native-packages/sbt/0.13.9/sbt-0.13.9.zip',
+          'C:\sbt-bin.zip'
+        )
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-bin.zip", "C:\sbt")
+      }
+  - cmd: SET JDK_HOME=C:\Program Files\Java\jdk1.8.0
+  - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - cmd: SET PATH=C:\sbt\sbt\bin;%JDK_HOME%\bin;%PATH%
+  - cmd: SET SBT_OPTS=-Xmx4g -Xss2m -Dslick.testkit-config=test-dbs/testkit-appveyor.conf
+# Start up sqlservers: 2008 on port 1433, 2012 on 1533, 2014 on 1633. Enable tcp connections
+  - ps: |
+      [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null;
+      [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement") | Out-Null;
+      $port = 1433
+      foreach($instancename in @('SQL2008R2SP2', 'SQL2012SP1', 'SQL2014'))
+      {
+          $wmi = New-Object('Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer');
+          $tcp = $wmi.GetSmoObject("ManagedComputer[@Name='${env:computername}']/ServerInstance[@Name='${instancename}']/ServerProtocol[@Name='Tcp']");
+          $tcp.IsEnabled = $true;
+          foreach ($ipAddress in $tcp.IPAddresses)
+          {
+            $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
+            $ipAddress.IPAddressProperties["TcpPort"].Value = "${port}"
+          }
+          $tcp.Alter();
+          Start-Service -Name "MSSQL`$$instancename";
+          $wmi = New-Object('Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer');
+          $ipall = $wmi.GetSmoObject("ManagedComputer[@Name='${env:computername}']/ServerInstance[@Name='${instancename}']/ServerProtocol[@Name='Tcp']/IPAddress[@Name='IPAll']");
+          $config = @{
+            instanceName = $instancename;
+            config = @{
+              server = "localhost";
+              userName = "sa";
+              password = "Password12!";
+              options = @{
+                port = ${port};
+                database = "master";
+                  cryptoCredentialsDetails = @{
+                ciphers = "RC4-MD5"
+                }
+              }
+            }
+          } | ConvertTo-Json -Depth 3;
+          Write-Host "${config}"
+          $port += 100
+      }
+  - bash -v ./travis/extractNonPublicDeps
+build_script:
+  - sbt clean compile test:compile
+test_script:
+  - sbt testkit/test:test
+cache:
+  - C:\sbt\
+  - C:\Users\appveyor\.ivy2

--- a/osgi-tests/src/test/scala/slick/osgi/testutil/SlickOsgiHelper.scala
+++ b/osgi-tests/src/test/scala/slick/osgi/testutil/SlickOsgiHelper.scala
@@ -13,8 +13,10 @@ trait SlickOsgiHelper {
   private def makeBundle(file: File): exam.Option = 
     bundle(file.toURI.toASCIIString)
 
-  private def allBundleFiles: Array[File] =
-    Option(sys.props("slick.osgi.bundlepath")).getOrElse("").split(":").map(new File(_))
+  private def allBundleFiles: Array[File] = {
+    val paths = Option(sys.props("slick.osgi.bundlepath")).getOrElse("")
+    paths.split("@").map(new File(_))
+  }
 
   def standardOptions: Array[exam.Option] =
     allBundleFiles.map(makeBundle) ++ Array[exam.Option](junitBundles())

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -282,7 +282,7 @@ object SlickBuild extends Build {
   ).configs(DocTest).settings(inConfig(DocTest)(Defaults.testSettings): _*).settings(
     unmanagedSourceDirectories in DocTest += (baseDirectory in slickProject).value / "src/sphinx/code",
     unmanagedResourceDirectories in DocTest += (baseDirectory in slickProject).value / "src/sphinx/resources"
-  ) dependsOn(slickProject, slickCodegenProject % "compile->compile", slickHikariCPProject % "test->compile")
+  ) dependsOn(slickProject, slickCodegenProject % "compile->compile", slickHikariCPProject)
 
   lazy val slickCodegenProject = Project(id = "codegen", base = file("slick-codegen"),
     settings = Defaults.coreDefaultSettings ++ sdlcSettings ++ sharedSettings ++ extTarget("codegen") ++ commonSdlcSettings ++ Seq(
@@ -339,7 +339,8 @@ object SlickBuild extends Build {
       fork in Test := true,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),
       javaOptions in Test ++= Seq(
-        "-Dslick.osgi.bundlepath=" + osgiBundleFiles.value.map(_.getCanonicalPath).mkString(":"),
+        // Use '@' as a seperator that shouldn't appear in any filepaths or names
+        "-Dslick.osgi.bundlepath=" + osgiBundleFiles.value.map(_.getCanonicalPath).mkString("@"),
         "-Dorg.ops4j.pax.logging.DefaultServiceLog.level=WARN"
       ),
       osgiBundleFiles := Seq((OsgiKeys.bundle in slickProject).value),

--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -26,8 +26,6 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
   import com.zaxxer.hikari._
 
   def forConfig(c: Config, driver: Driver, name: String, classLoader: ClassLoader): HikariCPJdbcDataSource = {
-    if(driver ne null)
-      throw new SlickException("An explicit Driver object is not supported by HikariCPJdbcDataSource")
     val hconf = new HikariConfig()
 
     // Connection settings

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMetaTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMetaTest.scala
@@ -45,7 +45,7 @@ class JdbcMetaTest extends AsyncTest[JdbcTestDB] {
       DBIO.sequence(ps.map(_.getProcedureColumns()))
     }.named("Procedures from DatabaseMetaData"),
 
-    MTable.getTables(None, None, None, None).flatMap { ts =>
+    tdb.profile.defaultTables.flatMap { ts =>
       DBIO.sequence(ts.filter(t => Set("users", "orders") contains t.name.name).map { t =>
         DBIO.seq(
           t.getColumns.flatMap { cs =>
@@ -68,7 +68,7 @@ class JdbcMetaTest extends AsyncTest[JdbcTestDB] {
     ifCap(tcap.jdbcMetaGetClientInfoProperties)(MClientInfoProperty.getClientInfoProperties)
       .named("Client Info Properties from DatabaseMetaData"),
 
-    MTable.getTables(None, None, None, None).map(_.should(ts =>
+    tdb.profile.defaultTables.map(_.should(ts =>
       Set("orders_xx", "users_xx") subsetOf ts.map(_.name.name).toSet
     )).named("Tables before deleting")
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
@@ -11,6 +11,8 @@ import slick.jdbc._
 import slick.jdbc.GetResult._
 import slick.jdbc.meta.MTable
 import org.junit.Assert
+import slick.util.ConfigExtensionMethods._
+
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
@@ -182,24 +184,19 @@ object StandardTestDBs {
     val profile = SQLServerProfile
     import profile.api.actionBasedSQLInterpolation
 
-    val defaultSchema = config.getString("defaultSchema")
     // sqlserver has valid "select for update" syntax, but in testing on Appveyor, the test hangs due to lock escalation
     // so exclude from explicit ForUpdate testing
     override def capabilities = super.capabilities - TestDB.capabilities.selectForUpdateRowLocking
+    val defaultSchema = config.getStringOpt("defaultSchema")
 
-    override def localTables(implicit ec: ExecutionContext): DBIO[Vector[String]] =
-      ResultSetAction[(String,String,String, String)](_.conn.getMetaData().getTables(testDB, defaultSchema, null, null)).map { ts =>
-        ts.map(_._3).sorted
-      }
+    override def localTables(implicit ec: ExecutionContext): DBIO[Vector[String]] = {
+      MTable.getTables(None, defaultSchema, None, Some(Seq("TABLE"))).map(_.map(_.name.name).sorted)
+    }
 
     override def dropUserArtifacts(implicit session: profile.Backend#Session) = blockingRunOnSession { implicit ec =>
       for {
-        constraints <- sql"""select constraint_name, table_name from information_schema.table_constraints where constraint_type = 'FOREIGN KEY'""".as[(String, String)]
-        constraintStatements = constraints.collect { case (c, t) if !c.startsWith("SQL") =>
-          sqlu"alter table #${profile.quoteIdentifier(t)} drop constraint #${profile.quoteIdentifier(c)}"
-        }
-        _ <- DBIO.sequence(constraintStatements)
         tables <- localTables
+        _ <- DBIO.sequence(tables.map(t => sqlu"exec sp_MSdropconstraints #$t"))
         tableStatements = tables.map(t => sqlu"drop table #${profile.quoteIdentifier(t)}")
         _ <- DBIO.sequence(tableStatements)
       } yield ()
@@ -209,7 +206,19 @@ object StandardTestDBs {
   lazy val SQLServerJTDS = new SQLServerDB("sqlserver-jtds") {
     override def capabilities = super.capabilities - TestDB.capabilities.plainSql
   }
+  lazy val SQLServer2012JTDS = new SQLServerDB("sqlserver2012-jtds") {
+    override def capabilities = super.capabilities - TestDB.capabilities.plainSql
+  }
+  lazy val SQLServer2014JTDS = new SQLServerDB("sqlserver2014-jtds") {
+    override def capabilities = super.capabilities - TestDB.capabilities.plainSql
+  }
   lazy val SQLServerSQLJDBC = new SQLServerDB("sqlserver-sqljdbc") {
+    override def capabilities = profile.capabilities - JdbcCapabilities.createModel
+  }
+  lazy val SQLServer2012SQLJDBC = new SQLServerDB("sqlserver2012-sqljdbc") {
+    override def capabilities = profile.capabilities - JdbcCapabilities.createModel
+  }
+  lazy val SQLServer2014SQLJDBC = new SQLServerDB("sqlserver2014-sqljdbc") {
     override def capabilities = profile.capabilities - JdbcCapabilities.createModel
   }
 
@@ -221,13 +230,26 @@ object StandardTestDBs {
     override def capabilities =
       super.capabilities - TestDB.capabilities.jdbcMetaGetIndexInfo - TestDB.capabilities.transactionIsolation
 
-    /* Only drop and recreate the user. This is much faster than dropping
-     * the tablespace. */
-    override def dropUserArtifacts(implicit session: profile.Backend#Session) = {
-      session.close()
-      val a = DBIO.sequence(Seq(drop(0), create(1), create(2)).map(s => sqlu"#$s"))
-      await(databaseFor("adminConn").run(a))
+    override def localTables(implicit ec: ExecutionContext): DBIO[Vector[String]] = {
+      val tableNames = profile.defaultTables.map(_.map(_.name.name)).map(_.toVector)
+      tableNames
     }
+
+    override def localSequences(implicit ec: ExecutionContext): DBIO[Vector[String]] = {
+      // user_sequences much quicker than going to metadata if you don't know the schema they are going to be in
+      sql"select sequence_Name from user_sequences".as[String]
+    }
+
+    override def dropUserArtifacts(implicit session: profile.Backend#Session) =
+      blockingRunOnSession { implicit ec =>
+        for {
+          tables <- localTables
+          sequences <- localSequences
+          _ <- DBIO.seq(tables.map(t => sqlu"drop table #${profile.quoteIdentifier(t)} cascade constraints") ++
+                        sequences.map(s => sqlu"drop sequence #${profile.quoteIdentifier(s)}"): _*)
+        } yield ()
+      }
+
   }
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -1,5 +1,7 @@
 package com.typesafe.slick.testkit.util
 
+import java.lang.reflect.Method
+
 import com.typesafe.config.Config
 
 import org.junit.Assert
@@ -265,7 +267,21 @@ object ExternalTestDB {
   // A cache for custom drivers to avoid excessive reloading and memory leaks
   private[this] val driverCache = new mutable.HashMap[(String, String), Driver]()
 
-  def getCustomDriver(url: String, driverClass: String): Driver = synchronized {
+  def getCustomDriver(url: String, driverClass: String) = synchronized {
+    val sysloader = java.lang.ClassLoader.getSystemClassLoader
+    val sysclass = classOf[URLClassLoader]
+
+    // Add the supplied jar onto the system classpath
+    // Doing this allows Hikari to initialise the driver, if needed
+    try {
+        val method = sysclass.getDeclaredMethod("addURL", classOf[URL])
+        method.setAccessible(true)
+        method.invoke(sysloader, new URL(url))
+    } catch {
+      case t: Throwable =>
+        t.printStackTrace()
+        throw new IOException(s"Error, could not add URL $url to system classloader");
+    }
     driverCache.getOrElseUpdate((url, driverClass),
       new URLClassLoader(Array(new URL(url)), getClass.getClassLoader).loadClass(driverClass).newInstance.asInstanceOf[Driver]
     )

--- a/slick-testkit/src/test/scala/slick/test/profile/ProfileTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/profile/ProfileTest.scala
@@ -49,4 +49,16 @@ class OracleTest extends ProfileTest(StandardTestDBs.Oracle)
 class SQLServerJTDSTest extends ProfileTest(StandardTestDBs.SQLServerJTDS)
 
 @RunWith(classOf[Testkit])
+class SQLServer2012JTDSTest extends ProfileTest(StandardTestDBs.SQLServer2012JTDS)
+
+@RunWith(classOf[Testkit])
+class SQLServer2014JTDSTest extends ProfileTest(StandardTestDBs.SQLServer2014JTDS)
+
+@RunWith(classOf[Testkit])
 class SQLServerSQLJDBCTest extends ProfileTest(StandardTestDBs.SQLServerSQLJDBC)
+
+@RunWith(classOf[Testkit])
+class SQLServer2012SQLJDBCTest extends ProfileTest(StandardTestDBs.SQLServer2012SQLJDBC)
+
+@RunWith(classOf[Testkit])
+class SQLServer2014SQLJDBCTest extends ProfileTest(StandardTestDBs.SQLServer2014SQLJDBC)

--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -96,8 +96,7 @@ trait OracleProfile extends JdbcProfile {
   override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] = {
     for {
       user <- SimpleJdbcAction(_.session.metaData.getUserName)
-      tables <- SQLActionBuilder(Seq("select TABLE_NAME from all_tables where OWNER = ?"), implicitly[SetParameter[String]].applied(user)).as[String]
-      mtables <- MTable.getTables(None, None, None, Some(Seq("TABLE"))).map(_.filter(t => tables contains t.name.name)) // FIXME: this should check schema and maybe more
+      mtables <- MTable.getTables(None, Some(user), None, Some(Seq("TABLE")))
     } yield mtables
   }
 

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -107,8 +107,13 @@ trait SQLServerProfile extends JdbcProfile {
   override def createModelBuilder(tables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext): JdbcModelBuilder =
     new ModelBuilder(tables, ignoreInvalidDefaults)
 
-  override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] =
-    MTable.getTables(None, None, None, Some(Seq("TABLE")))
+  override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] = {
+    import api._
+    for {
+      schema <- Functions.user.result
+      mtables <- MTable.getTables(None, Some(schema), None, Some(Seq("TABLE")))
+    } yield mtables
+  }
 
   override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
     case java.sql.Types.VARCHAR =>

--- a/test-dbs/testkit-appveyor.conf
+++ b/test-dbs/testkit-appveyor.conf
@@ -1,0 +1,151 @@
+##############################################################################
+# Configurations for running test dbs on AppVeyor
+# The Microsoft SQL profile configs (sqlserver*-sqljdbc) need the
+# non-free jdbc driver placed at file:./sqljdbc42.jar
+##############################################################################
+
+testkit {
+  # Set this high as lots of dbs running in parallel on appveyor
+  asyncTimeout = 10 minutes
+  testDBs = [sqlserver-jtds,sqlserver2012-jtds,sqlserver2014-jtds,sqlserver-sqljdbc,sqlserver2012-sqljdbc,sqlserver2014-sqljdbc]
+}
+
+sqlserver-jtds {
+  enabled = true
+  baseURL = "jdbc:jtds:sqlserver://localhost:1433;instanceName=SQL2008R2SP2;loginTimeout=120;DatabaseName="
+  urlSuffix = ""
+  user = sa
+  password = "Password12!"
+  testDB = slicktest
+  admindb = master
+  defaultSchema = dbo
+  testConn {
+    keepAliveConnection=true
+  }
+  create = [
+    if db_id('${testDB}') is null create database ${testDB}
+    use ${testDB}
+    exec sp_MSforeachtable """"declare @name nvarchar(max); set @name = parsename('?', 1); exec sp_MSdropconstraints @name""""
+    "exec sp_MSforeachtable 'drop table ?'"
+  ]
+  drop = [
+    use ${adminDB}
+  ]
+  driver = net.sourceforge.jtds.jdbc.Driver
+}
+
+sqlserver2012-jtds {
+  enabled = true
+  baseURL = "jdbc:jtds:sqlserver://localhost:1533;instanceName=SQL2012SP1;loginTimeout=120;DatabaseName="
+  user = sa
+  password = "Password12!"
+  testDB = slicktest
+  admindb = master
+  defaultSchema = dbo
+  testConn {
+    keepAliveConnection=true
+  }
+  create = [
+    if db_id('${testDB}') is null create database ${testDB}
+    use ${testDB}
+    exec sp_MSforeachtable """"declare @name nvarchar(max); set @name = parsename('?', 1); exec sp_MSdropconstraints @name""""
+    "exec sp_MSforeachtable 'drop table ?'"
+  ]
+  driver = net.sourceforge.jtds.jdbc.Driver
+}
+
+sqlserver2014-jtds {
+  enabled = true
+  baseURL = "jdbc:jtds:sqlserver://localhost:1633;instanceName=SQL2014;loginTimeout=120;DatabaseName="
+  user = sa
+  password = "Password12!"
+  testDB = slicktest
+  admindb = master
+  defaultSchema = dbo
+  testConn {
+    keepAliveConnection=true
+  }
+  create = [
+    if db_id('${testDB}') is null create database ${testDB}
+    use ${testDB}
+    exec sp_MSforeachtable """"declare @name nvarchar(max); set @name = parsename('?', 1); exec sp_MSdropconstraints @name""""
+    "exec sp_MSforeachtable 'drop table ?'"
+
+  ]
+  driver = net.sourceforge.jtds.jdbc.Driver
+}
+
+sqlserver-sqljdbc {
+  enabled = true
+  baseURL = "jdbc:sqlserver://localhost:1433;instanceName=SQL2008R2SP2;loginTimeout=120;DatabaseName="
+  user = sa
+  password = "Password12!"
+  testDB = slicktest
+  admindb = master
+  defaultSchema = dbo
+  testConn {
+    keepAliveConnection=true
+  }
+  create = [
+    if db_id('${testDB}') is null create database ${testDB}
+    use ${testDB}
+    exec sp_MSforeachtable """"declare @name nvarchar(max); set @name = parsename('?', 1); exec sp_MSdropconstraints @name""""
+    "exec sp_MSforeachtable 'drop table ?'"
+
+    ]
+  drop = [
+    use ${adminDB}
+  ]
+  driverJar = "file:./sqljdbc42.jar"
+  driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+}
+
+sqlserver2012-sqljdbc {
+  enabled = true
+  baseURL = "jdbc:sqlserver://localhost:1533;instanceName=SQL2012SP1;loginTimeout=120;DatabaseName="
+  user = sa
+  password = "Password12!"
+  testDB = slicktest
+  admindb = master
+  defaultSchema = dbo
+  testConn {
+    keepAliveConnection=true
+  }
+  create = [
+    if db_id('${testDB}') is null create database ${testDB}
+    use ${testDB}
+    exec sp_MSforeachtable """"declare @name nvarchar(max); set @name = parsename('?', 1); exec sp_MSdropconstraints @name""""
+    "exec sp_MSforeachtable 'drop table ?'"
+
+    ]
+  drop = [
+    use ${testDB}
+  ]
+  driverJar = "file:./sqljdbc42.jar"
+  driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+}
+
+sqlserver2014-sqljdbc {
+  enabled = true
+  baseURL = "jdbc:sqlserver://localhost:1633;instanceName=SQL2014;loginTimeout=120;DatabaseName="
+  user = sa
+  password = "Password12!"
+  testDB = slicktest
+  admindb = master
+  defaultSchema = dbo
+  testConn {
+    keepAliveConnection=true
+  }
+  create = [
+    if db_id('${testDB}') is null create database ${testDB}
+    use ${testDB}
+    exec sp_MSforeachtable """"declare @name nvarchar(max); set @name = parsename('?', 1); exec sp_MSdropconstraints @name""""
+    "exec sp_MSforeachtable 'drop table ?'"
+
+    ]
+  drop = [
+    use ${testDB}
+  ]
+  driverJar = "file:./sqljdbc42.jar"
+  driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+}

--- a/test-dbs/testkit.travis.conf
+++ b/test-dbs/testkit.travis.conf
@@ -1,4 +1,17 @@
 # Test database configuration for Travis CI build
+# ....
+# The Oracle profile config needs the non-free jdbc driver placed at file:./ojdbc7-12.1.0.2.jar
+# The DB2 profile config needs the non-free jdbc driver placed at file:./db2jcc4.jar
+testkit {
+  # Set this high as travis agents are stressed and better to succeed slowly sometimes than fail intermittently
+  asyncTimeout = 10 minutes
+}
+
+mysql {
+  enabled = true
+  baseURL = "jdbc:mysql://127.0.0.1/"
+  user = root
+}
 
 postgres {
   enabled = true
@@ -6,8 +19,93 @@ postgres {
   drop = DROP DATABASE IF EXISTS ${testDB}
 }
 
-mysql {
+db2 {
   enabled = true
-  baseURL = "jdbc:mysql://127.0.0.1/"
-  user = travis
+  driverJar = "file:./db2jcc4.jar"
+  user = db2inst1
+  schema = "SLICK_TEST"
+  password = db2inst1-pwd
+  testDB = "SLICKTST"
+  adminConn {
+    user = ${user}
+    password = ${password}
+    tableTableSpace = "SLICK_DATA"
+    indexTableSpace = "SLICK_INDEX"
+  }
+  create = [
+      """
+      begin
+        declare tsCount int default 0;
+        select count(*) into tsCount from SYSIBMADM."USER_TABLESPACES" where tablespace_name = '"""${adminConn.tableTableSpace}"""';
+        if (tsCount = 0) then
+          execute immediate 'create tablespace """${adminConn.tableTableSpace}""" managed by database using (file ''./dbdata/"""${adminConn.tableTableSpace}""".dat'' 10M)';
+          execute immediate 'create tablespace """${adminConn.indexTableSpace}""" managed by database using (file ''./dbdata/"""${adminConn.indexTableSpace}""".dat'' 10M)';
+          grant use of tablespace """${adminConn.tableTableSpace}""" to """${user}""" with grant option
+          grant use of tablespace """${adminConn.indexTableSpace}""" to """${user}""" with grant option
+        end if;
+        for v_row as (select 'drop table "' || table_schema || '"."' || table_name || '"' as NAME from sysibm.tables where table_schema = 'DB2INST1')
+        do
+         execute immediate v_row.NAME;
+        end for;
+        for v_seq as (select 'drop sequence "' || seqname || '"' as NAME from syscat.sequences where seqschema = 'DB2INST1')
+        do
+         execute immediate v_seq.NAME;
+        end for;
+      end"""
+    ]
 }
+
+oracle {
+  enabled = true
+  driverJar = "file:./ojdbc7-12.1.0.2.jar"
+  driver=oracle.jdbc.OracleDriver
+  baseURL = "jdbc:oracle:thin:@//localhost:49161/xe"
+  testDB = ""
+  admindb = ""
+  adminConn {
+    user = system
+    password = oracle
+    keepAliveConnection=true
+    connectionPool=HikariCP
+    connectionTimeout=600000
+    idleTimeout=60000
+    numThreads=1
+    tableTableSpace = "slick_data"
+    indexTableSpace = "slick_index"
+  }
+  testConn {
+    user = SLICKTEST
+    password = ${testConn.user}
+    keepAliveConnection=true
+    connectionPool=HikariCP
+    connectionTimeout=600000
+    idleTimeout=60000
+    numThreads=3
+  }
+  create = [
+    """declare
+    userCount integer := 0;
+    begin
+      select count(*) into userCount from dba_users where username = '"""${testConn.user}"""';
+      if (userCount = 0)
+      then
+        execute immediate ('create tablespace """${adminConn.tableTableSpace}""" datafile ''"""${adminConn.tableTableSpace}""".dat'' size 10M autoextend on');
+        execute immediate ('create tablespace """${adminConn.indexTableSpace}""" datafile ''"""${adminConn.indexTableSpace}""".dat'' size 10M autoextend on');
+        execute immediate ('create user """${testConn.user}""" identified by """${testConn.user}""" DEFAULT TABLESPACE """${adminConn.tableTableSpace}""" TEMPORARY TABLESPACE temp QUOTA UNLIMITED ON """${adminConn.tableTableSpace}"""');
+        execute immediate ('grant all privileges to """${testConn.user}"""');
+      else
+        FOR r1 IN ( SELECT 'DROP ' || object_type || ' """${testConn.user}"""."' || object_name || '"' || DECODE ( object_type, 'TABLE', ' CASCADE CONSTRAINTS PURGE' ) AS v_sql
+                    FROM dba_objects
+                    WHERE object_type IN ( 'TABLE', 'SEQUENCE' )
+                    and owner = '"""${testConn.user}"""'
+                    ORDER BY object_type, object_name ) LOOP
+           EXECUTE IMMEDIATE r1.v_sql;
+        END LOOP;
+      end if;
+    end;"""
+  ]
+  // override the drop in the reference conf
+  drop = null
+}
+
+

--- a/travis/extractNonPublicDeps
+++ b/travis/extractNonPublicDeps
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script extracts jars that aren't in public repositories. This is used for slick CI.
+# Don't use this script to get the jars for your environment. Download them from the relevant source.
+# https://www.microsoft.com/en-gb/download/details.aspx?id=11774
+# http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html
+# http://www-01.ibm.com/support/docview.wss?uid=swg21363866
+
+DIR="$( cd "$( dirname $0 )" && pwd )"
+SCRIPTPATH=$DIR/ZNonPublicDeps
+OJDBCDIR=ojdbc7
+export CxD=$(echo wraan | tr '[A-Za-z]' '[N-ZA-Mn-za-m]')
+openssl enc -in ${SCRIPTPATH}/mssql.enc -out ./sqljdbc42.jar -d -aes256  -pass env:CxD
+openssl enc -in ${SCRIPTPATH}/npj.enc -out ${SCRIPTPATH}/npj.tjz -d -aes256  -pass env:CxD
+tar xvjf ${SCRIPTPATH}/npj.tjz -C ${SCRIPTPATH}
+cp ${SCRIPTPATH}/nonpublicjars/${OJDBCDIR}/jars/ojdbc7-12.1.0.2.jar .

--- a/travis/runcontainer.sh
+++ b/travis/runcontainer.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# This script is used by travis to start docker containers. You can also use this script if you want
+# to start oracle or db2 locally. It will re-use previously created containers if it finds them.
+# The password in the Oracle image can expire. When this happens, you need to remove the cached image, so
+# docker can create a new one: docker stop oracleslick && docker rm oracleslick: then re-run this script
+
+if [ $# -eq 0 ]; then
+  echo "Need to specify container to start. One or both of oracle, db2"
+  exit 1
+fi
+
+SUCCESS_TOKEN=SUCCESS
+RESULT=${SUCCESS_TOKEN}
+while [ $# -ge 1 ]
+do
+  if [ "${1}" = "oracle" ]; then
+    CONTAINER_NAMES="${CONTAINER_NAMES} oracleslick"
+  elif [ "${1}" = "db2" ]; then
+    CONTAINER_NAMES="${CONTAINER_NAMES} db2slick"
+    DB2NAME=SLICKTST
+  else
+    echo "Unknown container type ${1}"
+    exit 1
+  fi
+  shift
+done
+
+# This bit is properly weird and took me ages to find a workaround. Basically, without a connection
+# to the db in a shell that is kept alive, aggregate functions with nulls behave incorrectly
+# so the AggregateTest.testGroupBy test fails
+db2HackConnection () {
+  echo "Starting persitant db2 connection"
+  docker exec -i ${CONTAINER_NAME} bash -c "su - db2inst1 -c 'while true; do db2 connect to $DB2NAME && while sleep 65535;do :; done; sleep 5; done'" &
+}
+
+# sometimes, startup on travis fails, so retry up to 5 times.
+for try in 1 2 3 4 5
+do
+  for CONTAINER_NAME in ${CONTAINER_NAMES}
+  do
+    echo "Trying to start container ${CONTAINER_NAME} #$try"
+    RUNNING=$(docker inspect  --format="{{ .State.Running}}" ${CONTAINER_NAME}  2> /dev/null)
+    if [ $? -eq 1 ]; then
+      if [ "${CONTAINER_NAME}" = "oracleslick" ]; then
+	RESULT=$(docker run -d -p 49160:22 -p 49161:1521 --name ${CONTAINER_NAME} wnameless/oracle-xe-11g && echo -e "\n${SUCCESS_TOKEN}")
+      elif [ "${CONTAINER_NAME}" = "db2slick" ]; then
+	RESULT=$(docker run -d -p 50000:50000 --name ${CONTAINER_NAME} -e DB2INST1_PASSWORD=db2inst1-pwd -e LICENSE=accept  ibmcom/db2express-c:latest "db2start" &&
+	# Extract non-free db2 jdbc driver jar
+	docker cp ${CONTAINER_NAME}:/home/db2inst1/sqllib/java/db2jcc4.jar . &&
+	docker exec -i -u db2inst1 -t ${CONTAINER_NAME} bash -l -c "db2 create database $DB2NAME" &&
+	echo -e "\n${SUCCESS_TOKEN}")
+      fi
+    elif [ "$RUNNING" = "false" ]; then
+      echo "Container ${CONTAINER_NAME} exists, but stopped. Starting ..."
+      RESULT=$(docker start ${CONTAINER_NAME} && echo -e "\n${SUCCESS_TOKEN}")
+    elif [ "$RUNNING" = "true" ]; then
+      echo "Container ${CONTAINER_NAME} already running"
+      RESULT=${SUCCESS_TOKEN}
+    fi
+    LAST_LINE=$(echo "${RESULT}" | tail -n 1)
+    if [ "${LAST_LINE}" != "${SUCCESS_TOKEN}" ]; then
+      echo "Container startup failed. Retry ..."
+      break
+    elif [ "${CONTAINER_NAME}" = "db2slick" ]; then
+      db2HackConnection
+    fi
+  done
+  if [ "${LAST_LINE}" = "${SUCCESS_TOKEN}" ]; then
+    echo "Container startup succeeded"
+    exit 0
+  fi
+
+# If in travis environment, restart docker service can help initalisation problems
+  if [ "${TRAVIS}" = "true" ]; then
+    echo "Removing container: ${CONTAINER_NAME}"
+    docker stop ${CONTAINER_NAME} && docker rm ${CONTAINER_NAME}
+
+    echo "Restart Docker:"
+    sudo restart docker
+    echo "Resetting iptables:"
+    sudo iptables -F
+
+    echo "Docker status:"
+    sudo service docker status
+
+    echo "Docker status:"
+    sudo service docker status
+  fi
+
+  echo "Sleeping..."
+  sleep 5
+done 
+# if we got here, container startup has failed
+exit 1


### PR DESCRIPTION
The use of Hikari for the Oracle test on travis is because Hikari handles the limited resources available to the docker image in a travis environment well. i.e. not running out of connections and retrying SQLExceptions where possible.

Getting hold of the non-free drivers is one of the tricky problems to solve. The DB2 driver can just be copied from the docker image. For the MS SQL and Oracle driver, I've put a git submodule with encrypted copies of them in the travis directory. I'm open to any better suggestions that anyone can think of. 
The advantages that this approach has
- Being in a submodule means that just checking out the slick repo wont get the encrypted jars. So there is no bloat on the slick repo size.
- The way that the script unencrypts them, means it will work with PRs (putting a secret in an environment variable doesn't work on PR builds).
 

That hard part of putting this PR together was trying to make sure the builds would be stable. We are stressing the build agents with both the compile and the testkit tests alongside db instances. The way things are configured in this PR, the travis builds take about 30 mins and the appveyor builds, less that 40 mins. I had to just do sbt testAll (i.e. not sbt +testAll) on appveyor, otherwise this builds would get too near the 60min limit that a build has before it fails. Currently travis agents have 8Gb and appveyor agents only have 1.7Gb.

If anyone sees any intermittent failures, let me know, an I'll see what I can do to make the build more resilient.

When this PR is merged, we will need to create an appveyor build for slick. You can see it running against my slick repo here. https://ci.appveyor.com/project/smootoo/slick/build/1.0.120