### PR TITLE
Backport fix in master to 3.1.x; bump version to 3.1.2 for a release

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import de.johoop.testngplugin.TestNGPlugin._
 
 object SlickBuild extends Build {
 
-  val slickVersion = "3.1.1"
+  val slickVersion = "3.1.2"
   val slickExtensionsVersion = "3.1.0" // Slick extensions version for links in the manual
   val binaryCompatSlickVersion = "3.1.0" // Slick base version for binary compatibility checks
   val scalaVersions = Seq("2.10.5", "2.11.6")

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -45,6 +45,7 @@ testkit {
     ${testPackage}.TemplateTest
     ${testPackage}.TransactionTest
     ${testPackage}.UnionTest
+    ${testPackage}.ForceInsertQueryTest
   ]
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ForceInsertQueryTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ForceInsertQueryTest.scala
@@ -1,0 +1,45 @@
+package com.typesafe.slick.testkit.tests
+
+import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
+
+class ForceInsertQueryTest extends AsyncTest[JdbcTestDB] {
+
+  import tdb.profile.api._
+
+  case class Person(id: Option[Long] = None,
+                    name: Option[String] = None,
+                    hairColor: Option[String] = None,
+                    eyeColor: Option[String] = None)
+
+  class People(tag: Tag) extends Table[Person](tag, "people") {
+    def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
+
+    def name = column[Option[String]]("name")
+
+    def hairColor = column[Option[String]]("hair_color")
+
+    def eyeColor = column[Option[String]]("eye_color")
+
+    def * = (id.?, name, hairColor, eyeColor) <>(Person.tupled, Person.unapply)
+  }
+
+  object peopleTable extends TableQuery(new People(_)) {
+    def someForcedInsert(person: Person) = {
+      this.map(p => (p.name, p.hairColor, p.eyeColor))
+        .forceInsertQuery {
+          Query((person.name, person.hairColor, person.eyeColor))
+        }
+    }
+  }
+
+  def testForceInsert = {
+    DBIO.seq(
+      peopleTable.schema.create,
+      peopleTable.someForcedInsert(Person(name = Some("John"), hairColor = Some("Brown"), eyeColor = Some("Brown"))),
+      peopleTable.someForcedInsert(Person(name = Some("John"), hairColor = None, eyeColor = None)),
+      peopleTable.someForcedInsert(Person(name = None, hairColor = None, eyeColor = None)),
+      peopleTable.someForcedInsert(Person(name = Some("John"), hairColor = None, eyeColor = Some("Blue"))),
+      peopleTable.schema.drop
+    )
+  }
+}

--- a/slick/src/main/scala/slick/compiler/HoistClientOps.scala
+++ b/slick/src/main/scala/slick/compiler/HoistClientOps.scala
@@ -17,12 +17,12 @@ class HoistClientOps extends Phase {
     from1 match {
       case Bind(s2, from2, Pure(StructNode(defs2), ts2)) =>
         // Extract client-side operations into ResultSetMapping
-        val hoisted = defs2.map { case (ts, n) => (ts, n, unwrap(n, true)) }
+        val hoisted = defs2.map { case (ts, n) => (ts, n, unwrap(n, topLevel = true)) }
         logger.debug("Hoisting operations from defs: " + hoisted.iterator.filter(t => t._2 ne t._3._1).map(_._1).mkString(", "))
-        val newDefsM = hoisted.iterator.map { case (ts, n, (n2, wrap)) => (n2, new AnonSymbol) }.toMap
+        val newDefsM = hoisted.iterator.zipWithIndex.map { case ((ts, n, (n2, wrap)), idx) => (idx, (n2, new AnonSymbol)) }.toMap
         logger.debug("New defs: "+newDefsM)
-        val oldDefsM = hoisted.iterator.map { case (ts, n, (n2, wrap)) => (ts, wrap(Select(Ref(rsm.generator), newDefsM(n2)))) }.toMap
-        val bind2 = rewriteDBSide(Bind(s2, from2, Pure(StructNode(ConstArray.from(newDefsM.map(_.swap))), new AnonTypeSymbol)).infer())
+        val oldDefsM = hoisted.iterator.zipWithIndex.map { case ((ts, n, (n2, wrap)), idx) => (ts, wrap(Select(Ref(rsm.generator), newDefsM(idx)._2))) }.toMap
+        val bind2 = rewriteDBSide(Bind(s2, from2, Pure(StructNode(ConstArray.from(newDefsM.map(_._2.swap))), new AnonTypeSymbol)).infer())
         val rsm2 = rsm.copy(from = bind2, map = rsm.map.replace {
           case Select(Ref(s), f) if s == rsm.generator => oldDefsM(f)
         }).infer()


### PR DESCRIPTION
I'm not sure if this is the appropriate workflow. Should the version bump be in a separate PR?

I've confirmed this fixes our current problems in our codebase.

We'd also benefit from https://github.com/slick/slick/pull/1674 but that hasn't been merged to `master` yet, and we have a local workaround. I'd prefer to get a 3.1.2 out ASAP (and maybe backport that fix to 3.1 and cut a separate 3.1.3) but I'm open to helping however.