### PR TITLE
Regression with joins when sorting

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JoinTest.scala
@@ -322,6 +322,42 @@ class JoinTest extends AsyncTest[RelationalTestDB] {
     )
   }
 
+  def testManyToManyJoinSort = {
+    class A(tag: Tag) extends Table[Int](tag, "a_manytomanyjoin") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def * = id
+      def bs = cs.filter(_.aId === id).flatMap(_.b)
+    }
+    lazy val as = TableQuery[A]
+    class B(tag: Tag) extends Table[Int](tag, "b_manytomanyjoin") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def * = id
+      def as = cs.filter(_.bId === id).flatMap(_.a)
+    }
+    lazy val bs = TableQuery[B]
+    class C(tag: Tag) extends Table[(Int, Int)](tag, "c_manytomanyjoin") {
+      def aId = column[Int]("aId")
+      def bId = column[Int]("bId")
+      def * = (aId, bId)
+      def a = foreignKey("a_fk", aId, as)(_.id)
+      def b = foreignKey("b_fk", bId, bs)(_.id)
+    }
+    lazy val cs = TableQuery[C]
+
+    def q1 = for {
+      a <- as
+      b <- a.bs.sortBy(_.id)
+    } yield (a, b)
+
+    DBIO.seq(
+      (as.schema ++ bs.schema ++ cs.schema).create,
+      as ++= Seq(1),
+      bs ++= Seq(2),
+      cs ++= Seq((1,2)),
+      q1.result.named("q1").map(_.toSet shouldBe Set((1, 2)))
+    )
+  }
+
   def testDiscriminatorCheck = {
     class A(tag: Tag) extends Table[Int](tag, "a_joinfiltering") {
       def id = column[Int]("id")


### PR DESCRIPTION
I found another regression with joins and for comprehensions which is not solved by the solution in #1316. I added some test cases instead of plottering this issue.

Accessing foreign key relation through a many-to-many raises query compilation error as seen in this pull request: #1512 
a has and belongs to many b through c and d belongs to b
a <-> b -> d

Sorting on relation in many-to-many for comprehension raises query compilation error as seen in this pull request
a has and belongs to many b through c
a <-> b
