### PR TITLE
Make chained calls to flatmap stack safe

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -102,13 +102,15 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
     val a3 = DBIO.sequence((1 to 20).toSeq.map(i => if((i/4)%2 == 0) LiteralColumn(i).result else DBIO.from(Future.successful(i))))
     val a4 = DBIO.seq((1 to 50000).toSeq.map(i => DBIO.successful("a4")): _*)
     val a5 = (1 to 50000).toSeq.map(i => DBIO.successful("a5")).reduceLeft(_ andThen _)
+    val a6 = DBIO.fold((1 to 50000).toSeq.map(i => LiteralColumn(i).result), 0)(_ + _)
 
     DBIO.seq(
       a1.map(_ shouldBe (1 to 5000).toSeq),
       a2.map(_ shouldBe (1 to 20).toSeq),
       a3.map(_ shouldBe (1 to 20).toSeq),
       a4.map(_ shouldBe (())),
-      a5.map(_ shouldBe "a5")
+      a5.map(_ shouldBe "a5"),
+      a6.map(_ shouldBe (1 to 50000).sum)
     )
   } else DBIO.successful(())
 

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -145,8 +145,14 @@ trait BasicBackend { self =>
         case SuccessAction(v) => Future.successful(v)
         case FailureAction(t) => Future.failed(t)
         case FutureAction(f) => f
-        case FlatMapAction(base, f, ec) =>
-          runInContext(base, ctx, false, topLevel).flatMap(v => runInContext(f(v), ctx, streaming, false))(ctx.getEC(ec))
+        case FlatMapAction(base, fs, ec) =>
+          val last = fs.length - 1
+          def run(pos: Int, v: Any): Future[Any] = {
+            val f1 = runInContext(fs(pos)(v), ctx, streaming && pos == last, pos == 0)
+            if(pos == last) f1
+            else f1.flatMap(run(pos + 1, _))(ctx.getEC(ec))
+          }
+          runInContext(base, ctx, false, topLevel).flatMap(run(0, _))(ctx.getEC(ec)).asInstanceOf[Future[R]]
         case AndThenAction(actions) =>
           val last = actions.length - 1
           def run(pos: Int, v: Any): Future[Any] = {


### PR DESCRIPTION
Fix for #1700

Uses the same code as andThen, but modified for flatMap