### PR TITLE
Backport fix for #1471: Drop / dropStatements for MySQL are not escaping reserved words (like "order")

### DIFF
--- a/slick/src/main/scala/slick/driver/MySQLDriver.scala
+++ b/slick/src/main/scala/slick/driver/MySQLDriver.scala
@@ -191,10 +191,10 @@ trait MySQLDriver extends JdbcDriver { driver =>
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {
     override protected def dropForeignKey(fk: ForeignKey) = {
-      "ALTER TABLE " + table.tableName + " DROP FOREIGN KEY " + fk.name
+      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP FOREIGN KEY " + quoteIdentifier(fk.name)
     }
     override protected def dropPrimaryKey(pk: PrimaryKey): String = {
-      "ALTER TABLE " + table.tableName + " DROP PRIMARY KEY"
+      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP PRIMARY KEY"
     }
   }
 


### PR DESCRIPTION
Closes #1471: Drop / dropStatements for MySQL are not escaping reserved words (like "order")