### PR TITLE
WIP: Add a basic DatabaseSubscriber

### DIFF
--- a/reactive-streams-tests/src/test/scala/slick/test/stream/RelationalSubscriberTest.scala
+++ b/reactive-streams-tests/src/test/scala/slick/test/stream/RelationalSubscriberTest.scala
@@ -1,0 +1,41 @@
+package slick.test.stream
+
+import org.reactivestreams.Subscriber
+import org.reactivestreams.tck._
+import org.scalatest.testng.TestNGSuiteLike
+import org.testng.annotations.{AfterClass, BeforeClass}
+import slick.basic.DatabaseSubscriber
+import slick.relational.RelationalProfile
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+
+abstract class RelationalSubscriberTest[P <: RelationalProfile](val profile: P, timeout: Long) extends SubscriberBlackboxVerification[slick.dbio.DBIO[Int]](new TestEnvironment(timeout)) with TestNGSuiteLike {
+  import profile.api._
+
+  class Data(tableName: String)(tag: Tag) extends Table[Int](tag, tableName) {
+    def id = column[Int]("id")
+    def * = id
+  }
+  lazy val data = TableQuery(new Data("data")(_))
+
+  var db: Database = _
+  def createDB: Database
+
+  @BeforeClass def setUpDB: Unit = {
+    db = createDB
+    Await.result(db.run(data.schema.create), Duration.Inf)
+  }
+
+  @AfterClass def tearDownDB: Unit =
+    db.close()
+
+  override def createSubscriber(): Subscriber[DBIO[Int]] = {
+    implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+    new DatabaseSubscriber[Int,P](db)
+  }
+
+  override def createElement(element: Int): DBIO[Int] = {
+    DBIO.from(Future.successful(element))
+  }
+}

--- a/reactive-streams-tests/src/test/scala/slick/test/stream/SubscriberTest.scala
+++ b/reactive-streams-tests/src/test/scala/slick/test/stream/SubscriberTest.scala
@@ -1,0 +1,18 @@
+package slick.test.stream
+
+import slick.jdbc.{H2Profile, JdbcProfile}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+
+class SubscriberTest extends RelationalSubscriberTest[JdbcProfile](H2Profile, 1000L) {
+  import profile.api._
+
+  def createDB = {
+    val db = Database.forURL("jdbc:h2:mem:SubscriberTest", driver = "org.h2.Driver", keepAliveConnection = true)
+    // Wait until the database has been initialized and can process queries:
+    try { Await.result(db.run(sql"select 1".as[Int]), Duration.Inf) } catch { case NonFatal(ex) => }
+    db
+  }
+}

--- a/slick/src/main/scala/slick/basic/DatabaseSubscriber.scala
+++ b/slick/src/main/scala/slick/basic/DatabaseSubscriber.scala
@@ -1,0 +1,48 @@
+package slick.basic
+
+import java.util.concurrent.atomic.AtomicReference
+
+import org.reactivestreams.{Subscriber, Subscription}
+import slick.dbio.DBIO
+import slick.relational.RelationalProfile
+
+import scala.concurrent.ExecutionContext
+
+/** A Reactive Streams `Subscriber` for database Actions. */
+class DatabaseSubscriber[E, P <: RelationalProfile](db: P#Backend#Database)(implicit ec: ExecutionContext) extends Subscriber[DBIO[E]] {
+  val subscription: AtomicReference[Subscription] = new AtomicReference[Subscription]()
+  val done: AtomicReference[Boolean] = new AtomicReference[Boolean](true)
+
+  override def onError(t: Throwable): Unit = {
+    if (null == t) throw new NullPointerException("throwable is null")
+  }
+
+  override def onSubscribe(s: Subscription): Unit = {
+    if (null == subscription.get()) {
+      subscription.set(s)
+      done.set(false)
+      subscription.get().request(1L)
+    } else {
+      s.cancel()
+    }
+  }
+
+  override def onComplete(): Unit = {
+    // mmhh What to do here?
+  }
+
+  /**
+    * Consumes the element and executes the dbio action with the provided database
+    */
+  override def onNext(e: DBIO[E]): Unit = {
+    if (null == e) {
+      throw new NullPointerException("element is null")
+    } else {
+      if (!done.get()) {
+        db
+          .run(e)
+          .andThen{case _ => subscription.get().request(1L)}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi,

this is a draft for a database subscriber which implements the reactive streams `Subscriber` interface.

Maybe this is a useful addition to slick?! I am not very familiar with the slick codebase or how to implement reactive streams interfaces. But as I somehow want this functionality in my project I thought I try to implement it on my own.

There are still some questions in my head:
- Is it correct to demand 1 more element after the db Future completes?
- Is the subscription thread synchronization correct?
- Is there something meaningful todo after the stream completes?

What do think about this addition?

Best regards,
Matthias