### PR TITLE
Add quoting of table names and fk in ALTER TABLE for MySQL

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/MySQLDDLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/MySQLDDLTest.scala
@@ -1,0 +1,37 @@
+package slick.test.lifted
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Test case for the MySQL SQL DDL overrides */
+class MysqlDDLTest {
+  import slick.jdbc.MySQLProfile.api._
+
+  @Test def testTablenameEscaped {
+    class T(tag: Tag) extends Table[Int](tag, "mytable") {
+      def id = column[Int]("id", O.PrimaryKey)
+
+      def * = id
+    }
+    val ts = TableQuery[T]
+
+    class T2(tag: Tag) extends Table[Int](tag, "mytable2") {
+      def id = column[Int]("id", O.PrimaryKey)
+
+      def testFk = column[Int]("test_fk")
+      def fk = foreignKey("t_test_fk", testFk, ts)(_.id)
+
+      def * = id
+    }
+    val ts2 = TableQuery[T2]
+
+    val s1 = ts2.schema.createStatements.toList
+    assertTrue("DDL (create) must contain any SQL statements", s1.nonEmpty)
+    s1.foreach(s => assertTrue("DDL (create) uses escaped table name: " + s, s contains "`mytable2`"))
+    assertTrue("Fk name must be escaped", s1.exists(_.contains("`t_test_fk`")))
+
+    val s2 = ts2.schema.dropStatements.toList
+    s2.foreach(s => assertTrue("DDL (drop) uses escaped table name: " + s, s contains "`mytable2`"))
+    assertTrue("Fk name must be escaped", s2.exists(_.contains("`t_test_fk`")))
+  }
+}

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -194,10 +194,10 @@ trait MySQLProfile extends JdbcProfile { profile =>
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {
     override protected def dropForeignKey(fk: ForeignKey) = {
-      "ALTER TABLE " + table.tableName + " DROP FOREIGN KEY " + fk.name
+      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP FOREIGN KEY " + quoteIdentifier(fk.name)
     }
     override protected def dropPrimaryKey(pk: PrimaryKey): String = {
-      "ALTER TABLE " + table.tableName + " DROP PRIMARY KEY"
+      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP PRIMARY KEY"
     }
   }
 


### PR DESCRIPTION
Closes #1471: Drop / dropStatements for MySQL are not escaping reserved words (like "order")