### PR TITLE
Improvements to teskit for simplifying tests using action-based queries

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -115,13 +115,13 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
       create.map(_ shouldBe 0),
       DBIO.fold((for {
         (id, name) <- List((1, "szeiger"), (0, "admin"), (2, "guest"), (3, "foo"))
-      } yield sqlu"insert into USERS values ($id, $name)"), 0)(_ + _).map(_ shouldBe 4),
-      sql"select id from USERS".as[Int].map(_.toSet shouldBe Set(0,1,2,3)), //TODO Support `to` in Plain SQL Actions
-      userForID(2).map(_.head shouldBe User(2,"guest")), //TODO Support `head` and `headOption` in Plain SQL Actions
-      s1.map(_ shouldBe List(1)),
-      s2.map(_ shouldBe List(2)),
-      userForIdAndName(2, "guest").map(_.head shouldBe User(2,"guest")), //TODO Support `head` and `headOption` in Plain SQL Actions
-      userForIdAndName(2, "foo").map(_.headOption shouldBe None) //TODO Support `head` and `headOption` in Plain SQL Actions
+      } yield sqlu"insert into USERS values ($id, $name)"), 0)(_ + _) shouldYield(4),
+      sql"select id from USERS".as[Int] shouldYield Set(0,1,2,3), //TODO Support `to` in Plain SQL Actions
+      userForID(2).head shouldYield User(2,"guest"), //TODO Support `head` and `headOption` in Plain SQL Actions
+      s1 shouldYield List(1),
+      s2 shouldYield List(2),
+      userForIdAndName(2, "guest").head shouldYield User(2,"guest"), //TODO Support `head` and `headOption` in Plain SQL Actions
+      userForIdAndName(2, "foo").headOption shouldYield None //TODO Support `head` and `headOption` in Plain SQL Actions
     )
   }
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -366,4 +366,14 @@ abstract class AsyncTest[TDB >: Null <: TestDB](implicit TdbClass: ClassTag[TDB]
       if(!f.isDefinedAt(x)) fixStack(Assert.fail("Value does not match expected shape: "+x))
     }
   }
+
+  implicit class DBIOActionExtensionMethods[T, +S <: NoStream, -E <: Effect](action: DBIOAction[T, S, E]) {
+    @inline def shouldYield(t: T) = action.map(_.shouldBe(t))
+  }
+
+  implicit class CollectionDBIOActionExtensionMethods[T, +S <: NoStream, -E <: Effect](action: DBIOAction[Vector[T], S, E]) {
+    @inline def shouldYield(t: Set[T]) = action.map(_.toSet.shouldBe(t))
+    @inline def shouldYield(t: Seq[T]) = action.map(_.toSeq.shouldBe(t))
+    @inline def shouldYield(t: List[T]) = action.map(_.toList.shouldBe(t))
+  }
 }


### PR DESCRIPTION
Added `shouldYield` operator so that we can now have
`query shouldYield aValue` instead of `query.map(_ shouldBe aValue)`
`query shouldYield Set(...)` instead of `query.map(_.toSet shouldBe Set(...))`
Similarly for `Seq` and  `List`