### PR TITLE
Ignore sqlite indices generated by autoindex feature.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,7 +37,7 @@ object SlickBuild extends Build {
     val h2 = "com.h2database" % "h2" % "1.4.191"
     val testDBs = Seq(
       h2,
-      "org.xerial" % "sqlite-jdbc" % "3.8.7",
+      "org.xerial" % "sqlite-jdbc" % "3.8.11.2",
       "org.apache.derby" % "derby" % "10.9.1.0",
       "org.hsqldb" % "hsqldb" % "2.2.8",
       "postgresql" % "postgresql" % "9.1-901.jdbc4",

--- a/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
@@ -120,6 +120,11 @@ trait SQLiteProfile extends JdbcProfile {
       // in 3.7.15-M1:
       override def columns = super.columns.map(_.stripPrefix("\"").stripSuffix("\""))
     }
+    override def readIndices(t: MTable) = super.readIndices(t).map(
+      _.filterNot(
+        _.exists( _.indexName.exists(_.startsWith("sqlite_autoindex_")) )
+      )
+    )
   }
 
   override def createModelBuilder(tables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext): JdbcModelBuilder =


### PR DESCRIPTION
This started breaking the tests when upgrading from org.xerial:sqlite-jdbc:3.8.7 to 3.8.11.2
But since they are automatically generated by sqlite it sort of makes sense not to put them into slick's
schema, so it doesn't try to create them. One might argue differently. We can change our minds in the
future if we need to.

superseeds #1473 
