### PR TITLE
Do not generate constructor methods for more than 254 columns

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -81,7 +81,9 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
           (if(caseClassFinal) "final " else "") +
           s"""case class $name($args)$prns"""
         } else {
-          s"""
+          if(columns.size > 254)
+            s"type $name = $types" // constructor method would exceed JVM parameter limit
+          else s"""
 type $name = $types
 /** Constructor for $name providing default values if available in the database schema. */
 def $name($args): $name = {


### PR DESCRIPTION
The JVM has a limit of 254 parameters for a method.