### PR TITLE
Adding overloaded sequence method for Option - #1192

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -122,8 +122,8 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
     val aSetup = ts.schema.create
 
     val a1 = LiteralColumn(Option(1)).result
-    val a2 = DBIO.sequence(Option(LiteralColumn(1).result))
-    val a3 = DBIO.sequence(Option.empty[DBIO[Int]])
+    val a2 = DBIO.sequenceOption(Option(LiteralColumn(1).result))
+    val a3 = DBIO.sequenceOption(Option.empty[DBIO[Int]])
 
     for {
       _ <- aSetup

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -1,6 +1,8 @@
 package com.typesafe.slick.testkit.tests
 
-import com.typesafe.slick.testkit.util.{StandardTestDBs, RelationalTestDB, AsyncTest}
+import com.typesafe.slick.testkit.util.{AsyncTest, RelationalTestDB, StandardTestDBs}
+import slick.dbio.DBIOAction
+import slick.dbio.Effect.Read
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
@@ -109,6 +111,30 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
       a5.map(_ shouldBe "a5")
     )
   } else DBIO.successful(())
+
+  def testOptionSequence = {
+    class T(tag: Tag) extends Table[Option[Int]](tag, u"t") {
+      def a = column[Int]("a")
+      def * = a.?
+    }
+    val ts = TableQuery[T]
+
+    val aSetup = ts.schema.create
+
+    val a1 = LiteralColumn(Option(1)).result
+    val a2 = DBIO.sequence(Option(LiteralColumn(1).result))
+    val a3 = DBIO.sequence(Option.empty[DBIO[Int]])
+
+    for {
+      _ <- aSetup
+      b1 <- a1
+      b2 <- a2
+      b3 <- a3
+    } yield {
+      b1 shouldBe b2
+      b2 shouldNotBe b3
+    }
+  }
 
   def testFlatten = {
     class T(tag: Tag) extends Table[Int](tag, u"t") {

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -171,7 +171,7 @@ object DBIOAction {
   }
 
   /** Transform a `Option[ DBIO[R] ]` into a `DBIO[ Option[R] ]`. */
-  def sequence[R, E <: Effect](in: Option[DBIOAction[R, NoStream, E]]): DBIOAction[Option[R], NoStream, E] = {
+  def sequenceOption[R, E <: Effect](in: Option[DBIOAction[R, NoStream, E]]): DBIOAction[Option[R], NoStream, E] = {
     implicit val ec = DBIO.sameThreadExecutionContext
     sequence(in.toList).map(_.headOption)
   }

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -170,6 +170,12 @@ object DBIOAction {
     total.result()
   }
 
+  /** Transform a `Option[ DBIO[R] ]` into a `DBIO[ Option[R] ]`. */
+  def sequence[R, E <: Effect](in: Option[DBIOAction[R, NoStream, E]]): DBIOAction[Option[R], NoStream, E] = {
+    implicit val ec = DBIO.sameThreadExecutionContext
+    sequence(in.toList).map(_.headOption)
+  }
+
   /** Transform a `TraversableOnce[ DBIO[R] ]` into a `DBIO[ TraversableOnce[R] ]`. */
   def sequence[R, M[+_] <: TraversableOnce[_], E <: Effect](in: M[DBIOAction[R, NoStream, E]])(implicit cbf: CanBuildFrom[M[DBIOAction[R, NoStream, E]], R, M[R]]): DBIOAction[M[R], NoStream, E] = {
     implicit val ec = DBIO.sameThreadExecutionContext


### PR DESCRIPTION
An incredibly lazy fix for #1192. Uses overloading for simplicity, but I know some people have strong feelings about that so I'm happy to rename the method.

Typesafe Corporate CLA not yet signed, but should be coming soon.