### PR TITLE
Improvements to Plain-Sql API

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -124,4 +124,17 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
       userForIdAndName(2, "foo").headOption shouldYield None //TODO Support `head` and `headOption` in Plain SQL Actions
     )
   }
+
+  def testComposableQueries = ifCap(tcap.plainSql) {
+    val create: DBIO[Int] = sqlu"create table USERS(ID int not null primary key, NAME varchar(255))"
+
+    def findUser(name: Option[String], id: Option[Long]) = {
+      val nameQ = name.map{ n => sql"NAME = $n" }
+      val idQ = id.map{ i => sql"ID = $i"}
+      sql"SELECT * FROM USERS " ++ nameQ ++ idQ
+    }.as[User]
+
+
+    DBIO.successful(())
+  }
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -21,10 +21,10 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
     val s2 = sql"select id from USERS where name = '#${"guest"}'".as[Int]
     val s3 = sql"select id from USERS where name = $foo".as[Int]
     val s4 = sql"select id from USERS where name = '#$foo'".as[Int]
-    s1.statements.head shouldBe "select id from USERS where name = ? "
-    s2.statements.head shouldBe "select id from USERS where name = 'guest' "
-    s3.statements.head shouldBe "select id from USERS where name = ? "
-    s4.statements.head shouldBe "select id from USERS where name = 'foo' "
+    s1.statements.head shouldBe "select id from USERS where name = ?"
+    s2.statements.head shouldBe "select id from USERS where name = 'guest'"
+    s3.statements.head shouldBe "select id from USERS where name = ?"
+    s4.statements.head shouldBe "select id from USERS where name = 'foo'"
 
     val create: DBIO[Int] = sqlu"create table USERS(ID int not null primary key, NAME varchar(255))"
 
@@ -76,13 +76,13 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
     val q6 = findUser(id = Some(2), name = Some("foo"))
     val q7 = unsafeSQL(queryString).as[User]
 
-    q1.statements.head shouldBe "SELECT id, name FROM USERS2 "
-    q2.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?) "
-    q3.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?) "
-    q4.statements.head shouldBe "SELECT * FROM USERS2 WHERE ID = ? "
-    q5.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ? "
-    q6.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ? "
-    q7.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE id = 77 "
+    q1.statements.head shouldBe "SELECT id, name FROM USERS2"
+    q2.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?)"
+    q3.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?)"
+    q4.statements.head shouldBe "SELECT * FROM USERS2 WHERE ID = ?"
+    q5.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ?"
+    q6.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ?"
+    q7.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE id = 77"
 
     seq(
       createTable,

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -12,90 +12,7 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
 
   case class User(id:Int, name:String)
 
-  //TODO convert to new API:
-  /*
-  def testSimple = ifCap(tcap.plainSql) {
-    def getUsers(id: Option[Int]) = {
-      val q = Q[User] + "select id, name from USERS "
-      id map { q + "where id =" +? _ } getOrElse q
-    }
-
-    def InsertUser(id: Int, name: String) = Q.u + "insert into USERS values (" +? id + "," +? name + ")"
-
-    val createTable = Q[Int] + "create table USERS(ID int not null primary key, NAME varchar(255))"
-    val populateUsers = List(InsertUser(1, "szeiger"), InsertUser(0, "admin"), InsertUser(2, "guest"), InsertUser(3, "foo"))
-
-    val allIDs = Q[Int] + "select id from USERS"
-    val userForID = Q[Int, User] + "select id, name from USERS where id = ?"
-    val userForIdAndName = Q[(Int, String), User] + "select id, name from USERS where id = ? and name = ?"
-
-    implicitSession.withTransaction {
-      println("Creating user table: "+createTable.first)
-      println("Inserting users:")
-      for(i <- populateUsers) println("  "+i.first)
-    }
-
-    println("All IDs:")
-    for(s <- allIDs.list) println("  "+s)
-    assertEquals(Set(1,0,2,3), allIDs.list.toSet)
-
-    println("All IDs with foreach:")
-    var s1 = Set[Int]()
-    allIDs foreach { s =>
-      println("  "+s)
-      s1 += s
-    }
-    assertEquals(Set(1,0,2,3), s1)
-
-    val res = userForID(2).first
-    println("User for ID 2: "+res)
-    assertEquals(User(2,"guest"), res)
-
-    assertEquals(User(2,"guest"), userForIdAndName(2, "guest").first)
-    assertEquals(None, userForIdAndName(2, "foo").firstOption)
-
-    println("User 2 with foreach:")
-    var s2 = Set[User]()
-    userForID(2) foreach { s =>
-      println("  "+s)
-      s2 += s
-    }
-    assertEquals(Set(User(2,"guest")), s2)
-
-    println("User 2 with foreach:")
-    var s3 = Set[User]()
-    getUsers(Some(2)) foreach { s =>
-      println("  "+s)
-      s3 += s
-    }
-    assertEquals(Set(User(2,"guest")), s3)
-
-    println("All users with foreach:")
-    var s4 = Set[User]()
-    getUsers(None) foreach { s =>
-      println("  "+s)
-      s4 += s
-    }
-    assertEquals(Set(User(1,"szeiger"), User(2,"guest"), User(0,"admin"), User(3,"foo")), s4)
-
-    println("All users with iterator.foreach:")
-    var s5 = Set[User]()
-    for(s <- getUsers(None).iterator) {
-      println("  "+s)
-      s5 += s
-    }
-    assertEquals(Set(User(1,"szeiger"), User(2,"guest"), User(0,"admin"), User(3,"foo")), s5)
-
-    if(tdb.canGetLocalTables) {
-      println("All tables:")
-      for(t <- tdb.getLocalTables) println("  "+t)
-      assertEquals(List("users"), tdb.getLocalTables.map(_.toLowerCase))
-    }
-    assertUnquotedTablesExist("USERS")
-  }
-  */
-
-  def testInterpolation = ifCap(tcap.plainSql) {
+  def testSimpleQueries = ifCap(tcap.plainSql) {
     def userForID(id: Int) = sql"select id, name from USERS where id = $id".as[User]
     def userForIdAndName(id: Int, name: String) = sql"select id, name from USERS where id = $id and name = $name".as[User]
 
@@ -116,25 +33,65 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
       DBIO.fold((for {
         (id, name) <- List((1, "szeiger"), (0, "admin"), (2, "guest"), (3, "foo"))
       } yield sqlu"insert into USERS values ($id, $name)"), 0)(_ + _) shouldYield(4),
-      sql"select id from USERS".as[Int] shouldYield Set(0,1,2,3), //TODO Support `to` in Plain SQL Actions
-      userForID(2).head shouldYield User(2,"guest"), //TODO Support `head` and `headOption` in Plain SQL Actions
+      sql"select id from USERS".as[Int] shouldYield Set(0,1,2,3),
+      userForID(2).head shouldYield User(2,"guest"),
       s1 shouldYield List(1),
       s2 shouldYield List(2),
-      userForIdAndName(2, "guest").head shouldYield User(2,"guest"), //TODO Support `head` and `headOption` in Plain SQL Actions
-      userForIdAndName(2, "foo").headOption shouldYield None //TODO Support `head` and `headOption` in Plain SQL Actions
+      userForIdAndName(2, "guest").head shouldYield User(2,"guest"),
+      userForIdAndName(2, "foo").headOption shouldYield None
     )
   }
 
   def testComposableQueries = ifCap(tcap.plainSql) {
-    val create: DBIO[Int] = sqlu"create table USERS(ID int not null primary key, NAME varchar(255))"
+    val createTable: DBIO[Int] = sqlu"create table USERS2(ID int not null primary key, NAME varchar(255))"
 
-    def findUser(name: Option[String], id: Option[Long]) = {
+    def insertUser(id: Int, name: String) = sql"INSERT INTO USERS2 VALUES ($id, $name)".asUpdate
+
+    val users = Set((1, "szeiger"), (0, "admin"), (2, "guest"), (3, "foo"), (4, "bar"))
+    val insertAll: DBIO[Int] = DBIO.fold(users.map{case(i, s) => insertUser(i, s)}.toSeq, 0)(_ + _)
+
+
+    def getAllIDs = sql"SELECT id FROM USERS2".as[Int]
+
+    def getUsers(name: Option[String] = None) = {
+      val q = sql"SELECT id, name FROM USERS2"
+      (name map {n => q ++ sql"WHERE NAME LIKE ($n)" } getOrElse q).as[(Int, String)]
+    }
+
+    def findUser(name: Option[String] = None, id: Option[Long] = None) = {
       val nameQ = name.map{ n => sql"NAME = $n" }
       val idQ = id.map{ i => sql"ID = $i"}
-      sql"SELECT * FROM USERS " ++ nameQ ++ idQ
-    }.as[User]
+      val query = sql"SELECT * FROM USERS2" ++
+        (nameQ ++ idQ).reduceOption(_ ++ sql"AND" ++ _).map(sql"WHERE" ++ _).getOrElse(sql"")
+      query.as[User].headOption
+    }
 
 
-    DBIO.successful(())
+    val q1 = getUsers()
+    val q2 = getUsers(name = Some("ad%"))
+    val q3 = getUsers(name = Some("%r"))
+    val q4 = findUser(id = Some(2))
+    val q5 = findUser(id = Some(3), name = Some("foo"))
+    val q6 = findUser(id = Some(2), name = Some("foo"))
+
+    q1.statements.head shouldBe "SELECT id, name FROM USERS2"
+    q2.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?)"
+    q3.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?)"
+    q4.statements.head shouldBe "SELECT * FROM USERS2 WHERE ID = ?"
+    q5.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ?"
+    q6.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ?"
+
+
+    seq(
+      createTable,
+      insertAll shouldYield 5,
+      getAllIDs shouldYield Set(1, 0, 2, 3, 4),
+      q1 shouldYield users,
+      q2 shouldYield Set((0, "admin")),
+      q3 shouldYield Set((1, "szeiger"), (4, "bar")),
+      q4 shouldYield Some(User(2, "guest")),
+      q5 shouldYield Some(User(3, "foo")),
+      q6 shouldYield None
+    )
   }
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -21,10 +21,10 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
     val s2 = sql"select id from USERS where name = '#${"guest"}'".as[Int]
     val s3 = sql"select id from USERS where name = $foo".as[Int]
     val s4 = sql"select id from USERS where name = '#$foo'".as[Int]
-    s1.statements.head shouldBe "select id from USERS where name = ?"
-    s2.statements.head shouldBe "select id from USERS where name = 'guest'"
-    s3.statements.head shouldBe "select id from USERS where name = ?"
-    s4.statements.head shouldBe "select id from USERS where name = 'foo'"
+    s1.statements.head shouldBe "select id from USERS where name = ? "
+    s2.statements.head shouldBe "select id from USERS where name = 'guest' "
+    s3.statements.head shouldBe "select id from USERS where name = ? "
+    s4.statements.head shouldBe "select id from USERS where name = 'foo' "
 
     val create: DBIO[Int] = sqlu"create table USERS(ID int not null primary key, NAME varchar(255))"
 
@@ -66,6 +66,7 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
       query.as[User].headOption
     }
 
+    val queryString = "SELECT id, name FROM USERS2 WHERE id = 77"
 
     val q1 = getUsers()
     val q2 = getUsers(name = Some("ad%"))
@@ -73,14 +74,15 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
     val q4 = findUser(id = Some(2))
     val q5 = findUser(id = Some(3), name = Some("foo"))
     val q6 = findUser(id = Some(2), name = Some("foo"))
+    val q7 = unsafeSQL(queryString).as[User]
 
-    q1.statements.head shouldBe "SELECT id, name FROM USERS2"
-    q2.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?)"
-    q3.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?)"
-    q4.statements.head shouldBe "SELECT * FROM USERS2 WHERE ID = ?"
-    q5.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ?"
-    q6.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ?"
-
+    q1.statements.head shouldBe "SELECT id, name FROM USERS2 "
+    q2.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?) "
+    q3.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE NAME LIKE (?) "
+    q4.statements.head shouldBe "SELECT * FROM USERS2 WHERE ID = ? "
+    q5.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ? "
+    q6.statements.head shouldBe "SELECT * FROM USERS2 WHERE NAME = ? AND ID = ? "
+    q7.statements.head shouldBe "SELECT id, name FROM USERS2 WHERE id = 77 "
 
     seq(
       createTable,
@@ -91,7 +93,8 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
       q3 shouldYield Set((1, "szeiger"), (4, "bar")),
       q4 shouldYield Some(User(2, "guest")),
       q5 shouldYield Some(User(3, "foo")),
-      q6 shouldYield None
+      q6 shouldYield None,
+      q7 shouldYield Set.empty[User]
     )
   }
 }

--- a/slick-testkit/src/test/scala/slick/test/jdbc/TypedStaticQueryTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/TypedStaticQueryTest.scala
@@ -22,8 +22,8 @@ class TypedStaticQueryTest {
       val id2 = 1
       val s1 = tsql"select * from SUPPLIERS where SUP_ID = ${id1}"
       val s2 = tsql"select * from COFFEES where SUP_ID = ${id2}"
-      assertEquals("select * from SUPPLIERS where SUP_ID = ? ", s1.statements.head)
-      assertEquals("select * from COFFEES where SUP_ID = ? ", s2.statements.head)
+      assertEquals("select * from SUPPLIERS where SUP_ID = ?", s1.statements.head)
+      assertEquals("select * from COFFEES where SUP_ID = ?", s2.statements.head)
 
       val (total1, sales1) = (5, 4)
       val s3 = tsql"select COF_NAME from COFFEES where SALES = ${sales1} and TOTAL = ${total1}"

--- a/slick-testkit/src/test/scala/slick/test/jdbc/TypedStaticQueryTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/TypedStaticQueryTest.scala
@@ -22,8 +22,8 @@ class TypedStaticQueryTest {
       val id2 = 1
       val s1 = tsql"select * from SUPPLIERS where SUP_ID = ${id1}"
       val s2 = tsql"select * from COFFEES where SUP_ID = ${id2}"
-      assertEquals("select * from SUPPLIERS where SUP_ID = ?", s1.statements.head)
-      assertEquals("select * from COFFEES where SUP_ID = ?", s2.statements.head)
+      assertEquals("select * from SUPPLIERS where SUP_ID = ? ", s1.statements.head)
+      assertEquals("select * from COFFEES where SUP_ID = ? ", s2.statements.head)
 
       val (total1, sales1) = (5, 4)
       val s3 = tsql"select COF_NAME from COFFEES where SALES = ${sales1} and TOTAL = ${total1}"

--- a/slick/src/main/scala/slick/jdbc/JdbcProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcProfile.scala
@@ -63,7 +63,7 @@ trait JdbcProfile extends SqlProfile with JdbcActionComponent
 
     implicit def actionBasedSQLInterpolation(s: StringContext): ActionBasedSQLInterpolation = new ActionBasedSQLInterpolation(s)
 
-    def unsafeSQL(sql: String): SQLActionBuilder = new SQLActionBuilder(Seq(sql + " "), SetParameter.SetUnit)
+    def unsafeSQL(sql: String): SQLActionBuilder = new SQLActionBuilder(Seq(sql), SetParameter.SetUnit)
   }
 
   val api: API = new API {}

--- a/slick/src/main/scala/slick/jdbc/JdbcProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcProfile.scala
@@ -62,6 +62,8 @@ trait JdbcProfile extends SqlProfile with JdbcActionComponent
       new JdbcActionExtensionMethods[E, R, S](a)
 
     implicit def actionBasedSQLInterpolation(s: StringContext): ActionBasedSQLInterpolation = new ActionBasedSQLInterpolation(s)
+
+    def unsafeSQL(sql: String): SQLActionBuilder = new SQLActionBuilder(Seq(sql + " "), SetParameter.SetUnit)
   }
 
   val api: API = new API {}

--- a/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
@@ -32,7 +32,7 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
       val x1 = c.untypecheck(q"String.valueOf(${other.duplicate})")
       Some(c.eval(c.Expr[String](x1)))
     } catch {
-      case _ : Throwable => None
+      case scala.util.control.NonFatal(_) => None
     }
   }
 

--- a/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
@@ -16,9 +16,10 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
   lazy val rawQueryParts: List[String] = {
     //Deconstruct macro application to determine the passed string and the actual parameters
     val Apply(Select(Apply(_, List(Apply(_, strArg))), _), paramList) = c.macroApplication
-    strArg map { str =>
+    val list = strArg map { str =>
       evalString(str).getOrElse(abort("The interpolation contained something other than constants..."))
     }
+    list.init :+ (list.last + " ")
   }
 
   /**
@@ -165,7 +166,7 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
     }
   }
 
-  lazy val queryParts: Tree = q"scala.collection.immutable.Vector(..${interpolationResultParams._1})"
+  lazy val queryParts: Tree = q"_root_.scala.collection.immutable.Vector(..${interpolationResultParams._1})"
 
   def staticQueryString: String = interpolationResultParams._1 match {
     case Literal(Constant(s: String)) :: Nil => s

--- a/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
@@ -16,10 +16,9 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
   lazy val rawQueryParts: List[String] = {
     //Deconstruct macro application to determine the passed string and the actual parameters
     val Apply(Select(Apply(_, List(Apply(_, strArg))), _), paramList) = c.macroApplication
-    val list = strArg map { str =>
+    strArg map { str =>
       evalString(str).getOrElse(abort("The interpolation contained something other than constants..."))
     }
-    list.init :+ (list.last + " ")
   }
 
   /**
@@ -33,6 +32,8 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
       Some(c.eval(c.Expr[String](x1)))
     } catch {
       case scala.util.control.NonFatal(_) => None
+      // This is a workaround for a bug in c.eval in 2.12.0-M5. Should be removed as soon as it is rectified!
+      case _: StackOverflowError => None
     }
   }
 

--- a/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/MacroTreeBuilder.scala
@@ -72,9 +72,9 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
     })
 
     resultTypes.size match {
-      case 0 => q"scala.Predef.implicitly[slick.jdbc.GetResult[Int]]"
-      case 1 => q"scala.Predef.implicitly[slick.jdbc.GetResult[${resultTypeTrees(0)}]]"
-      case n if (n <= 22) => q"scala.Predef.implicitly[slick.jdbc.GetResult[(..$resultTypeTrees)]]"
+      case 0 => q"_root_.scala.Predef.implicitly[_root_.slick.jdbc.GetResult[Int]]"
+      case 1 => q"_root_.scala.Predef.implicitly[_root_.slick.jdbc.GetResult[${resultTypeTrees(0)}]]"
+      case n if (n <= 22) => q"_root_.scala.Predef.implicitly[_root_.slick.jdbc.GetResult[(..$resultTypeTrees)]]"
       case n =>
         val rtypeTree = {
           val zero = TypeTree(typeOf[slick.collection.heterogeneous.syntax.HNil])
@@ -97,7 +97,7 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
               Block(
                 zipped.map { case (i: Int, typ: Tree) =>
                   val termName = TermName("gr" + i)
-                  q"val $termName = scala.Predef.implicitly[slick.jdbc.GetResult[$typ]]"
+                  q"val $termName = _root_.scala.Predef.implicitly[_root_.slick.jdbc.GetResult[$typ]]"
                 }.toList,
                 zipped.foldRight[Tree](zero) { (tup, prev) =>
                   val (i: Int, typ: Tree) = tup
@@ -141,7 +141,7 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
     }
 
     if(rawQueryParts.length == 1)
-      (List(Literal(Constant(rawQueryParts.head))), q"slick.jdbc.SetParameter.SetUnit")
+      (List(Literal(Constant(rawQueryParts.head))), q"_root_.slick.jdbc.SetParameter.SetUnit")
     else {
       val queryString = new ListBuffer[Tree]
       val remaining = new ListBuffer[c.Expr[SetParameter[Unit]]]
@@ -153,14 +153,14 @@ private[jdbc] class MacroTreeBuilder[C <: Context](val c: C)(paramsList: List[C#
           queryString.append(Literal(Constant("?")))
           val tpe = TypeTree(param.actualType)
           remaining += c.Expr[SetParameter[Unit]] {
-            q"scala.Predef.implicitly[slick.jdbc.SetParameter[$tpe]].applied($param)"
+            q"_root_.scala.Predef.implicitly[_root_.slick.jdbc.SetParameter[$tpe]].applied($param)"
           }
         }
       }
       queryString.append(Literal(Constant(rawQueryParts.last)))
       val pconv =
-        if(remaining.isEmpty) q"slick.jdbc.SetParameter.SetUnit"
-        else q"slick.jdbc.SetParameter.compose(..$remaining)"
+        if(remaining.isEmpty) q"_root_.slick.jdbc.SetParameter.SetUnit"
+        else q"_root_.slick.jdbc.SetParameter.compose(..$remaining)"
       (fuse(queryString.result()), pconv)
     }
   }

--- a/slick/src/main/scala/slick/jdbc/SetParameter.fm
+++ b/slick/src/main/scala/slick/jdbc/SetParameter.fm
@@ -72,4 +72,8 @@ object SetParameter {
   def apply[T](implicit f: (T, PositionedParameters) => Unit) = new SetParameter[T] {
     def apply(v: T, pp: PositionedParameters) = f(v, pp)
   }
+
+  def compose[T](sps: SetParameter[T]*): SetParameter[T] = SetParameter { (t, pp) =>
+    sps.foreach(_.apply(t, pp))
+  }
 }

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -89,8 +89,10 @@ object ActionBasedSQLInterpolation {
 
 case class SQLActionBuilder(queryParts: Seq[Any], unitPConv: SetParameter[Unit]) {
 
-  def ++(that: SQLActionBuilder): SQLActionBuilder =
-    SQLActionBuilder(this.queryParts ++ that.queryParts, SetParameter.compose(this.unitPConv, that.unitPConv))
+  def ++(that: SQLActionBuilder): SQLActionBuilder = {
+    val that2 = if (that.queryParts.headOption.exists(_.toString.startsWith(" "))) that else that.copy(queryParts = " " +: that.queryParts)
+    SQLActionBuilder(this.queryParts ++ that2.queryParts, SetParameter.compose(this.unitPConv, that2.unitPConv))
+  }
 
   def as[R](implicit rconv: GetResult[R]): SqlStreamingAction[Vector[R], R, Effect] = {
     val query =

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -94,8 +94,8 @@ case class SQLActionBuilder(queryParts: Seq[Any], unitPConv: SetParameter[Unit])
 
   def as[R](implicit rconv: GetResult[R]): SqlStreamingAction[Vector[R], R, Effect] = {
     val query =
-      if(queryParts.length == 1 && queryParts(0).isInstanceOf[String]) queryParts(0).asInstanceOf[String].trim
-      else queryParts.iterator.map(String.valueOf).mkString.trim
+      if(queryParts.length == 1 && queryParts(0).isInstanceOf[String]) queryParts(0).asInstanceOf[String]
+      else queryParts.iterator.map(String.valueOf).mkString
     new StreamingInvokerAction[Vector[R], R, Effect] {
       def statements = List(query)
       protected[this] def createInvoker(statements: Iterable[String]) = new StatementInvoker[R] {


### PR DESCRIPTION
**Composable queries #1161**

We need to devise a new API as an extension of existing "PlainSQL Interpolation API"
The proposal is to add a `++` operator to the SQLActionBuilder so that queries can be composed like

``` scala
val q = sql" ... " ++ sql" ... "
```

The `++` operator also supports optional queries. For eg

``` scala
val id: Option[String] = ...
val optQ = id.map { i => sql" WHERE ID = $i" }
val q = sql"SELECT * FROM table" ++ optQ
```

The final result can be evaluated using the `as`, `asUpdate` or `typecheck` method

``` scala
val ac1 = q.as[T]     //same as sql
val ac2 = q.asUpdate  //same as sqlu
val ac3 = q.typecheck //same as tsql
```

Existing interpolators resolve to one of the above functions in the background.

**Open Questions**
1. Should we delay the macro evaluation until `as`, `asUpdate` or `typecheck` is called?
2. How can we better support multiple optional constructs? like multiple optional checks in `WHERE` clause. Do we want to support this?
3. Other suggestions/requirements for this API improvement?

**Other Improvements**
1. Improvements in `MacroTreeBuilder.scala` and `StaticQuery.scala`: elaborate use of quasiquotes and macro bundles can be brought in.
2. Let the macro evaluate Strings instead of demanding String literals when trying to construct a query statement

This is still a WIP(and hence the PlainSQLTests are only indicative and not complete). This PR has been opened to encourage discussion.

Edit: `typecheck` is not being implemented in this PR. Check [this comment](https://github.com/slick/slick/pull/1548#issuecomment-232558031) for details.
