### PR TITLE
Add schema feature createIfNotExists and dropIfExists

### DIFF
--- a/doc/code/LiftedEmbedding.scala
+++ b/doc/code/LiftedEmbedding.scala
@@ -159,16 +159,20 @@ object LiftedEmbedding extends App {
   //#ddl
     db.run(DBIO.seq(
       schema.create,
+      schema.createIfNotExists,
       //...
-      schema.drop
+      schema.drop,
+      schema.dropIfExists
     ))
   //#ddl
     , Duration.Inf)
 
   //#ddl2
     schema.create.statements.foreach(println)
+    schema.createIfNotExists.statements.foreach(println)
     schema.truncate.statements.foreach(println)
     schema.drop.statements.foreach(println)
+    schema.dropIfExists.statements.foreach(println)
   //#ddl2
     TableQuery[A].schema.create.statements.foreach(println)
 

--- a/doc/src/schemas.md
+++ b/doc/src/schemas.md
@@ -154,7 +154,7 @@ Data Definition Language {index="DDL;create;drop"}
 DDL statements for a table can be created with its `TableQuery`'s `schema` method. Multiple
 `DDL` objects can be concatenated with `++` to get a compound `DDL` object which can create
 and drop all entities in the correct order, even in the presence of cyclic dependencies between
-tables. The `create`, `drop` and `truncate` methods produce the Actions for executing the DDL statements:
+tables. The `create`, `createIfNotExists`, `dropIfExists`, `drop` and `truncate` methods produce the Actions for executing the DDL statements. To safely create and drop tables use the methods `createIfNotExists` and `dropIfExists` :
 
 ```scala src=../code/LiftedEmbedding.scala#ddl
 ```

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -215,4 +215,109 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
       _ = assert(newRes.toSet == Set())
     } yield ()
   }
+
+  def testCreateIfNotExistsDropIfExists = {
+    import scala.util.{Success, Failure}
+    class T(_tag: Tag) extends Table[Int](_tag , "ddl_test"){
+      def a = column[Int]("a")
+      def * = a
+    }
+
+    class S(_tag: Tag) extends Table[String](_tag, "ddl_test2"){
+      def a = column[String]("a2")
+      def * = a
+    }
+
+    class A(tag: Tag) extends Table[(Int, Int, String)](tag, "a") {
+      def k1 = column[Int]("k1")
+      def k2 = column[Int]("k2")
+      def s = column[String]("s")
+      def * = (k1, k2, s)
+      def pk = primaryKey("pk_a", (k1, k2))
+    }
+
+    val as = TableQuery[A]
+    val ts = TableQuery[T]
+    val ts2 = TableQuery[S]
+    val batch = (ts.schema ++ ts2.schema)
+
+    for{
+      _ <- ts.schema.create
+      _  <- ts2.schema.create
+      _ <- ts.schema.createIfNotExists
+      _ <- ts2.schema.createIfNotExists
+      initial1 <- ts.result
+      _ = assert(initial1.toSet == Set())
+      initial2 <- ts2.result
+      _ = assert(initial2.toSet == Set())
+      res <- (ts ++= Seq(2, 3, 1, 5, 4)) >> ts.result
+      _ = assert(res.toSet == Set(2, 3, 1, 5, 4))
+      res2 <- (ts2 ++= Seq("2", "3", "1", "5", "4")) >> ts2.result
+      _ = assert(res2.toSet == Set("2", "3", "1", "5", "4"))
+      _ <- ts.schema.drop
+      _ <- ts2.schema.drop
+      _ <- ts.schema.dropIfExists
+      _ <- ts2.schema.dropIfExists
+      _ <- ts.schema.createIfNotExists
+      _ <- ts.schema.create.asTry.map{
+        case Failure(e:java.sql.SQLException) => ()
+        case Failure(e: slick.SlickException) if tdb.profile == slick.memory.MemoryProfile => ()
+        case Failure(e) => throw e
+        case Success(_) => throw new Exception("Should have failed to create new table. Table exists")
+      }
+      _ <- ts2.schema.createIfNotExists
+      _ <- ts2.schema.create.asTry.map{
+        case Failure(e:java.sql.SQLException) => ()
+        case Failure(e: slick.SlickException) if tdb.profile == slick.memory.MemoryProfile => ()
+        case Failure(e) => throw e
+        case Success(_) => throw new Exception("Should have failed to create new table. Table exists")
+      }
+      initial3 <- ts.result
+      _ = assert(initial3.toSet == Set())
+      initial4 <- ts2.result
+      _ = assert(initial4.toSet == Set())
+      _ <- ts.schema.dropIfExists
+      _ <- ts.schema.drop.asTry.map{
+        case Failure(e:java.sql.SQLException) => ()
+        case Failure(e: slick.SlickException) if tdb.profile == slick.memory.MemoryProfile => ()
+        case Failure(e) => throw e
+        case Success(_) => throw new Exception("Should have failed to drop table. Table already dropped")
+      }
+      _ <- ts2.schema.dropIfExists
+      _ <- ts2.schema.drop.asTry.map{
+        case Failure(e:java.sql.SQLException) => ()
+        case Failure(e: slick.SlickException) if tdb.profile == slick.memory.MemoryProfile => ()
+        case Failure(e) => throw e
+        case Success(_) => throw new Exception("Should have failed to drop table. Table already dropped")
+      }
+      //test batch create/drop
+      _ <- batch.create
+      _ <- batch.createIfNotExists
+      res <- (ts ++= Seq(2, 3, 1, 5, 4)) >> ts.result
+      _ = assert(res.toSet == Set(2, 3, 1, 5, 4))
+      res2 <- (ts2 ++= Seq("2", "3", "1", "5", "4")) >> ts2.result
+      _ = assert(res2.toSet == Set("2", "3", "1", "5", "4"))
+      _ <- batch.drop
+      _ <- batch.dropIfExists
+      _ <- batch.createIfNotExists
+      _ <- batch.create.asTry.map{
+        case Failure(e:java.sql.SQLException) => ()
+        case Failure(e: slick.SlickException) if tdb.profile == slick.memory.MemoryProfile => ()
+        case Failure(e) => throw e
+        case Success(_) => throw new Exception("Should have failed to create new table. Table exists")
+      }
+      _ <- batch.dropIfExists
+      _ <- batch.drop.asTry.map{
+        case Failure(e:java.sql.SQLException) => ()
+        case Failure(e: slick.SlickException) if tdb.profile == slick.memory.MemoryProfile => ()
+        case Failure(e) => throw e
+        case Success(_) => throw new Exception("Should have failed to drop table. Table already dropped")
+      }
+      //test create/drop with constraints
+      _ <- as.schema.createIfNotExists
+      _ <- as ++= Seq((1, 1, "a11"), (1, 2, "a12"), (2, 1, "a21"), (2, 2, "a22") )
+      _ <- (as += (1, 1, "a11-conflict")).failed
+      _ <- as.schema.drop
+    } yield ()
+  }
 }

--- a/slick-testkit/src/test/scala/slick/test/lifted/SchemaSupportTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/SchemaSupportTest.scala
@@ -37,5 +37,13 @@ class SchemaSupportTest {
     val s6 = ts.schema.dropStatements.toList
     s6.foreach(println)
     s6.foreach(s => assertTrue("DDL (drop) uses schema name", s contains """ "myschema"."mytable""""))
+
+    val s7 = ts.schema.dropIfExistsStatements.toList
+    s7.foreach(println)
+    s7.foreach(s => assertTrue("DDL (dropIfExists) uses schema name", s contains """ "myschema"."mytable""""))
+
+    val s8 = ts.schema.createIfNotExistsStatements.toList
+    s6.foreach(println)
+    s6.foreach(s => assertTrue("DDL (createIfNotExists) uses schema name", s contains """ "myschema"."mytable""""))
   }
 }

--- a/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
@@ -102,6 +102,35 @@ trait DerbyProfile extends JdbcProfile {
   override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] =
     MTable.getTables(None, None, None, Some(Seq("TABLE")))
 
+  override def createSchemaActionExtensionMethods(schema: SchemaDescription): SchemaActionExtensionMethods =
+    new SchemaActionExtensionMethodsImpl(schema){
+      override def createIfNotExists: ProfileAction[Unit, NoStream, Effect.Schema] = new SimpleJdbcProfileAction[Unit]("schema.createIfNotExists", schema.createIfNotExistsStatements.toVector) {
+        def run(ctx: Backend#Context, sql: Vector[String]): Unit = {
+          import java.sql.SQLException
+          for(s <- sql) try{
+            ctx.session.withPreparedStatement(s)(_.execute)
+          }catch{
+            //<value> '<value>' already exists in <value> '<value>'.
+            case e: SQLException if e.getSQLState().equals("X0Y32") =>  ()
+            case e: Throwable => throw e
+          }
+        }
+      }
+
+      override def dropIfExists: ProfileAction[Unit, NoStream, Effect.Schema] = new SimpleJdbcProfileAction[Unit]("schema.dropIfExists", schema.dropIfExistsStatements.toVector) {
+        def run(ctx: Backend#Context, sql: Vector[String]): Unit = {
+          import java.sql.SQLException
+          for(s <- sql) try{
+            ctx.session.withPreparedStatement(s)(_.execute)
+          }catch{
+            //'<value>' cannot be performed on '<value>' because it does not exist.
+            case e: SQLException if e.getSQLState().equals("42Y55") =>  ()
+            case e: Throwable => throw e
+          }
+        }
+      }
+    }
+
   override protected def computeQueryCompiler = super.computeQueryCompiler + Phase.rewriteBooleans + Phase.specializeParameters
   override val columnTypes = new JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
@@ -186,6 +215,10 @@ trait DerbyProfile extends JdbcProfile {
         sb.toString
       } else super.createIndex(idx)
     }
+
+    override def dropIfExistsPhase = dropPhase1 ++ dropPhase2
+
+    override def createIfNotExistsPhase = createPhase1 ++ createPhase2
   }
 
   class ColumnDDLBuilder(column: FieldSymbol) extends super.ColumnDDLBuilder(column) {

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -288,12 +288,22 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
         for(s <- sql) ctx.session.withPreparedStatement(s)(_.execute)
     }
 
+    def createIfNotExists: ProfileAction[Unit, NoStream, Effect.Schema] = new SimpleJdbcProfileAction[Unit]("schema.createIfNotExists", schema.createIfNotExistsStatements.toVector) {
+      def run(ctx: Backend#Context, sql: Vector[String]): Unit =
+        for(s <- sql) ctx.session.withPreparedStatement(s)(_.execute)
+    }
+
     def truncate: ProfileAction[Unit, NoStream, Effect.Schema] = new SimpleJdbcProfileAction[Unit]("schema.truncate" , schema.truncateStatements.toVector ){
       def run(ctx: Backend#Context, sql: Vector[String]): Unit =
         for(s <- sql) ctx.session.withPreparedStatement(s)(_.execute)
     }
 
     def drop: ProfileAction[Unit, NoStream, Effect.Schema] = new SimpleJdbcProfileAction[Unit]("schema.drop", schema.dropStatements.toVector) {
+      def run(ctx: Backend#Context, sql: Vector[String]): Unit =
+        for(s <- sql) ctx.session.withPreparedStatement(s)(_.execute)
+    }
+
+    def dropIfExists: ProfileAction[Unit, NoStream, Effect.Schema] = new SimpleJdbcProfileAction[Unit]("schema.dropIfExists", schema.dropIfExistsStatements.toVector) {
       def run(ctx: Backend#Context, sql: Vector[String]): Unit =
         for(s <- sql) ctx.session.withPreparedStatement(s)(_.execute)
     }

--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -594,17 +594,19 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
       if(primaryKeys.size > 1)
         throw new SlickException("Table "+tableNode.tableName+" defines multiple primary keys ("
           + primaryKeys.map(_.name).mkString(", ") + ")")
-      DDL(createPhase1, createPhase2, dropPhase1, dropPhase2 , truncatePhase)
+      DDL(createPhase1, createIfNotExistsPhase, createPhase2, dropPhase1, dropIfExistsPhase, dropPhase2 , truncatePhase)
     }
 
-    protected def createPhase1 = Iterable(createTable) ++ primaryKeys.map(createPrimaryKey) ++ indexes.map(createIndex)
+    protected def createPhase1 = Iterable(createTable(false)) ++ primaryKeys.map(createPrimaryKey) ++ indexes.map(createIndex)
+    protected def createIfNotExistsPhase = Iterable(createTable(true)) ++ primaryKeys.map(createPrimaryKey) ++ indexes.map(createIndex)
     protected def createPhase2 = foreignKeys.map(createForeignKey)
     protected def dropPhase1 = foreignKeys.map(dropForeignKey)
-    protected def dropPhase2 = primaryKeys.map(dropPrimaryKey) ++ Iterable(dropTable)
+    protected def dropIfExistsPhase = primaryKeys.map(dropPrimaryKey) ++Iterable(dropTable(true))
+    protected def dropPhase2 = primaryKeys.map(dropPrimaryKey) ++ Iterable(dropTable(false))
     protected def truncatePhase = Iterable(truncateTable)
 
-    protected def createTable: String = {
-      val b = new StringBuilder append "create table " append quoteTableName(tableNode) append " ("
+    protected def createTable(checkNotExists: Boolean): String = {
+      val b = new StringBuilder append "create table " append (if(checkNotExists) "if not exists " else "") append quoteTableName(tableNode) append " ("
       var first = true
       for(c <- columns) {
         if(first) first = false else b append ","
@@ -617,7 +619,7 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
 
     protected def addTableOptions(b: StringBuilder) {}
 
-    protected def dropTable: String = "drop table "+quoteTableName(tableNode)
+    protected def dropTable(ifExists: Boolean): String = "drop table "+(if(ifExists) "if exists " else "")+quoteTableName(tableNode)
 
     protected def truncateTable: String = "truncate table "+ quoteTableName(tableNode)
 

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -217,6 +217,36 @@ trait SQLServerProfile extends JdbcProfile {
       sb append ") on update " append (if(updateAction == "RESTRICT") "NO ACTION" else updateAction)
       sb append " on delete " append (if(deleteAction == "RESTRICT") "NO ACTION" else deleteAction)
     }
+
+    override def dropIfExistsPhase = {
+      //http://stackoverflow.com/questions/7887011/how-to-drop-a-table-if-it-exists-in-sql-server
+      Iterable(
+      "IF EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'"
+      + (tableNode.schemaName match{
+        case Some(s)=>s+"."
+        case None=>""
+      })
+      + tableNode.tableName
+      + "') AND type in (N'U'))\n"
+      + "begin\n"
+      + dropPhase1.mkString("\n") + dropPhase2.mkString("\n")
+      + "\nend")
+    }
+
+    override def createIfNotExistsPhase = {
+      //http://stackoverflow.com/questions/5952006/how-to-check-if-table-exist-and-if-it-doesnt-exist-create-table-in-sql-server-2
+      Iterable(
+      "IF  NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'"
+      + (tableNode.schemaName match{
+        case Some(s)=>s+"."
+        case None=>""
+      })
+      + tableNode.tableName
+      + "') AND type in (N'U'))\n"
+      + "begin\n"
+      + createPhase1.mkString("\n") + createPhase2.mkString("\n")
+      + "\nend")
+    }
   }
 
   class ColumnDDLBuilder(column: FieldSymbol) extends super.ColumnDDLBuilder(column) {

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -50,9 +50,19 @@ trait HeapBackend extends RelationalBackend with Logging {
       tables += ((name, t))
       t
     }
+    def createTableIfNotExists(name: String, columns: IndexedSeq[HeapBackend.Column],
+                    indexes: IndexedSeq[Index], constraints: IndexedSeq[Constraint]): HeapTable = synchronized {
+      val t = new HeapTable(name, columns, indexes, constraints)
+      if(!tables.contains(name)) tables += ((name, t))
+      t
+    }
     def dropTable(name: String): Unit = synchronized {
       if(!tables.remove(name).isDefined)
         throw new SlickException(s"Table $name does not exist")
+    }
+    def dropTableIfExists(name: String): Unit = try dropTable(name) catch{
+      case e: SlickException => ()
+      case e: Throwable => throw e
     }
     def truncateTable(name: String): Unit = synchronized{
       getTable(name).data.clear

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -157,6 +157,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
 
   class SchemaActionExtensionMethodsImpl(schema: SchemaDescription) extends super.SchemaActionExtensionMethodsImpl {
     protected[this] val tables = schema.asInstanceOf[DDL].tables
+    import slick.SlickException
     def create = dbAction { session =>
       tables.foreach(t =>
         session.database.createTable(t.tableName,
@@ -164,8 +165,21 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
           t.indexes.toIndexedSeq, t.tableConstraints.toIndexedSeq)
       )
     }
+
+    def createIfNotExists = dbAction { session =>
+      tables.foreach(t =>
+        session.database.createTableIfNotExists(t.tableName,
+          t.create_*.map { fs => new HeapBackend.Column(fs, typeInfoFor(fs.tpe)) }.toIndexedSeq,
+          t.indexes.toIndexedSeq, t.tableConstraints.toIndexedSeq)
+      )
+    }
+
     def drop = dbAction { session =>
       tables.foreach(t => session.database.dropTable(t.tableName))
+    }
+
+    def dropIfExists = dbAction { session =>
+      tables.foreach(t => session.database.dropTableIfExists(t.tableName))
     }
 
     def truncate = dbAction{ session =>

--- a/slick/src/main/scala/slick/relational/RelationalProfile.scala
+++ b/slick/src/main/scala/slick/relational/RelationalProfile.scala
@@ -245,8 +245,14 @@ trait RelationalActionComponent extends BasicActionComponent { self: RelationalP
     /** Create an Action that creates the entities described by this schema description. */
     def create: ProfileAction[Unit, NoStream, Effect.Schema]
 
+    /** Create an Action that creates the entities described by this schema description if the entities do not exist. */
+    def createIfNotExists: ProfileAction[Unit, NoStream, Effect.Schema]
+
     /** Create an Action that drops the entities described by this schema description. */
     def drop: ProfileAction[Unit, NoStream, Effect.Schema]
+
+    /** Create an Action that drops the entities described by this schema description only if the entities exist. */
+    def dropIfExists: ProfileAction[Unit, NoStream, Effect.Schema]
 
     /** Create an Action that truncates entries described by this schema description */
     def truncate: ProfileAction[Unit, NoStream, Effect.Schema]

--- a/slick/src/main/scala/slick/sql/SqlProfile.scala
+++ b/slick/src/main/scala/slick/sql/SqlProfile.scala
@@ -28,17 +28,27 @@ trait SqlProfile extends RelationalProfile with SqlTableComponent with SqlAction
     /** Statements to execute after createPhase1, e.g. creating foreign keys. */
     protected def createPhase2: Iterable[String]
 
+    protected def createIfNotExistsPhase: Iterable[String]
+
     /** All statements to execute for create() */
     def createStatements: Iterator[String] = createPhase1.iterator ++ createPhase2.iterator
 
+    /** All statements to execute for createIfNotExists() */
+    def createIfNotExistsStatements: Iterator[String] = createIfNotExistsPhase.iterator
+
     /** Statements to execute first for drop(), e.g. removing connections from other entities. */
     protected def dropPhase1: Iterable[String]
+
+    protected def dropIfExistsPhase: Iterable[String]
 
     /** Statements to execute after dropPhase1, e.g. actually dropping a table. */
     protected def dropPhase2: Iterable[String]
 
     /** All statements to execute for drop() */
     def dropStatements: Iterator[String] = dropPhase1.iterator ++ dropPhase2.iterator
+
+    /** All statements to execute for dropIfExists() */
+    def dropIfExistsStatements: Iterator[String] = dropIfExistsPhase.iterator
 
     /** Statements to execute first for truncate() */
     protected def truncatePhase: Iterable[String]
@@ -54,7 +64,9 @@ trait SqlProfile extends RelationalProfile with SqlTableComponent with SqlAction
     override def ++(other: DDL): DDL = new DDL {
       protected lazy val createPhase1 = self.createPhase1 ++ other.createPhase1
       protected lazy val createPhase2 = self.createPhase2 ++ other.createPhase2
+      protected lazy val createIfNotExistsPhase = self.createIfNotExistsPhase ++ other.createIfNotExistsPhase
       protected lazy val dropPhase1 = other.dropPhase1 ++ self.dropPhase1
+      protected lazy val dropIfExistsPhase = other.dropIfExistsPhase ++ self.dropIfExistsPhase
       protected lazy val dropPhase2 = other.dropPhase2 ++ self.dropPhase2
       protected lazy val truncatePhase = other.truncatePhase ++ self.truncatePhase
     }
@@ -65,25 +77,29 @@ trait SqlProfile extends RelationalProfile with SqlTableComponent with SqlAction
     override def equals(o: Any) = o match {
       case ddl: DDL => 
         self.createPhase1 == ddl.createPhase1 &&
+        self.createIfNotExistsPhase == ddl.createIfNotExistsPhase &&
         self.createPhase2 == ddl.createPhase2 &&
         self.dropPhase1 == ddl.dropPhase1 &&
+        self.dropIfExistsPhase == ddl.dropIfExistsPhase &&
         self.dropPhase2 == ddl.dropPhase2 &&
-        self.truncatePhase == ddl.truncatePhase
+        self.truncatePhase == ddl.truncatePhase 
       case _ => false
     }
   }
 
   object DDL { 
-    def apply(create1: Iterable[String], create2: Iterable[String], drop1: Iterable[String],
-              drop2: Iterable[String] , truncate: Iterable[String]): DDL = new DDL {
+    def apply(create1: Iterable[String], createIfNotExists: Iterable[String], create2: Iterable[String], drop1: Iterable[String],
+              dropIfExists: Iterable[String], drop2: Iterable[String] , truncate: Iterable[String]): DDL = new DDL {
       protected def createPhase1 = create1
+      protected def createIfNotExistsPhase = createIfNotExists
       protected def createPhase2 = create2
       protected def dropPhase1 = drop1
+      protected def dropIfExistsPhase = dropIfExists
       protected def dropPhase2 = drop2
       protected def truncatePhase = truncate
     }
 
-    def apply(create1: Iterable[String], drop2: Iterable[String]): DDL = apply(create1, Nil, Nil, drop2 , Nil)
+    def apply(create1: Iterable[String], drop2: Iterable[String]): DDL = apply(create1, Nil, Nil, Nil, Nil, drop2 , Nil)
 
     def apply(create1: String, drop2: String): DDL = apply(Iterable(create1), Iterable(drop2))
   }


### PR DESCRIPTION
Addresses points discussed in #93 

Adds methods createIfNotExists and dropIfExists
```scala
val ts = TableQuery[T]
val ts2 = TableQuery[S]
ts.schema.createIfNotExists
ts.schema.dropIfExists
(ts.schema ++ ts2.schema).createIfNotExists
```

### Issues now
- Some dbms don't support ``` IF NOT EXISTS``` either in create, drop or both statements. (DB2, Derby, Sqlserver - cause of failing tests).
- Consecutive calls to ```createIfNotExists``` fail if the table definition has a foreign key. 
