### PR TITLE
Fix syntactical typo in Getting Started

### DIFF
--- a/slick/src/sphinx/gettingstarted.rst
+++ b/slick/src/sphinx/gettingstarted.rst
@@ -154,7 +154,7 @@ similar to how you add data to mutable Scala collections.
 
 The ``create``, ``+=`` and ``++=`` methods return a ``DBIOAction`` which can be executed on a database
 at a later time to produce a result. There are several different combinators for combining multiple
-``DBIOAction``s into sequences, yielding another action. Here we use the simplest one, ``DBIO.seq``, which
+``DBIOAction`` values into sequences, yielding another action. Here we use the simplest one, ``DBIO.seq``, which
 can concatenate any number of actions, discarding the return values (i.e. the resulting ``DBIOAction``
 produces a result of type ``Unit``). We then execute the setup action asynchronously with
 ``db.run``, yielding a ``Future[Unit]``.


### PR DESCRIPTION
This fixes a syntax bug in doc of http://slick.lightbend.com/doc/3.2.0/gettingstarted.html (also rendered in GitHub):

<img width="794" alt="screen shot 2017-03-05 at 23 44 46" src="https://cloud.githubusercontent.com/assets/113730/23597200/c2acf390-01fe-11e7-98bd-bb2caf2bb599.png">
