### PR TITLE
Fix error in the test.

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/SchemaSupportTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/SchemaSupportTest.scala
@@ -30,11 +30,11 @@ class SchemaSupportTest {
     println(s4)
     assertTrue("delete uses schema name", s4 contains """delete from "myschema"."mytable"""")
 
-    val s5 = ts.schema.createStatements
+    val s5 = ts.schema.createStatements.toList
     s5.foreach(println)
     s5.foreach(s => assertTrue("DDL (create) uses schema name", s contains """ "myschema"."mytable""""))
 
-    val s6 = ts.schema.dropStatements
+    val s6 = ts.schema.dropStatements.toList
     s6.foreach(println)
     s6.foreach(s => assertTrue("DDL (drop) uses schema name", s contains """ "myschema"."mytable""""))
   }


### PR DESCRIPTION
"createStatements" returns an Iterator, which results in no elements
left to test after foreach for "println". The checks would always succeed.