### PR TITLE
Update sqlite-jdbc to latest version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,7 +37,7 @@ object SlickBuild extends Build {
     val h2 = "com.h2database" % "h2" % "1.4.191"
     val testDBs = Seq(
       h2,
-      "org.xerial" % "sqlite-jdbc" % "3.8.7",
+      "org.xerial" % "sqlite-jdbc" % "3.8.11.2",
       "org.apache.derby" % "derby" % "10.9.1.0",
       "org.hsqldb" % "hsqldb" % "2.2.8",
       "postgresql" % "postgresql" % "9.1-901.jdbc4",


### PR DESCRIPTION
sqlite-jdbc version 3.8.5 codegen tests fail upgrading to latest version of sqlite-jdbc fixes this problem

Under sqllite-jdbc3.8.5
`trevor@base2theory:~/slick$ activator test codegen
[info] Loading project definition from /home/trevor/slick/project/project
[info] Loading project definition from /home/trevor/slick/project
[info] Set current project to root (in build file:/home/trevor/slick/)
[info] Compiling 1 Scala source to /home/trevor/slick/slick-testkit/target/scala-2.11/codegen-classes...
[info] Running slick.test.codegen.GenerateMainSources /home/trevor/slick/slick-testkit/target/scala-2.11/src_managed/test/slick-codegen
[error] (AsyncExecutor.default-2) java.lang.UnsatisfiedLinkError: org.sqlite.core.NativeDB._open(Ljava/lang/String;I)V
`

Upgraded to sqlite-jdbc-3.8.11.2



`[info] Loading project definition from /home/trevor/slick/project/project
[info] Loading project definition from /home/trevor/slick/project
[info] Compiling 1 Scala source to /home/trevor/slick/project/target/scala-2.10/sbt-0.13/classes...
[info] Set current project to root (in build file:/home/trevor/slick/)
[info] Updating {file:/home/trevor/slick/}testkit...
[info] Resolving jline#jline;2.12.1 ...
[info] downloading https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.8.11.2/sqlite-jdbc-3.8.11.2.jar ...
[info] 	[SUCCESSFUL ] org.xerial#sqlite-jdbc;3.8.11.2!sqlite-jdbc.jar (28390ms)
[info] Done updating.
[info] Compiling 1 Scala source to /home/trevor/slick/slick-testkit/target/scala-2.11/test-classes...
[info] Test run started
[info] Test slick.test.jdbc.PositionedResultTest.testMaxRows started
[info] Test run finished: 0 failed, 0 ignored, 1 total, 0.08s
[info] Test run started
[info] Test com.typesafe.slick.testkit.tests.ActionTest.testSimpleActionAsFuture[h2mem] started
.......
`


Not really sure of the cause seems even version 3.8.11.2 [https://github.com/xerial/sqlite-jdbc/issues/97](url)