### PR TITLE
add 'override' for scala/scala#5331

### DIFF
--- a/slick/src/main/scala/slick/util/InternalArrayQueue.scala
+++ b/slick/src/main/scala/slick/util/InternalArrayQueue.scala
@@ -173,7 +173,7 @@ private[util] final class InternalArrayQueue[E >: Null <: AnyRef](capacity: Int)
       x
     }
 
-    def remove(): Unit = throw new UnsupportedOperationException
+    override def remove(): Unit = throw new UnsupportedOperationException
   }
 
 }

--- a/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
+++ b/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
@@ -209,7 +209,7 @@ class ManagedArrayBlockingQueue[E >: Null <: PrioritizedRunnable](maximumInUse: 
       }
     }
 
-    def remove(): Unit = throw new UnsupportedOperationException
+    override def remove(): Unit = throw new UnsupportedOperationException
   }
 
   @inline private[this] def locked[T](f: => T) = {


### PR DESCRIPTION
Rebased patch by @adriaanm to restore compatibility with the upcoming Scala 2.12.0-RC1 (see https://github.com/scala/scala-dev/issues/203)