### PR TITLE
WIP : fix #1424 - issue with union and limit

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,7 +38,7 @@ object SlickBuild extends Build {
     val testDBs = Seq(
       h2,
       "org.xerial" % "sqlite-jdbc" % "3.8.7",
-      "org.apache.derby" % "derby" % "10.10.1.1",
+      "org.apache.derby" % "derby" % "10.11.1.1",
       "org.hsqldb" % "hsqldb" % "2.2.8",
       "postgresql" % "postgresql" % "9.1-901.jdbc4",
       "mysql" % "mysql-connector-java" % "5.1.38",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,7 +38,7 @@ object SlickBuild extends Build {
     val testDBs = Seq(
       h2,
       "org.xerial" % "sqlite-jdbc" % "3.8.7",
-      "org.apache.derby" % "derby" % "10.9.1.0",
+      "org.apache.derby" % "derby" % "10.10.1.1",
       "org.hsqldb" % "hsqldb" % "2.2.8",
       "postgresql" % "postgresql" % "9.1-901.jdbc4",
       "mysql" % "mysql-connector-java" % "5.1.38",

--- a/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
@@ -169,6 +169,14 @@ trait DerbyProfile extends JdbcProfile {
         } else super.expr(c, skipParens)
       case Library.NextValue(SequenceNode(name)) => b"(next value for `$name)"
       case Library.CurrentValue(_*) => throw new SlickException("Derby does not support CURRVAL")
+      case Union(left, right, all) =>
+        b"\{"
+        buildFrom(left, None, true)
+        if(all) b"\nunion all " else b"\nunion "
+        b"\["
+        buildFrom(right, None, true)
+        b"\]"
+        b"\}"
       case _ => super.expr(c, skipParens)
     }
   }

--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -425,9 +425,13 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
         b"\}"
       case Union(left, right, all) =>
         b"\{"
+        b"\["
         buildFrom(left, None, true)
+        b"\]"
         if(all) b"\nunion all " else b"\nunion "
+        b"\["
         buildFrom(right, None, true)
+        b"\]"
         b"\}"
       case SimpleLiteral(w) => b += w
       case s: SimpleExpression => s.toSQL(this)

--- a/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
@@ -177,6 +177,17 @@ trait SQLiteProfile extends JdbcProfile {
       case RowNumber(_) => throw new SlickException("SQLite does not support row numbers")
       // https://github.com/jOOQ/jOOQ/issues/1595
       case Library.Repeat(n, times) => b"replace(substr(quote(zeroblob(($times + 1) / 2)), 3, $times), '0', $n)"
+      case Union(left, right, all) =>
+        b"\{ select * from "
+        b"\["
+        buildFrom(left, None, true)
+        b"\]"
+        if(all) b"\nunion all " else b"\nunion "
+        b"select * from "
+        b"\["
+        buildFrom(right, None, true)
+        b"\]"
+        b"\}"
       case _ => super.expr(c, skipParens)
     }
   }


### PR DESCRIPTION
union with limit was not properly supported by at least 
- postgres
- derby 
- sqlite
- Hsqldb
- H2

General fix is simply to add parenthesis on both side, special case must be done for derby and sqlite

derby related issue : https://issues.apache.org/jira/browse/DERBY-2374
sqlite related issue : http://stackoverflow.com/questions/10812910/combine-two-statements-with-limits-using-union
