### PR TITLE
Removed headOption from ReadAheadIterator

### DIFF
--- a/slick/src/main/scala/slick/util/ReadAheadIterator.scala
+++ b/slick/src/main/scala/slick/util/ReadAheadIterator.scala
@@ -43,3 +43,11 @@ trait ReadAheadIterator[+T] extends BufferedIterator[T] {
     } else throw new NoSuchElementException("next on empty iterator");
   }
 }
+
+object ReadAheadIterator {
+
+  /** Feature implemented in Scala library 2.12 this maintains functionality for 2.11 */
+  implicit class headOptionReverseCompatibility[T](readAheadIterator: ReadAheadIterator[T]){
+    def headOption : Option[T] = if (readAheadIterator.hasNext) Some(readAheadIterator.head) else None
+  }
+}

--- a/slick/src/main/scala/slick/util/ReadAheadIterator.scala
+++ b/slick/src/main/scala/slick/util/ReadAheadIterator.scala
@@ -47,7 +47,7 @@ trait ReadAheadIterator[+T] extends BufferedIterator[T] {
 object ReadAheadIterator {
 
   /** Feature implemented in Scala library 2.12 this maintains functionality for 2.11 */
-  implicit class headOptionReverseCompatibility[T](readAheadIterator: ReadAheadIterator[T]){
+  final implicit class headOptionReverseCompatibility[T](val readAheadIterator: ReadAheadIterator[T]) extends AnyVal {
     def headOption : Option[T] = if (readAheadIterator.hasNext) Some(readAheadIterator.head) else None
   }
 }

--- a/slick/src/main/scala/slick/util/ReadAheadIterator.scala
+++ b/slick/src/main/scala/slick/util/ReadAheadIterator.scala
@@ -23,12 +23,6 @@ trait ReadAheadIterator[+T] extends BufferedIterator[T] {
     else throw new NoSuchElementException("head on empty iterator")
   }
 
-  def headOption: Option[T] = {
-    update()
-    if(state == 1) Some(cached)
-    else None
-  }
-
   private[this] def update() {
     if(state == 0) {
       cached = fetchNext()


### PR DESCRIPTION
Implemented headOption in scala 2.12.0-RC1 retains same functionality and current
implementation will not compile on 2.12.0-RC1. Removing retains the same functionality.

Will likely fail any tests until 2.12.0-RC1 can be built against. I'm quite open to having missed some functionality, but hopefully this does the trick so I can plug the holes I made. May need more if other issues arise from the release candidate.

Refs #1572 
