### PR TITLE
Unified expansion of table types with same baseIdentity

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
@@ -185,4 +185,22 @@ class UnionTest extends AsyncTest[RelationalTestDB] {
     )
   }
 
+  def testMappedUnion = {
+    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, u"t") {
+      def a = column[String]("a")
+      def b = column[Int]("b")
+      def c = column[String]("c")
+      def d = column[Int]("d")
+      def e = column[String]("e")
+      def * = (a, b, c, d)
+      override def create_* = collectFieldSymbols((*, e).shaped.toNode)
+    }
+    val ts = TableQuery[T]
+    val q1 = ts.filter(_.a === "a") ++ ts.filter(_.e === "e")
+    DBIO.seq(
+      ts.schema.create,
+      ts.map(f => (f.a, f.b, f.c, f.d, f.e)) += (("a", 1, "c", 3, "e")),
+      q1.result.map(_ shouldBe Vector(("a",1,"c",3), ("a",1,"c",3)))
+    )
+  }
 }


### PR DESCRIPTION
In `expandTables` table fields used to be identified based on the
tables’s identity. This breaks when performing a union operation over
raw table rows where the right-hand side references more columns than
the left-hand side.

This situation can be prevented by taking field references of sibling
tables (with a different identity but the same baseIdentity) into
account when computing a tables’s structural type to ensure that the
structural types on both sides are compatible.

Test in UnionTest.testMappedUnion. Fixes #1571.