### PR TITLE
Replace nbsp by proper space in SQL setup script

### DIFF
--- a/slick-testkit/src/codegen/resources/dbs/mysql.sql
+++ b/slick-testkit/src/codegen/resources/dbs/mysql.sql
@@ -1,3 +1,3 @@
 CREATE TABLE `LongTextTest`( entry1 LONGTEXT NOT NULL , entry2 MEDIUMTEXT NOT NULL , entry3 TEXT NOT NULL , entry4 VARCHAR(255) NOT NULL );
 
-CREATE TABLE `table_name`( id INT NOT NULL );
+CREATE TABLE `table_name`( id INT NOT NULL );


### PR DESCRIPTION
See comment on #1528. /cc @trevorsibanda 