### PR TITLE
fixes issue 1274: Slick deadlock

### DIFF
--- a/common-test-resources/application.conf
+++ b/common-test-resources/application.conf
@@ -76,3 +76,11 @@ distrib2 {
     keepAliveConnection = true
   }
 }
+
+h2mem1 = {
+  url = "jdbc:h2:mem:test1"
+  driver = org.h2.Driver
+  connectionPool = "HikariCP"
+  numThreads = 1
+  keepAliveConnection = true
+}

--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -1,16 +1,25 @@
 package slick.jdbc.hikaricp
 
-import java.sql.{Driver, Connection}
+import java.sql.{Connection, Driver}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+
 import com.typesafe.config.Config
 import slick.SlickException
-import slick.jdbc.{JdbcDataSourceFactory, JdbcDataSource}
+import slick.jdbc.{JdbcDataSource, JdbcDataSourceFactory}
 import slick.util.ConfigExtensionMethods._
+import slick.util.Logging
 
 /** A JdbcDataSource for a HikariCP connection pool.
   * See `slick.jdbc.JdbcBackend#Database.forConfig` for documentation on the config parameters. */
-class HikariCPJdbcDataSource(val ds: com.zaxxer.hikari.HikariDataSource, val hconf: com.zaxxer.hikari.HikariConfig) extends JdbcDataSource {
+class HikariCPJdbcDataSource(val ds: com.zaxxer.hikari.HikariDataSource, val hconf: com.zaxxer.hikari.HikariConfig)
+  extends JdbcDataSource {
+
   def createConnection(): Connection = ds.getConnection()
+
   def close(): Unit = ds.close()
+
+  override val maxConnections: Option[Int] = Some(ds.getMaximumPoolSize)
 }
 
 object HikariCPJdbcDataSource extends JdbcDataSourceFactory {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DelegateConnection.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DelegateConnection.scala
@@ -11,7 +11,7 @@ class DelegateConnection(conn: Connection) extends Connection {
   def setAutoCommit(autoCommit: Boolean): Unit = conn.setAutoCommit(autoCommit)
   def setHoldability(holdability: Int): Unit = conn.setHoldability(holdability)
   def clearWarnings(): Unit = conn.clearWarnings()
-  def getNetworkTimeout: Int = ??? //conn.getNetworkTimeout
+  def getNetworkTimeout: Int = conn.getNetworkTimeout
   def createBlob(): Blob = conn.createBlob()
   def createSQLXML(): SQLXML = conn.createSQLXML()
   def setSavepoint(): Savepoint = conn.setSavepoint()
@@ -20,8 +20,8 @@ class DelegateConnection(conn: Connection) extends Connection {
   def getTransactionIsolation: Int = conn.getTransactionIsolation
   def getClientInfo(name: String): String = conn.getClientInfo(name)
   def getClientInfo: Properties = conn.getClientInfo
-  def getSchema: String = ??? //conn.getSchema
-  def setNetworkTimeout(executor: Executor, milliseconds: Int): Unit = ??? //conn.setNetworkTimeout(executor, milliseconds)
+  def getSchema: String = conn.getSchema
+  def setNetworkTimeout(executor: Executor, milliseconds: Int): Unit = conn.setNetworkTimeout(executor, milliseconds)
   def getMetaData: DatabaseMetaData = conn.getMetaData
   def getTypeMap: util.Map[String, Class[_]] = conn.getTypeMap
   def rollback(): Unit = conn.rollback()
@@ -45,7 +45,7 @@ class DelegateConnection(conn: Connection) extends Connection {
   def setCatalog(catalog: String): Unit = conn.setCatalog(catalog)
   def close(): Unit = conn.close()
   def getAutoCommit: Boolean = conn.getAutoCommit
-  def abort(executor: Executor): Unit = ??? //conn.abort(executor)
+  def abort(executor: Executor): Unit = conn.abort(executor)
   def isValid(timeout: Int): Boolean = conn.isValid(timeout)
   def prepareStatement(sql: String): PreparedStatement = conn.prepareStatement(sql)
   def prepareStatement(sql: String, resultSetType: Int, resultSetConcurrency: Int): PreparedStatement = conn.prepareStatement(sql, resultSetType, resultSetConcurrency)
@@ -57,7 +57,7 @@ class DelegateConnection(conn: Connection) extends Connection {
   def isClosed: Boolean = conn.isClosed
   def createStruct(typeName: String, attributes: Array[AnyRef]): Struct = conn.createStruct(typeName, attributes)
   def getWarnings: SQLWarning = conn.getWarnings
-  def setSchema(schema: String): Unit = ??? //conn.setSchema(schema)
+  def setSchema(schema: String): Unit = conn.setSchema(schema)
   def commit(): Unit = conn.commit()
   def unwrap[T](iface: Class[T]): T = conn.unwrap[T](iface)
   def isWrapperFor(iface: Class[_]): Boolean = conn.isWrapperFor(iface)

--- a/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
@@ -1,13 +1,16 @@
 package slick.test.jdbc
 
-import java.sql.{SQLException, DriverPropertyInfo, Connection, Driver}
+import java.io.PrintWriter
+import java.sql.{Connection, Driver, DriverPropertyInfo, SQLException}
 import java.util.Properties
 import java.util.logging.Logger
+import javax.sql.DataSource
 
+import com.typesafe.config.ConfigFactory
 import org.junit.Test
 import org.junit.Assert._
 import slick.basic.DatabaseConfig
-import slick.jdbc.{JdbcProfile, JdbcBackend}
+import slick.jdbc.{JdbcBackend, JdbcProfile}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -34,6 +37,7 @@ class DataSourceTest {
     MockDriver.reset
     val db = JdbcBackend.Database.forConfig("databaseUrl")
     try {
+      assertEquals(Some(100), db.source.maxConnections)
       try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
       val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
       assertEquals("jdbc:postgresql://host/dbname", url)
@@ -42,6 +46,54 @@ class DataSourceTest {
       assertEquals("bar", info.getProperty("foo"))
     } finally db.close
   }
+
+  @Test def testMaxConnections: Unit = {
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrl", ConfigFactory.parseString(
+      """
+         |databaseUrl {
+         |  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+         |  maxConnections = 20
+         |  url = "postgres://user:pass@host/dbname"
+         |}
+         |""".stripMargin))
+    try {
+      assertEquals("maxConnections should be respected", Some(20), db.source.maxConnections)
+    } finally db.close
+  }
+
+  @Test def testMaxConnectionsNumThreads: Unit = {
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrl", ConfigFactory.parseString(
+      """
+        |databaseUrl {
+        |  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+        |  numThreads = 10
+        |  url = "postgres://user:pass@host/dbname"
+        |}
+        |""".stripMargin
+    ))
+    try {
+      assertEquals("maxConnections should be numThreads * 5", Some(50), db.source.maxConnections)
+    } finally db.close
+  }
+
+  @Test def testConnectionPoolDisabled: Unit = {
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrl", ConfigFactory.parseString(
+      """
+        |databaseUrl {
+        |  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+        |  connectionPool = "disabled"
+        |  url = "postgres://user:pass@host/dbname"
+        |}
+        |
+      """.stripMargin))
+    try {
+      assertEquals("maxConnections should be None when not using a pool", None, db.source.maxConnections)
+    } finally db.close
+  }
+
 }
 
 object MockDriver {
@@ -62,3 +114,4 @@ class MockDriver extends Driver {
   }
   def getMajorVersion: Int = 0
 }
+

--- a/slick-testkit/src/test/scala/slick/test/jdbc/hikaricp/SlickDeadlockTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/hikaricp/SlickDeadlockTest.scala
@@ -1,0 +1,86 @@
+package slick.test.jdbc.hikaricp
+
+import java.sql.Blob
+import java.util.concurrent.TimeUnit
+import javax.sql.rowset.serial.SerialBlob
+
+import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
+import org.junit.{After, Before, Ignore, Test}
+import slick.jdbc.H2Profile.api._
+import slick.lifted.{ProvenShape, TableQuery}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class SlickDeadlockTest extends AsyncTest[JdbcTestDB] {
+
+  class TestTable(tag: Tag) extends Table[(Int)](tag, "SDL") {
+
+    def id: Rep[Int] = column[Int]("ID")
+    def * : ProvenShape[(Int)] = id
+
+  }
+
+  class BlobTable(tag: Tag) extends Table[(Int, Blob)](tag, "SDLIO") {
+    def id = column[Int]("id")
+    def data = column[Blob]("data")
+    def * = (id, data)
+  }
+
+
+  var database: Database = _
+  val testTable: TableQuery[TestTable] = TableQuery[TestTable]
+  val blobTable: TableQuery[BlobTable] = TableQuery[BlobTable]
+
+  @Before
+  def openDatabase() = {
+    database = Database.forConfig("h2mem1")
+    Await.result(database.run((testTable.schema ++ blobTable.schema).create), 2.seconds)
+  }
+
+  @After
+  def closeDatabase() = {
+    Await.result(database.run((testTable.schema ++ blobTable.schema).drop), 2.seconds)
+    database.close()
+  }
+
+
+  @Test def slickDoesNotDeadlock() {
+
+    val tasks = 1 to 100 map { i =>
+      val action = { testTable += i }
+        .flatMap { _ => testTable.length.result }
+        .flatMap { _ => DBIO.successful(s"inserted value $i") }
+
+      database.run(action.transactionally)
+    }
+    Await.result(Future.sequence(tasks), Duration(10, TimeUnit.SECONDS))
+  }
+
+  @Test def slickDoesNotDeadlockWithSleeps(): Unit = {
+    val tasks = 1 to 50 map { c =>
+      val action = sql"select $c".as[Int].head.map { i => Thread.sleep(if(c == 1) 100 else 200); i }
+
+      database.run(action.transactionally)
+    }
+    Await.result(Future.sequence(tasks), Duration(10, TimeUnit.SECONDS))
+
+  }
+
+  @Test def slickDoesNotDeadlockWithIo() {
+
+    Await.result(database.run((
+        (blobTable += (1, new SerialBlob(Array[Byte](1,2,3)))) >>
+        (blobTable += (2, new SerialBlob(Array[Byte](4,5)))) >>
+        blobTable.result
+    ).transactionally), Duration(2, TimeUnit.SECONDS))
+
+    val tasks = 1 to 100 map { i =>
+      materializeAsync[(Int, Blob), (Int, String)](database.stream(blobTable.result.transactionally, bufferNext = false),
+        { case (id, data) => database.io((id, data.getBytes(1, data.length.toInt).mkString)) })
+    }
+
+    Await.result(Future.sequence(tasks), Duration(10, TimeUnit.SECONDS))
+  }
+
+}

--- a/slick/src/main/scala/slick/jdbc/JdbcDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcDataSource.scala
@@ -3,10 +3,11 @@ package slick.jdbc
 import java.io.Closeable
 import java.util.Properties
 import java.util.concurrent.TimeUnit
-import java.sql.{SQLException, DriverManager, Driver, Connection}
+import java.sql.{Connection, Driver, DriverManager, SQLException}
 import javax.sql.DataSource
+
 import com.typesafe.config.Config
-import slick.util.{Logging, ClassLoaderUtil, BeanConfigurator}
+import slick.util._
 import slick.util.ConfigExtensionMethods._
 import slick.SlickException
 
@@ -14,12 +15,20 @@ import slick.SlickException
   * similar to a `javax.sql.DataSource` but simpler. Unlike [[JdbcBackend.DatabaseDef]] it is not a
   * part of the backend cake. This trait defines the SPI for 3rd-party connection pool support. */
 trait JdbcDataSource extends Closeable {
+
   /** Create a new Connection or get one from the pool */
   def createConnection(): Connection
 
   /** If this object represents a connection pool managed directly by Slick, close it.
     * Otherwise no action is taken. */
   def close(): Unit
+
+  /** If this object represents a connection pool managed directly by Slick, return the maximum pool size
+    * Otherwise return None.
+    * The AsyncExecutor uses this to make sure to not schedule any more work (that requires a connection) when all pooled JDBC connections are in use.
+    */
+  val maxConnections: Option[Int] = None
+
 }
 
 object JdbcDataSource extends Logging {

--- a/slick/src/main/scala/slick/util/AsyncExecutor.scala
+++ b/slick/src/main/scala/slick/util/AsyncExecutor.scala
@@ -1,11 +1,11 @@
 package slick.util
 
 import java.io.Closeable
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent._
+
 import scala.concurrent.duration._
-import scala.concurrent.{Promise, Future, ExecutionContext}
-import scala.util.control.NonFatal
+import scala.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
 
 /** A connection pool for asynchronous execution of blocking I/O actions.
   * This is used for the asynchronous query execution API on top of blocking back-ends like JDBC. */
@@ -15,6 +15,7 @@ trait AsyncExecutor extends Closeable {
   /** Shut the thread pool down and try to stop running computations. The thread pool is
     * transitioned into a state where it will not accept any new jobs. */
   def close(): Unit
+
 }
 
 object AsyncExecutor extends Logging {
@@ -33,10 +34,14 @@ object AsyncExecutor extends Logging {
     * @param minThreads The number of core threads in the pool.
     * @param maxThreads The maximum number of threads in the pool.
     * @param queueSize The size of the job queue, 0 for direct hand-off or -1 for unlimited size.
+    * @param maxConnections The maximum number of configured connections for the connection pool.
+    *                       The underlying ThreadPoolExecutor will not pick up any more work when all connections are in use.
+    *                       It will resume as soon as a connection is released again to the pool
+    *                       Default is Integer.MAX_VALUE which is only ever a good choice when not using connection pooling
     * @param keepAliveTime when the number of threads is greater than
     *        the core, this is the maximum time that excess idle threads
     *        will wait for new tasks before terminating.*/
-  def apply(name: String, minThreads: Int, maxThreads: Int, queueSize: Int, keepAliveTime: Duration = 1.minute): AsyncExecutor = {
+  def apply(name: String, minThreads: Int, maxThreads: Int, queueSize: Int, maxConnections: Int = Integer.MAX_VALUE, keepAliveTime: Duration = 1.minute): AsyncExecutor = {
     new AsyncExecutor {
       // Before init: 0, during init: 1, after init: 2, during/after shutdown: 3
       private[this] val state = new AtomicInteger(0)
@@ -46,39 +51,88 @@ object AsyncExecutor extends Logging {
       lazy val executionContext = {
         if(!state.compareAndSet(0, 1))
           throw new IllegalStateException("Cannot initialize ExecutionContext; AsyncExecutor already shut down")
-        val queue = queueSize match {
+        val queue: BlockingQueue[Runnable] = queueSize match {
           case 0 => new SynchronousQueue[Runnable]
           case -1 => new LinkedBlockingQueue[Runnable]
-          case n =>
-            new ManagedArrayBlockingQueue[Runnable](n * 2) {
-              def accept(r: Runnable, size: Int) = r match {
-                case pr: PrioritizedRunnable if pr.highPriority => true
-                case _ => size < n
-              }
-            }
+          case n => new ManagedArrayBlockingQueue(maxConnections, n).asInstanceOf[BlockingQueue[Runnable]]
         }
         val tf = new DaemonThreadFactory(name + "-")
-        executor = new ThreadPoolExecutor(minThreads, maxThreads, keepAliveTime.toMillis, TimeUnit.MILLISECONDS, queue, tf)
+        executor = new ThreadPoolExecutor(minThreads, maxThreads, keepAliveTime.toMillis, TimeUnit.MILLISECONDS, queue, tf) {
+
+          /**
+            * If the runnable/task is a low/medium priority item, we increase the items in use count, because first thing it will do
+            * is open a Jdbc connection from the pool.
+            */
+          override def beforeExecute(t: Thread, r: Runnable): Unit = {
+            (r, queue) match {
+              case (pr: PrioritizedRunnable, q: ManagedArrayBlockingQueue[Runnable]) if pr.priority != WithConnection => q.increaseInUseCount(pr)
+              case _ =>
+            }
+            super.beforeExecute(t, r)
+          }
+
+          /**
+            * If the runnable/task has released the Jdbc connection we decrease the counter again
+            */
+          override def afterExecute(r: Runnable, t: Throwable): Unit = {
+            super.afterExecute(r, t)
+            (r, queue) match {
+              case (pr: PrioritizedRunnable, q: ManagedArrayBlockingQueue[Runnable]) =>
+                if (pr.connectionReleased && pr.priority != WithConnection) q.decreaseInUseCount()
+                pr.inUseCounterSet = false
+              case _ =>
+            }
+          }
+
+        }
         if(!state.compareAndSet(1, 2)) {
           executor.shutdownNow()
           throw new IllegalStateException("Cannot initialize ExecutionContext; AsyncExecutor shut down during initialization")
         }
-        ExecutionContext.fromExecutorService(executor, loggingReporter)
+        new ExecutionContextExecutor {
+          override def reportFailure(t: Throwable): Unit = loggingReporter(t)
+
+          override def execute(command: Runnable): Unit = {
+            if (command.isInstanceOf[PrioritizedRunnable]) {
+              executor.execute(command)
+            } else {
+              executor.execute(new PrioritizedRunnable {
+
+                override val priority: Priority = WithConnection
+
+                override def run(): Unit = command.run()
+              })
+            }
+          }
+        }
+
       }
       def close(): Unit = if(state.getAndSet(3) == 2) {
         executor.shutdownNow()
         if(!executor.awaitTermination(30, TimeUnit.SECONDS))
           logger.warn("Abandoning ThreadPoolExecutor (not yet destroyed after 30 seconds)")
       }
+
     }
   }
 
   def default(name: String = "AsyncExecutor.default"): AsyncExecutor =
     apply(name, 20, 1000)
 
+  sealed trait Priority
+  /** Fresh is used for database actions that are scheduled/queued for the first time. */
+  case object Fresh extends Priority
+  /** Continuation is used for database actions that are a continuation of some previously executed actions */
+  case object Continuation extends Priority
+  /** WithContinuation is used for database actions that already have a JDBC connection associated. */
+  case object WithConnection extends Priority
 
   trait PrioritizedRunnable extends Runnable {
-    def highPriority: Boolean
+    def priority: Priority
+    /** true if the JDBC connection was released */
+    var connectionReleased = false
+    /** true if the inUseCounter of the ManagedArrayBlockQueue was already incremented */
+    var inUseCounterSet = false
   }
 
   private class DaemonThreadFactory(namePrefix: String) extends ThreadFactory {

--- a/slick/src/main/scala/slick/util/InternalArrayQueue.scala
+++ b/slick/src/main/scala/slick/util/InternalArrayQueue.scala
@@ -1,0 +1,179 @@
+package slick.util
+
+import java.util
+
+/** A simplified copy of `java.util.concurrent.ArrayBlockingQueue` with additional logic for
+  * temporarily rejecting elements based on the current size. All features of the original
+  * ArrayBlockingQueue have been ported, except the mutation methods of the iterator. See
+  * `java.util.concurrent.ArrayBlockingQueue` for documentation. */
+private[util] final class InternalArrayQueue[E >: Null <: AnyRef](capacity: Int) {
+
+  private[this] val items = new Array[AnyRef](capacity)
+  private[this] var takeIndex, putIndex = 0
+  private[util] var count = 0
+
+  private[this] def checkNotNull(v: AnyRef): Unit = if (v == null) throw new NullPointerException
+  private[this] def inc(i: Int): Int = if(i+1 == items.length) 0 else i+1
+  private[this] def itemAt(i: Int): E = items(i).asInstanceOf[E]
+
+  private[util] def extract: E = {
+    val items = this.items
+    val x: E = items(takeIndex).asInstanceOf[E]
+    items(takeIndex) = null
+    takeIndex = inc(takeIndex)
+    count -= 1
+    x
+  }
+
+  private[util] def insert(x: E): Boolean = {
+    if (count == items.length) {
+      false
+    } else {
+      items(putIndex) = x
+      putIndex = inc(putIndex)
+      count += 1
+      true
+    }
+  }
+
+  private[this] def removeAt(_i: Int) {
+    var i = _i
+    val items = this.items
+    if (i == takeIndex) {
+      items(takeIndex) = null
+      takeIndex = inc(takeIndex)
+    }
+    else {
+      var cond = true
+      while (cond) {
+        val nexti: Int = inc(i)
+        if (nexti != putIndex) {
+          items(i) = items(nexti)
+          i = nexti
+        }
+        else {
+          items(i) = null
+          putIndex = i
+          cond = false
+        }
+      }
+    }
+    count -= 1
+  }
+
+  private[util] def contains(o: AnyRef): Boolean = {
+    if (o == null) return false
+    val items = this.items
+    var i = takeIndex
+    var k = count
+    while (k > 0) {
+      if (o == items(i)) return true
+      i = inc(i)
+      k -= 1
+    }
+    false
+  }
+
+  private[util] def remove(o: AnyRef): Boolean = if (o eq null) false else {
+    val items = this.items
+    var i: Int = takeIndex
+    var k: Int = count
+    while (k > 0) {
+      if (o == items(i)) {
+        removeAt(i)
+        return true
+      }
+      i = inc(i)
+      k -= 1
+    }
+    false
+  }
+
+  def peek: E = if(count == 0) null else itemAt(takeIndex)
+
+  private[util] def clear() {
+    val items = this.items
+    var i = takeIndex
+    var k = count
+    while (k > 0) {
+      items(i) = null
+      i = inc(i)
+      k -= 1
+    }
+    count = 0
+    putIndex = 0
+    takeIndex = 0
+  }
+
+  private[util] def drainTo(c: util.Collection[_ >: E]): Int = {
+    checkNotNull(c)
+    val items = this.items
+    var i = takeIndex
+    var n = 0
+    val max = count
+    while (n < max) {
+      c.add(items(i).asInstanceOf[E])
+      items(i) = null
+      i = inc(i)
+      n += 1
+    }
+    if (n > 0) {
+      count = 0
+      putIndex = 0
+      takeIndex = 0
+    }
+    n
+  }
+
+  private[util] def drainTo(c: util.Collection[_ >: E], maxElements: Int): Int = {
+    checkNotNull(c)
+    if (maxElements <= 0) return 0
+    val items = this.items
+    var i: Int = takeIndex
+    var n: Int = 0
+    val max: Int = if (maxElements < count) maxElements else count
+    while (n < max) {
+      c.add(items(i).asInstanceOf[E])
+      items(i) = null
+      i = inc(i)
+      n += 1
+    }
+    if (n > 0) {
+      count -= n
+      takeIndex = i
+    }
+    n
+  }
+
+  private[util] def iterator: util.Iterator[E] = new util.Iterator[E] {
+    private var remaining: Int = _
+    private var nextIndex: Int = _
+    private var nextItem: E = _
+    private var lastItem: E = _
+    private var lastRet: Int = -1
+
+    remaining = count
+    if(remaining > 0) {
+      nextIndex = takeIndex
+      nextItem = itemAt(nextIndex)
+    }
+
+    def hasNext: Boolean = remaining > 0
+
+    def next: E = {
+      if (remaining <= 0) throw new NoSuchElementException
+      lastRet = nextIndex
+      var x: E = itemAt(nextIndex)
+      if (x == null) {
+        x = nextItem
+        lastItem = null
+      }
+      else lastItem = x
+      while ({ remaining -= 1; remaining > 0 } && { nextIndex = inc(nextIndex); nextItem = itemAt(nextIndex); nextItem == null }) ()
+      x
+    }
+
+    def remove(): Unit = throw new UnsupportedOperationException
+  }
+
+}

--- a/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
+++ b/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
@@ -1,96 +1,96 @@
 package slick.util
 
-import java.util.concurrent.{ArrayBlockingQueue, TimeUnit, BlockingQueue}
+import java.util.concurrent.{BlockingQueue, TimeUnit}
 import java.util.concurrent.locks._
-import java.util._
+import java.util
+
+import slick.util.AsyncExecutor._
 
 /** A simplified copy of `java.util.concurrent.ArrayBlockingQueue` with additional logic for
   * temporarily rejecting elements based on the current size. All features of the original
   * ArrayBlockingQueue have been ported, except the mutation methods of the iterator. See
   * `java.util.concurrent.ArrayBlockingQueue` for documentation. */
-abstract class ManagedArrayBlockingQueue[E >: Null <: AnyRef](capacity: Int, fair: Boolean = false) extends AbstractQueue[E] with BlockingQueue[E] { self =>
+class ManagedArrayBlockingQueue[E >: Null <: PrioritizedRunnable](maximumInUse: Int, capacity: Int, fair: Boolean = false)
+  extends util.AbstractQueue[E]
+  with BlockingQueue[E]
+  with Logging { self =>
 
-  /** Determine if the item should be accepted at the current time. */
-  protected[this] def accept(item: E, size: Int): Boolean
-
-  private[this] val items = new Array[AnyRef](capacity)
   private[this] val lock = new ReentrantLock(fair)
   private[this] val notEmpty = lock.newCondition
   private[this] val notFull = lock.newCondition
-  private[this] var takeIndex, putIndex, count = 0
 
   private[this] def checkNotNull(v: AnyRef): Unit = if (v == null) throw new NullPointerException
+  private[this] def checkNotInUse(e: E) = require(!e.inUseCounterSet, "in use count is already set")
 
-  private[this] def inc(i: Int): Int = if(i+1 == items.length) 0 else i+1
+  private[this] val itemQueue = new InternalArrayQueue[E](2*capacity)
+  private[this] val highPrioItemQueue = new InternalArrayQueue[E](capacity)
 
-  private[this] def dec(i: Int): Int = (if(i == 0) items.length else i) - 1
+  private[this] def counts = (if (paused) 0 else  itemQueue.count) + highPrioItemQueue.count
 
-  private[this] def itemAt(i: Int): E = items(i).asInstanceOf[E]
+  /**
+    * The number of low/medium priority items in use
+    */
+  private[this] var inUseCount = 0
 
-  private[this] def insert(x: E) {
-    items(putIndex) = x
-    putIndex = inc(putIndex)
-    count += 1
-    notEmpty.signal
-  }
+  private[this] var paused = false
 
-  private[this] def extract: E = {
-    val items = this.items
-    val x: E = items(takeIndex).asInstanceOf[E]
-    items(takeIndex) = null
-    takeIndex = inc(takeIndex)
-    count -= 1
-    notFull.signal
-    return x
-  }
-
-  private[this] def removeAt(_i: Int) {
-    var i = _i
-    val items = this.items
-    if (i == takeIndex) {
-      items(takeIndex) = null
-      takeIndex = inc(takeIndex)
-    }
-    else {
-      var cond = true
-      while (cond) {
-        val nexti: Int = inc(i)
-        if (nexti != putIndex) {
-          items(i) = items(nexti)
-          i = nexti
-        }
-        else {
-          items(i) = null
-          putIndex = i
-          cond = false
+  private[util] def increaseInUseCount(pr: PrioritizedRunnable): Unit = {
+    if (!pr.inUseCounterSet) {
+      locked {
+        require(inUseCount < maximumInUse, "count cannot be increased")
+        inUseCount += 1
+        pr.inUseCounterSet = true
+        if (inUseCount == maximumInUse) {
+          logger.debug("pausing")
+          paused = true
         }
       }
     }
-    count -= 1
-    notFull.signal
+  }
+
+  private[util] def decreaseInUseCount(): Unit = {
+    locked {
+      require(inUseCount > 0, "count cannot be decreased")
+      inUseCount -= 1
+      if (inUseCount == maximumInUse - 1) {
+        logger.debug("resuming")
+        paused = false
+        if (counts > 0) notEmpty.signalAll()
+      }
+    }
   }
 
   def offer(e: E): Boolean = {
     checkNotNull(e)
-    locked {
-      if (count == items.length || !accept(e, count)) false
-      else { insert(e); true }
-    }
+    checkNotInUse(e)
+    locked { insert(e) }
   }
 
-  def put(e: E) {
+  private[this] def insert(e: E): Boolean = {
+    val r = e.priority match {
+      case WithConnection => highPrioItemQueue.insert(e)
+      case Continuation => itemQueue.insert(e)
+      case Fresh => if (itemQueue.count < capacity) itemQueue.insert(e) else false
+    }
+    if (counts > 0) notEmpty.signal()
+    r
+  }
+
+  def put(e: E): Unit = {
     checkNotNull(e)
+    checkNotInUse(e)
     lockedInterruptibly {
-      while (count == items.length || !accept(e, count)) notFull.await
+      while (e.priority == Fresh && itemQueue.count >= capacity) notFull.await()
       insert(e)
     }
   }
 
   def offer(e: E, timeout: Long, unit: TimeUnit): Boolean = {
     checkNotNull(e)
+    checkNotInUse(e)
     var nanos: Long = unit.toNanos(timeout)
     lockedInterruptibly {
-      while (count == items.length || !accept(e, count)) {
+      while (e.priority == Fresh && itemQueue.count >= capacity) {
         if (nanos <= 0) return false
         nanos = notFull.awaitNanos(nanos)
       }
@@ -99,169 +99,126 @@ abstract class ManagedArrayBlockingQueue[E >: Null <: AnyRef](capacity: Int, fai
     }
   }
 
-  def poll: E = locked(if ((count == 0)) null else extract)
+  def poll: E = locked { extract() }
+
+  private[this] def extract(): E = {
+    if (highPrioItemQueue.count != 0) highPrioItemQueue.extract
+    else if (!paused && itemQueue.count != 0) {
+      val item = itemQueue.extract
+      increaseInUseCount(item)
+      item
+    }
+    else null
+  }
 
   def take: E = lockedInterruptibly {
-    while (count == 0) notEmpty.await
-    extract
+    while (counts == 0) notEmpty.await()
+    extract()
   }
 
   def poll(timeout: Long, unit: TimeUnit): E = {
     var nanos: Long = unit.toNanos(timeout)
     lockedInterruptibly {
-      while (count == 0) {
+      while (counts == 0) {
         if (nanos <= 0) return null
         nanos = notEmpty.awaitNanos(nanos)
       }
-      extract
+      extract()
     }
   }
 
-  def peek: E = locked((if(count == 0) null else itemAt(takeIndex)))
+  def peek: E = locked {
+    if (counts == 0) null
+    else {
+      val e = highPrioItemQueue.peek
+      if (e != null) e else itemQueue.peek
+    }
+  }
 
-  def size: Int = locked(count)
+  def size: Int = locked(counts)
 
-  def remainingCapacity: Int = locked(items.length - count)
+  def remainingCapacity: Int = locked(capacity - itemQueue.count - highPrioItemQueue.count)
 
   override def remove(o: AnyRef): Boolean = if (o eq null) false else {
-    val items = this.items
     locked {
-      var i: Int = takeIndex
-      var k: Int = count
-      while (k > 0) {
-        if (o == items(i)) {
-          removeAt(i)
-          return true
-        }
-        i = inc(i)
-        k -= 1
+      if (highPrioItemQueue.remove(o)) {
+        true
+      } else {
+        itemQueue.remove(o)
       }
-      false
     }
   }
 
   override def contains(o: AnyRef): Boolean = {
-    if (o == null) return false
-    val items = this.items
     locked {
-      var i = takeIndex
-      var k = count
-      while (k > 0) {
-        if (o == items(i)) return true
-        i = inc(i)
-        k -= 1
-      }
-      false
+      itemQueue.contains(o) || highPrioItemQueue.contains(o)
     }
   }
 
-  override def clear {
-    val items = this.items
+  override def clear() {
     locked {
-      var i = takeIndex
-      var k = count
-      while (k > 0) {
-        items(i) = null
-        i = inc(i)
-        k -= 1
-      }
-      count = 0
-      putIndex = 0
-      takeIndex = 0
-      notFull.signalAll
+      itemQueue.clear()
+      highPrioItemQueue.clear()
+      notFull.signalAll()
     }
   }
 
-  def drainTo(c: Collection[_ >: E]): Int = {
-    checkNotNull(c)
-    if (c eq this) throw new IllegalArgumentException
-    val items = this.items
+  def drainTo(c: util.Collection[_ >: E]): Int = {
     locked {
-      var i = takeIndex
-      var n = 0
-      val max = count
-      while (n < max) {
-        c.add(items(i).asInstanceOf[E])
-        items(i) = null
-        i = inc(i)
-        n += 1
-      }
+      val n = highPrioItemQueue.drainTo(c) + itemQueue.drainTo(c)
       if (n > 0) {
-        count = 0
-        putIndex = 0
-        takeIndex = 0
-        notFull.signalAll
+        notFull.signalAll()
       }
       n
     }
   }
 
-  def drainTo(c: Collection[_ >: E], maxElements: Int): Int = {
-    checkNotNull(c)
-    if (c eq this) throw new IllegalArgumentException
-    if (maxElements <= 0) return 0
-    val items = this.items
+  def drainTo(c: util.Collection[_ >: E], maxElements: Int): Int = {
     locked {
-      var i: Int = takeIndex
-      var n: Int = 0
-      val max: Int = if ((maxElements < count)) maxElements else count
-      while (n < max) {
-        c.add(items(i).asInstanceOf[E])
-        items(i) = null
-        i = inc(i)
-        n += 1
+      var n = highPrioItemQueue.drainTo(c, maxElements)
+      if (n < maxElements) {
+        n += itemQueue.drainTo(c, maxElements - n)
       }
       if (n > 0) {
-        count -= n
-        takeIndex = i
-        notFull.signalAll
+        notFull.signalAll()
       }
       n
     }
   }
 
-  def iterator: Iterator[E] = new Iterator[E] {
-    private var remaining: Int = _
-    private var nextIndex: Int = _
-    private var nextItem: E = _
-    private var lastItem: E = _
-    private var lastRet: Int = -1
+  def iterator: util.Iterator[E] = new util.Iterator[E] {
 
-    locked {
-      remaining = count
-      if(remaining > 0) {
-        nextIndex = takeIndex
-        nextItem = itemAt(nextIndex)
+    private var current = 0
+    private val iterators = Array(highPrioItemQueue.iterator, itemQueue.iterator)
+
+    override def hasNext: Boolean = {
+      locked {
+        while (current < iterators.length && !iterators(current).hasNext)
+          current = current + 1
+
+        current < iterators.length
       }
     }
-
-    def hasNext: Boolean = remaining > 0
 
     def next: E = {
       locked {
-        if (remaining <= 0) throw new NoSuchElementException
-        lastRet = nextIndex
-        var x: E = itemAt(nextIndex)
-        if (x == null) {
-          x = nextItem
-          lastItem = null
-        }
-        else lastItem = x
-        while ({ remaining -= 1; remaining > 0 } && { nextIndex = inc(nextIndex); nextItem = itemAt(nextIndex); nextItem == null }) ()
-        x
+        while (current < iterators.length && !iterators(current).hasNext)
+          current = current + 1
+
+        return iterators(current).next()
       }
     }
 
-    def remove: Unit = throw new UnsupportedOperationException
+    def remove(): Unit = throw new UnsupportedOperationException
   }
 
   @inline private[this] def locked[T](f: => T) = {
-    lock.lock
-    try f finally lock.unlock
+    lock.lock()
+    try f finally lock.unlock()
   }
 
   @inline private[this] def lockedInterruptibly[T](f: => T) = {
-    lock.lockInterruptibly
-    try f finally lock.unlock
+    lock.lockInterruptibly()
+    try f finally lock.unlock()
   }
 }


### PR DESCRIPTION
This should fix issue https://github.com/slick/slick/issues/1274

Solution is as described in https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/scalaquery/5MCUnwaJ7U0/-wTi7lVoBQAJ

Introduction of priority levels:
- HighPriority => a DBIO which already has a connection associated (due to running in a transaction or with pinned session)
- MediumPriority => the old highPrio = true case: a continuation of another DBIO action, it should always be able to be enqueued
- LowPriority => any other DBIO, if the queue is full it will not be enqueued

The queue backing Slick's ThreadPoolExecutor now consists internally of two backing queues:
- A HighPriority queue which contains only the HighPriority runnables
- The old queue containing the other priority levels.

HighPriority items are always taken first, until this queue is exhausted and only then Low- or MediumPriority items are considered.

We also do connection counting in the HikariCPJdbcDataSource:
- When there are no more connections in the pool, we prevent low/medium priority items from being processed from the queue. Only HighPriority items are able to make progress, because they already have a connection.

Added a SlickDeadlock test: while this was failing with previous versions, it now is able to run successfully.

**I'm explicitly soliciting feedback, because this is a possibly high impact change**