### PR TITLE
Change some type params in Shape.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -289,7 +289,7 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
     case class Pair[A, B](a: A, b: B)
 
     // A Shape that maps Pair to a ProductNode
-    final class PairShape[Level <: ShapeLevel, M <: Pair[_,_], U <: Pair[_,_] : ClassTag, P <: Pair[_,_]](val shapes: Seq[Shape[_, _, _, _]]) extends MappedScalaProductShape[Level, Pair[_,_], M, U, P] {
+    final class PairShape[Level <: ShapeLevel, M <: Pair[_,_], U <: Pair[_,_] : ClassTag, P <: Pair[_,_]](val shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) extends MappedScalaProductShape[Level, Pair[_,_], M, U, P] {
       def buildValue(elems: IndexedSeq[Any]) = Pair(elems(0), elems(1))
       def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new PairShape(shapes)
     }

--- a/slick/src/main/scala/slick/collection/heterogeneous/HList.scala
+++ b/slick/src/main/scala/slick/collection/heterogeneous/HList.scala
@@ -127,7 +127,7 @@ sealed abstract class HList extends Product {
 final object HList {
   import syntax._
 
-  final class HListShape[Level <: ShapeLevel, M <: HList, U <: HList : ClassTag, P <: HList](val shapes: Seq[Shape[_, _, _, _]]) extends MappedScalaProductShape[Level, HList, M, U, P] {
+  final class HListShape[Level <: ShapeLevel, M <: HList, U <: HList : ClassTag, P <: HList](val shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) extends MappedScalaProductShape[Level, HList, M, U, P] {
     def buildValue(elems: IndexedSeq[Any]) = elems.foldRight(HNil: HList)(_ :: _)
     def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new HListShape(shapes)
   }

--- a/slick/src/sphinx/code/LiftedEmbedding.scala
+++ b/slick/src/sphinx/code/LiftedEmbedding.scala
@@ -524,7 +524,7 @@ object LiftedEmbedding extends App {
 
       // A Shape implementation for Pair
       final class PairShape[Level <: ShapeLevel, M <: Pair[_,_], U <: Pair[_,_] : ClassTag, P <: Pair[_,_]](
-        val shapes: Seq[Shape[_, _, _, _]])
+        val shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]])
       extends MappedScalaProductShape[Level, Pair[_,_], M, U, P] {
         def buildValue(elems: IndexedSeq[Any]) = Pair(elems(0), elems(1))
         def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new PairShape(shapes)


### PR DESCRIPTION
Now I am writing a method to count the columns in the slick I use to use asInstanceOf. This fix hope for remove asInstanceOf in the code.

``` scala
@tailrec
def countColumns(columns: Seq[RepShape.type], shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]): Seq[RepShape.type] = {
  if (shapes.isEmpty) {
    columns
  } else {
    val repShapes = shapes.filter(s => s == RepShape).map(_ => RepShape)
    val hShapes = shapes.collect { case s: ProductNodeShape[ShapeLevel @unchecked, _, _, _, _] =>
      s.shapes.asInstanceOf[Seq[Shape[ShapeLevel, _, _, _]]]
    }.flatten
    countColumns(repShapes ++: columns, hShapes)
  }
}

def shapeLength(shape: Shape[_ <: ShapeLevel, _, _, _]): Int = {
  countColumns(Nil, List(shape)).size
}
```

The code is from a wrapper of slick. I need to be sure the column with autoInc(typesafe but it's type is unknown in compile time) is not empty. If it's empty autual, slick will throw an exception.
The code like:

``` scala
query1 returning query2 += data //if query2 is a tuple with no columns, it will throw an exception.
```
