### PR TITLE
Integrate the four official Activator templates into the manual.

### DIFF
--- a/doc/code/FirstExample.scala
+++ b/doc/code/FirstExample.scala
@@ -52,7 +52,7 @@ object FirstExample extends App {
 //#setup
   val db = Database.forConfig("h2mem1")
   try {
-    // ...
+    // val resultFuture: Future[_] = { ... }
 //#setup
 
     //#create
@@ -149,9 +149,9 @@ object FirstExample extends App {
       db.run(q3.result).map(_.foreach { case (s1, s2) => println("  " + s1 + " supplied by " + s2) })
 
     }
+    //#setup
     Await.result(resultFuture, Duration.Inf)
     lines.foreach(Predef.println _)
-//#setup
   } finally db.close
 //#setup
 }

--- a/doc/ornate.conf
+++ b/doc/ornate.conf
@@ -58,10 +58,6 @@ extension.globalRefs.refs {
   "Oracle": "https://www.oracle.com/database/"
   "SQL Server": "http://www.microsoft.com/en-us/server-cloud/products/sql-server/"
   "JMX": "https://en.wikipedia.org/wiki/Java_Management_Extensions"
-  "Hello Slick template": "https://typesafe.com/activator/template/hello-slick-"${shortVersion}
-  "Slick Plain SQL Queries template": "https://typesafe.com/activator/template/slick-plainsql-"${shortVersion}
-  "Slick Multi-DB Patterns template": "http://typesafe.com/activator/template/slick-multidb-"${shortVersion}
-  "Slick TestKit Example template": "https://typesafe.com/activator/template/slick-testkit-example-"${shortVersion}
 }
 
 extension.includeCode {
@@ -94,6 +90,8 @@ extension.externalLinks {
     uri = "https://issues.scala-lang.org/browse/SI-[all]"
     text = "SI-[all]"
   }
+  samplezip.uri = "https://example.lightbend.com/v1/download/[all]-"${shortVersion}
+  samplerepo.uri = "https://github.com/slick/slick/tree/"${shortVersion}"/samples/[all]"
 }
 
 extension.highlightjs {

--- a/doc/src/database.md
+++ b/doc/src/database.md
@@ -111,13 +111,127 @@ should therefore enable prepared statement caching in the connection pool's conf
 DatabaseConfig
 --------------
 
+> {.note}
+> This section is based on the **MultiDB** sample ([github](samplerepo:slick-multidb),
+> [zip](samplezip:slick-multidb)) which provides ready-to-run apps to demonstrate the features.
+
 On top of the configuration syntax for `Database`, there is another layer in the form of
 <api:slick.basic.DatabaseConfig> which allows you to configure a Slick profile plus a
 matching `Database` together. This makes it easy to abstract over different kinds of
 database systems by simply changing a configuration file.
 
-Here is a typical `DatabaseConfig` with a Slick profile object in `profile` and the database
-configuration in `db`:
+You can see it in action in `SimpleExample.scala`. First we load the DatabaseConfig and then import the
+Slick API from its profile:
 
-```yaml src=../code/application.conf#tsql
+```scala src=../../samples/slick-multidb/src/main/scala/databaseconfig/SimpleExample.scala#dc
 ```
+
+The `JdbcProfile` type annotation specifies the profile level whose API you get. You have to configure a profile of
+a matching type in the external configuration file. Since we're using the basic `forConfig` method with only a path
+("h2_dc"), the configuration must be located in the global application config, usually found in `application.conf`:
+
+```scala src=../../samples/slick-multidb/src/main/resources/application.conf#--doc-h2_db
+```
+
+You can use different database systems in your application by either switching out or overriding the application
+config (e.g. different `application.conf` files for development and production) or by passing a config path into
+the application. This way of implementing multi-database support is also used when building a Play app with Slick.
+
+Other Multi-DB Patterns
+-----------------------
+
+> {.note}
+> This section is based on the **MultiDB** sample ([github](samplerepo:slick-multidb),
+> [zip](samplezip:slick-multidb)) which provides ready-to-run apps to demonstrate the features.
+
+Since its addition in Slick 3.0 `DatabaseConfig` (see [above](#databaseconfig)) is the recommended solution.
+More complex scenarios (for example, where you need to map custom functions differently for different database
+systems, or where you cannot use the simple application.conf syntax) may require abstracting over databases in Scala
+code. The following sections explain two different ways of accomplishing this.
+
+### A DAO Class
+
+We start with a simple DAO (data access object) class, `DAO.scala`. It contains some database-related definitions
+(for a `PROPS` table that acts as a simple key/value store) and methods (for storing and reading entries).
+
+The class is parameterized by a concrete `JdbcProfile` and it imports all API features from this profile's api object:
+
+```scala src=../../samples/slick-multidb/src/main/scala/basic/DAO.scala#dao
+```
+
+Slick has multiple abstract profiles but in most cases you will want to use `JdbcProfile` which contains all the
+features that you also get when importing directly from one of Slick's concrete profiles for JDBC databases.
+
+Outside of the DAO class, you can still refer to its profile and the other features, but you have to get the imports
+from the profile in order to work with queries. This can be seen in `DAOHelper.scala`. It defines a new method
+`restrictKey` which we could have also put directly into the DAO class.
+
+To gain access to all of the profile's features, we parameterize the `DAOHelper` with the `DAO` and import from its
+profile:
+
+```scala src=../../samples/slick-multidb/src/main/scala/basic/DAOHelper.scala#daohelper
+```
+
+Note the use of the type projection `DAO#Props` in the definition of `restrictKey`. This points to the `Props` type
+coming from any `DAO` instance. This is less type-safe than using a path-dependent type like `dao.Props` but
+generally easier to use. You still need to ensure not to mix drivers when you do this.
+
+We are using the `DAO` and `DAOHelper` in `MultiDBExample.scala`. The `run` method is parameterized with both,
+a Slick profile and a matching JDBC `Database`:
+
+```scala src=../../samples/slick-multidb/src/main/scala/basic/MultiDBExample.scala#run
+```
+
+Since we don't have the convenience of a single profile's `api._` import at this point, we need to import the
+`Database` and `DBIO` types directly:
+
+```scala src=../../samples/slick-multidb/src/main/scala/basic/MultiDBExample.scala#imports
+```
+
+In the body of `MultiDBExample`, we create two `DAO` instances with matching `Database` objects in order to run the
+same code on both, H2 and SQLite:
+
+```scala src=../../samples/slick-multidb/src/main/scala/basic/MultiDBExample.scala#create
+```
+
+### The Cake Pattern
+
+In more complex designs where you want to split up the database code into separate modules that deal with different
+database entities, but still have dependencies between these modules, you can use the Cake Pattern to structure your
+code.
+
+We are doing this here in the app `MultiDBCakeExample.scala`. From the point of view of this main app, the new
+approach looks exactly like the previous one: You create a DAL (data access layer) object with a Slick profile, and
+use it together with a matching `Database`.
+
+The most basic slice of the cake is the `ProfileComponent`. It provides a `JdbcProfile` which is kept abstract at
+this point:
+
+```scala src=../../samples/slick-multidb/src/main/scala/cake/ProfileComponent.scala
+```
+
+Through the use of a self-type, the `PictureComponent` requires a `ProfileComponent` to me mixed in, so that it can
+import the query language features from the profile:
+
+```scala src=../../samples/slick-multidb/src/main/scala/cake/PictureComponent.scala#outline
+```
+
+Using the imported features, `PictureComponent` provides definitions and methods for working with `Picture` objects
+in the database. `UserComponent` does the same for `User` entities. In addition to `ProfileComponent` it also
+requires `PictureComponent`:
+
+```scala src=../../samples/slick-multidb/src/main/scala/cake/UserComponent.scala#outline
+```
+
+The `PictureComponent` dependency allows `UserComponent` to insert a new `Picture` when needed:
+
+```scala src=../../samples/slick-multidb/src/main/scala/cake/UserComponent.scala#insert
+```
+
+We put all slices of the cake together in `DAL.scala`. The `DAL` class inherits from all components and adds the
+missing profile through a field in the constructor:
+
+```scala src=../../samples/slick-multidb/src/main/scala/cake/DAL.scala
+```
+
+This is also a good place to add functionality that affects all components, like the `create` method.

--- a/doc/src/gettingstarted.md
+++ b/doc/src/gettingstarted.md
@@ -1,28 +1,41 @@
-# Getting Started {index="Activator;template"}
+# Getting Started {index="sample;download"}
 
-The easiest way to get started is with a working application in [Activator]. The following
-templates are created by the Slick team, with updated versions being made for new Slick releases:
+The easiest way to get started is with a working sample application. The following samples are part of the official
+Slick distribution. You can either clone Slick from github or download pre-packaged zip files with an indiviual
+sample plus an [sbt] launcher.
 
-* To learn the basics of Slick, start with the [Hello Slick template]. It contains an extended
-  version of the tutorial and code from this page.
+* To learn the basics of Slick, start with the **Hello Slick** sample ([github](samplerepo:hello-slick),
+  [zip](samplezip:hello-slick)). This is the one we are using in this chapter.
 
-* The [Slick Plain SQL Queries template] shows you how to do SQL queries with Slick.
+* The **Plain SQL Queries** sample ([github](samplerepo:slick-plainsql), [zip](samplezip:slick-plainsql)) shows you how
+  to do SQL queries with Slick. See [](sql.md) for details.
 
-* The [Slick Multi-DB Patterns template] shows you how to write Slick applications that can use
-  different database systems and how to use custom database functions in Slick queries.
+* The **Multi-DB Patterns** sample ([github](samplerepo:slick-multidb), [zip](samplezip:slick-multidb)) shows you how
+  to write Slick applications that can use different database systems and how to use custom database functions in
+  Slick queries.
 
-* The [Slick TestKit Example template] shows you how to use Slick TestKit to test your own Slick profiles.
+* The **TestKit** sample ([github](samplerepo:slick-testkit-example), [zip](samplezip:slick-testkit-example)) shows you
+  how to use Slick TestKit to test your own database profiles.
 
-There are more Slick templates created by the community, as well as versions of our own templates for other
-Slick releases. You can find [all Slick templates](https://lightbend.com/activator/templates#filter:slick)
-on the Lightbend web site.
+## Hello Slick
+
+The *Hello Slick* sample contains simple Scala application, `HelloSlick.scala`, that does basic FRM operations with
+Slick. You can run it out of the box with `sbt run`. To make things simple this project uses an embedded in-memory
+[H2] database, so no database installation or configuration is required.
+
+The file `TableSuite.scala` contains ScalaTest tests which perform some basic integration tests. You can run these
+tests with `sbt test`.
+
+> {.note}
+> Note: The example code in this app has intentionally verbose type information. In normal applications type inference
+> is used more extensively but to assist with learning the type information was included. 
 
 ## Adding Slick to Your Project {index="Maven; sbt; artifacts; build; dependency; logging; SLF4j"}
 
-To include Slick in an existing project use the library published on Maven Central.  For sbt projects add the
-following to your build definition - `build.sbt` or `project/Build.scala`:
+To include Slick in an existing project use the library published on Maven Central. Add the following to your
+build definition (`build.sbt` for [sbt] or `pom.xml` for Maven):
 
-```scala expandVars=true
+```scala expandVars=true tab=sbt
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "{{version}}",
   "org.slf4j" % "slf4j-nop" % "1.6.4",
@@ -30,29 +43,30 @@ libraryDependencies ++= Seq(
 )
 ```
 
-For Maven projects add the following to your `<dependencies>` (make sure to use the correct Scala
-version prefix, `_2.11` or `_2.12`, to match your project's Scala version):
-
-```xml expandVars=true
-<dependency>
-  <groupId>com.typesafe.slick</groupId>
-  <artifactId>slick_2.11</artifactId>
-  <version>{{version}}</version>
-</dependency>
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-nop</artifactId>
-  <version>1.6.4</version>
-</dependency>
-<dependency>
-  <groupId>com.typesafe.slick</groupId>
-  <artifactId>slick-hikaricp_2.11</artifactId>
-  <version>{{version}}</version>
-</dependency>
+```xml expandVars=true tab=Maven
+<!-- Make sure to use the correct Scala version suffix "_2.11" or "_2.12"
+     to match your project's Scala version. -->
+<dependencies>
+  <dependency>
+    <groupId>com.typesafe.slick</groupId>
+    <artifactId>slick_2.11</artifactId>
+    <version>{{version}}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-nop</artifactId>
+    <version>1.6.4</version>
+  </dependency>
+  <dependency>
+    <groupId>com.typesafe.slick</groupId>
+    <artifactId>slick-hikaricp_2.11</artifactId>
+    <version>{{version}}</version>
+  </dependency>
+</dependencies>
 ```
 
 Slick uses [SLF4J] for its own debug logging so you also need to add an SLF4J
-implementation. Here we are using `slf4j-nop` to disable logging. You have
+implementation. *Hello Slick* uses `slf4j-nop` to disable logging. You have
 to replace this with a real logging framework like [Logback] if you want to see
 log output.
 
@@ -64,11 +78,6 @@ provide a compatible version of HikariCP as a transitive dependency. Otherwise, 
 might need to disable connection pooling or specify a third-party connection pool.
 
 ## Quick Introduction
-
-> {.note}
-> Note: The rest of this chapter is based on the [Hello Slick template]. The preferred
-> way of reading this introduction is in [Activator], where you can edit and run the code
-> directly while reading the tutorial.
 
 To use Slick you first need to import the API for the database you will be using, like:
 
@@ -95,9 +104,17 @@ your `application.conf`, which is also used by [Play] and [Akka] for their confi
 ```
 
 For the purpose of this example we disable the connection pool (there is no point in using one for
-an embedded in-memory database) and request a keep-alive connection (which ensures that the
-database does not get dropped while we are using it). The database can be easily instantiated from
-the configuration like this:
+an embedded in-memory database). When you use a real, external database server, the connection pool provides
+improved performance and resilience.
+
+The `keepAliveConnection` option (which is only available without a connection pool) keeps an extra connection
+open for the lifetime of the `Database` object in the application. This ensures that the
+database does not get dropped while we are using it.
+
+*Hello Slick* is a standalone command-line application, not running inside of a container which takes care of
+resource management, so we have to do it ourselves. Since all database calls in Slick are asynchronous, we are
+going to compose Futures throughout the app, but eventually we have to wait for the result. This gives us the
+following scaffolding:
 
 ```scala src=../code/FirstExample.scala#setup
 ```
@@ -105,6 +122,11 @@ the configuration like this:
 > {.note}
 > Note: A `Database` object usually manages a thread pool and a connection pool. You should always
 > shut it down properly when it is no longer needed (unless the JVM process terminates anyway).
+> Do not create a new `Database` for every database operation. A single instance is meant to be kept
+> alive for the entire lifetime your your application.
+
+If you are not familiar with asynchronous, Future-based programming Scala, you can learn more about
+[Futures and Promises](http://docs.scala-lang.org/overviews/core/futures.html) in the Scala documentation.
 
 ### Schema
 
@@ -142,12 +164,15 @@ dependencies on each other.
 Inserting the tuples of data is done with the `+=` and `++=` methods, similar to how you add data to mutable
 Scala collections.
 
-The `create`, `+=` and `++=` methods return a `DBIOAction` which can be executed on a database
-at a later time to produce a result. There are several different combinators for combining multiple
-`DBIOAction`s into sequences, yielding another action. Here we use the simplest one, `DBIO.seq`, which
-can concatenate any number of actions, discarding the return values (i.e. the resulting `DBIOAction`
-produces a result of type `Unit`). We then execute the setup action asynchronously with
-`db.run`, yielding a `Future[Unit]`.
+The `create`, `+=` and `++=` methods return *database I/O actions* (`DBIOAction`) which can be executed on a database
+at a later time to produce a result. If you do not care about more advanced features like streaming, effect tracking
+or extension methods for certain actions, you can denote their type as `DBIO[T]` (for an operation which will
+eventually produce a value of type `T`).
+
+There are several different combinators for combining multiple `DBIOAction`s into sequences, yielding another action.
+Here we use the simplest one, `DBIO.seq`, which can concatenate any number of actions, discarding the return values
+(i.e. the resulting `DBIOAction` produces a result of type `Unit`). We then execute the setup action asynchronously
+with `db.run`, yielding a `Future[Unit]`.
 
 > {.note}
 > Note: Database connections and transactions are managed automatically by Slick. By default
@@ -157,9 +182,24 @@ produces a result of type `Unit`). We then execute the setup action asynchronous
 > (`db.run(setup.transactionally)`). Then the order would not matter because the constraints are
 > only enforced at the end when the transaction is committed.
 
+When inserting data, the database usually returns the number of affected rows, therefore the return type is
+`Option[Int]` as can be seen in this definition of `insertAction`:
+
+```scala src=../../samples/hello-slick/src/main/scala/HelloSlick.scala#insertAction
+```
+
+We can use the `map` combinator to run some code and compute a new value from the value returned by the action
+(or in this case run it only for its side effects and return `Unit`).
+
+> {.note}
+> Note that `map` and all other combinators which run user code (e.g. `flatMap`, `cleanup`, `filter`) take an implicit
+> `ExecutionContext` on which to run this code. Slick uses its own `ExecutionContext` internally for running blocking
+> database I/O but it always maintains a clean separation and prevents you from running non-I/O code on it.
+
 ### Querying
 
-The simplest kind of query iterates over all the data in a table:
+The simplest kind of query iterates over all the data in a table by calling `.result` on the `TableQuery` to get
+a `DBIOAction`:
 
 ```scala src=../code/FirstExample.scala#readall
 ```
@@ -201,3 +241,65 @@ key `Coffees.supplier`. Instead of repeating the join condition here we can use 
 
 ```scala src=../code/FirstExample.scala#fkjoin
 ```
+
+### Aggregations
+
+Aggregates values like minimum, maximum, summation, and average can be computed by the database using the query
+functions `min`, `max`, `sum` and `avg` like:
+
+```scala src=../../samples/hello-slick/src/main/scala/HelloSlick.scala#maxPrice
+```
+
+This creates a new scalar query (`Rep`) that can be run like a collection-valued `Query` by calling `.result`.
+
+### Plain SQL / String Interpolation
+
+Sometimes writing SQL code manually is the easiest and best way to go but we don't want to lose SQL injection
+protection that Slick includes. [SQL String Interpolation](sql.md) provides a nice API for doing this.
+In *Hello Slick* we use the `sql` interpolator:
+
+```scala src=../../samples/hello-slick/src/main/scala/HelloSlick.scala#plainSql
+```
+
+This produces a database I/O action that can be run or streamed in the usual way.
+
+### Case Class Mapping
+
+The `CaseClassMapping.scala` app provides an example which uses a *case class* instead of tupled values.
+To use case classes instead of tuples setup a `def *` projection which transforms the tuple values to and from the
+case class. For example:
+
+```scala src=../../samples/hello-slick/src/main/scala/CaseClassMapping.scala#mapTo
+```
+
+This uses the `mapTo` macro to convert between `(Option[Int], String)` and `User` bidirectionally. Now all of the
+queries can work with a `User` object instead of the tuples. 
+
+See [](schemas.md#mapped-tables) for details.
+
+### Auto-Generated Primary Keys
+
+The `Users` table mapping in `CaseClassMapping.scala` defines an `id` column which uses an auto-incrementing
+primary key:
+
+```scala src=../../samples/hello-slick/src/main/scala/CaseClassMapping.scala#autoInc
+```
+
+See [](schemas.md#table-rows) for more column options.
+
+### Running Queries
+
+So far you have seen how to get a `Seq` from a collection-valued query and how to stream individual elements.
+There are several other useful methods which are shown in `QueryActions.scala`. They are equally applicable to
+[Scala queries](queries.md) and [Plain SQL queries](sql.md).
+
+Note the use of `Compiled` in this app. It is used to define a pre-compiled query that can be executed with
+different parameters without having to recompile the SQL statement each time. This is the preferred way of defining
+queries in real-world applications. It prevents the (possibly expensive) compilation each time and leads to the
+same SQL statement (or a small, fixed set of SQL statements) so that the database system can also reuse a previously
+computed execution plan. As a side-effect, all parameters are automatically turned into bind variables:
+
+```scala src=../../samples/hello-slick/src/main/scala/QueryActions.scala#upTo
+```
+
+See [](queries.md#compiled-queries) for details.

--- a/doc/src/introduction.md
+++ b/doc/src/introduction.md
@@ -16,7 +16,6 @@ When using Scala instead of raw SQL for your queries you benefit from compile-ti
 and compositionality. Slick can generate queries for different back-end databases including
 your own, using its extensible query compiler.
 
-Get started learning Slick in minutes using the [Hello Slick template] in [Activator].
 See [here](supported-databases.md) for an overview of the supported database systems for which
 Slick can generate code.
 

--- a/doc/src/sql.md
+++ b/doc/src/sql.md
@@ -7,16 +7,15 @@ to the low level of [JDBC], you can use Slick's *Plain SQL* queries with a much
 nicer Scala-based API.
 
 > {.note}
-> The rest of this chapter is based on the [Slick Plain SQL Queries template].
-> The preferred way of reading this introduction is in [Activator], where you can edit and
-> run the code directly while reading the tutorial.
+> This chapter is based on the **Plain SQL Queries** sample ([github](samplerepo:slick-plainsql),
+> [zip](samplezip:slick-plainsql)) which provides a ready-to-run app to demonstrate the features.
 
 Scaffolding
 -----------
 
 The database connection is opened
 [in the usual way](gettingstarted.md#database-configuration). All *Plain SQL* queries result in
-<api:slick.dbio.DBIOAction> that can be composed and run like any other action.
+a <api:slick.dbio.DBIOAction> that can be composed and run like any other action.
 
 String Interpolation {index="interpolation; sqlu,interpolator; update,Plain SQL; Plain SQL;update"}
 --------------------

--- a/doc/src/testkit.md
+++ b/doc/src/testkit.md
@@ -1,92 +1,54 @@
 Slick TestKit {index="profile,custom; custom,profile; TestKit; testing"}
 =============
 
-> {.note}
-> This chapter is based on the [Slick TestKit Example template]/
-> The preferred way of reading this introduction is in [Activator], where you can
-> edit and run the code directly while reading the tutorial.
-
 When you write your own database profile for Slick, you need a way to run all
 the standard unit tests on it (in addition to any custom tests you may want to
 add) to ensure that it works correctly and does not claim to support any
 capabilities which are not actually implemented. For this purpose the Slick
-unit tests have been factored out into a separate Slick TestKit project.
+unit tests have been factored out into a separate *Slick TestKit* project.
 
-To get started, you can clone the [Slick TestKit Example template] which
-contains a copy of Slick's standard PostgreSQL profile and all the infrastructure
+To get started, you can [clone](samplerepo:slick-testkit-example) or [download](samplezip:slick-testkit-example)
+the **TestKit Example** project which contains a copy of Slick's standard PostgreSQL profile and all the infrastructure
 required to build and test it.
 
 Scaffolding
 -----------
 
-Its `build.sbt` file is straight-forward. Apart from the usual name and
-version settings, it adds the dependencies for Slick, the TestKit,
-junit-interface, Logback and the PostgreSQL JDBC driver, and it sets some
-options for the test runs:
+Its `build.sbt` file is straight-forward. It adds the dependencies for Slick, TestKit, junit-interface, Logback and
+the PostgreSQL JDBC driver, and it sets some options for the test runs:
 
-```scala expandVars=true
-libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick" % "{{version}}",
-  "com.typesafe.slick" %% "slick-testkit" % "{{version}}" % "test",
-  "com.novocode" % "junit-interface" % "0.10" % "test",
-  "ch.qos.logback" % "logback-classic" % "0.9.28" % "test",
-  "postgresql" % "postgresql" % "9.1-901.jdbc4" % "test"
-)
-
-testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a")
-
-parallelExecution in Test := false
-
-logBuffered := false
+```scala src=../../samples/slick-testkit-example/build.sbt
 ```
 
-There is a copy of Slick's logback configuration in
-`src/test/resources/logback-test.xml` but you can swap out the logging
-framework if you prefer a different one.
+There is a copy of Slick's logback configuration in `src/test/resources/logback-test.xml` but you can swap out the
+logging framework if you prefer a different one.
 
 Profile
 -------
 
-The actual profile implementation can be found under `src/main/scala`.
+The actual profile implementation can be found under `src/main/scala`:
+
+```scala src=../../samples/slick-testkit-example/src/main/scala/MyPostgresProfile.scala#outline
+```
 
 Test Harness {index="ProfileTest; TestDB; testkit.conf; ExternalTestDB; test-dbs"}
 ------------
 
-In order to run the TestKit tests, you need to add a class that extends
-`ProfileTest`, plus an implementation of `TestDB` which tells the TestKit
-how to connect to a test database, get a list of tables, clean up between
+In order to run the TestKit tests, you need to add a class that extends `ProfileTest`, plus an implementation of
+`TestDB` which tells TestKit how to connect to a test database, get a list of tables, clean up between
 tests, etc.
 
-In the case of the PostgreSQL test harness (in `src/test/slick/jdbc/test/MyPostgresTest.scala`)
+In the case of the PostgreSQL test harness (in `src/test/scala/MyPostgresTest.scala`)
 most of the default implementations can be used out of the box. Only `localTables` and
 `getLocalSequences` require custom implementations. We also modify the profile's `capabilities`
 to indicate that our profile does not support the JDBC `getFunctions` call:
 
-```scala
-@RunWith(classOf[Testkit])
-class MyPostgresTest extends ProfileTest(MyPostgresTest.tdb)
-
-object MyPostgresTest {
-  def tdb = new ExternalJdbcTestDB("mypostgres") {
-    val profile = MyPostgresProfile
-    override def localTables(implicit ec: ExecutionContext): DBIO[Vector[String]] =
-      ResultSetAction[(String,String,String, String)](_.conn.getMetaData().getTables("", "public", null, null)).map { ts =>
-        ts.filter(_._4.toUpperCase == "TABLE").map(_._3).sorted
-      }
-    override def getLocalSequences(implicit session: profile.Backend#Session) = {
-      val tables = ResultSetInvoker[(String,String,String, String)](_.conn.getMetaData().getTables("", "public", null, null))
-      tables.buildColl[List].filter(_._4.toUpperCase == "SEQUENCE").map(_._3).sorted
-    }
-    override def capabilities = super.capabilities - TestDB.capabilities.jdbcMetaGetFunctions
-  }
-}
+```scala src=../../samples/slick-testkit-example/src/test/scala/MyPostgresTest.scala#outline
 ```
 
 The name of a configuration prefix, in this case `mypostgres`, is passed to `ExternalJdbcTestDB`:
 
-```scala
-def tdb =
-  new ExternalJdbcTestDB("mypostgres") ...
+```scala src=../../samples/slick-testkit-example/src/test/scala/MyPostgresTest.scala#tdb
 ```
 
 Database Configuration
@@ -95,15 +57,15 @@ Database Configuration
 Since the PostgreSQL test harness is based on `ExternalJdbcTestDB`, it needs to be configured in
 `test-dbs/testkit.conf`:
 
-```yaml
-mypostgres.enabled = true
-mypostgres.user = myuser
-mypostgres.password = secret
+```yaml src=../../samples/slick-testkit-example/test-dbs/testkit.conf
 ```
 
 There are several other configuration options that need to be set for an `ExternalJdbcTestDB`.
 These are defined with suitable defaults in `testkit-reference.conf` so that `testkit.conf` can
-be kept very simple in most cases.
+be kept very simple in most cases:
+
+```yaml src=../../samples/slick-testkit-example/src/test/resources/testkit-reference.conf
+```
 
 Testing
 -------

--- a/doc/src/userdefined.md
+++ b/doc/src/userdefined.md
@@ -7,6 +7,10 @@ with Slick's Scala API.
 Scalar Database Functions {index="scalar,function,user-defined; function,scalar,user-defined"}
 -------------------------
 
+> {.note}
+> This section is based on the ready-to-run`CallNativeDBFunction` app in the **MultiDB** sample
+> ([github](samplerepo:slick-multidb), [zip](samplezip:slick-multidb)).
+
 If your database system supports a scalar function that is not available as a method in Slick you can define it as a
 <api:slick.lifted.SimpleFunction>. There are predefined methods for creating unary, binary and ternary functions with
 fixed parameter and return types.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
+# Remember to change the sbt version in all sample projects when updating it here
 sbt.version=0.13.13

--- a/samples/hello-slick/COPYING
+++ b/samples/hello-slick/COPYING
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/samples/hello-slick/LICENSE
+++ b/samples/hello-slick/LICENSE
@@ -1,0 +1,8 @@
+Slick sample code by Slick contributors
+
+To the extent possible under law, the person who associated CC0 with
+Slick sample code has waived all copyright and related or neighboring rights
+to Slick sample code.
+
+You should have received a copy of the CC0 legalcode along with this
+work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/samples/hello-slick/README
+++ b/samples/hello-slick/README
@@ -1,0 +1,2 @@
+This sample project is part of the Slick documentation.
+See http://slick.lightbend.com/docs/ for details.

--- a/samples/hello-slick/build.sbt
+++ b/samples/hello-slick/build.sbt
@@ -1,0 +1,12 @@
+scalaVersion := "2.12.1"
+
+libraryDependencies ++= List(
+  "com.typesafe.slick" %% "slick" % "3.2.0",
+  "org.slf4j" % "slf4j-nop" % "1.7.10",
+  "com.h2database" % "h2" % "1.4.187",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+)
+
+scalacOptions += "-deprecation"
+
+fork in run := true

--- a/samples/hello-slick/project/build.properties
+++ b/samples/hello-slick/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/samples/hello-slick/src/main/resources/application.conf
+++ b/samples/hello-slick/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+h2mem1 = {
+  url = "jdbc:h2:mem:test1"
+  driver = org.h2.Driver
+  connectionPool = disabled
+  keepAliveConnection = true
+}

--- a/samples/hello-slick/src/main/scala/CaseClassMapping.scala
+++ b/samples/hello-slick/src/main/scala/CaseClassMapping.scala
@@ -1,0 +1,41 @@
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import slick.jdbc.H2Profile.api._
+
+object CaseClassMapping extends App {
+
+  // the base query for the Users table
+  val users = TableQuery[Users]
+
+  val db = Database.forConfig("h2mem1")
+  try {
+    Await.result(db.run(DBIO.seq(
+      // create the schema
+      users.schema.create,
+
+      // insert two User instances
+      users += User("John Doe"),
+      users += User("Fred Smith"),
+
+      // print the users (select * from USERS)
+      users.result.map(println)
+    )), Duration.Inf)
+  } finally db.close
+}
+
+case class User(name: String, id: Option[Int] = None)
+
+class Users(tag: Tag) extends Table[User](tag, "USERS") {
+  // Auto Increment the id primary key column
+  //#autoInc
+  def id = column[Int]("ID", O.PrimaryKey, O.AutoInc)
+  //#autoInc
+  // The name can't be null
+  def name = column[String]("NAME")
+  // the * projection (e.g. select * ...) auto-transforms the tupled
+  // column values to / from a User
+  //#mapTo
+  def * = (name, id.?).mapTo[User]
+  //#mapTo
+}

--- a/samples/hello-slick/src/main/scala/HelloSlick.scala
+++ b/samples/hello-slick/src/main/scala/HelloSlick.scala
@@ -1,0 +1,200 @@
+import scala.concurrent.{Future, Await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import slick.basic.DatabasePublisher
+import slick.jdbc.H2Profile.api._
+
+// The main application
+object HelloSlick extends App {
+  val db = Database.forConfig("h2mem1")
+  try {
+
+    // The query interface for the Suppliers table
+    val suppliers: TableQuery[Suppliers] = TableQuery[Suppliers]
+
+    // the query interface for the Coffees table
+    val coffees: TableQuery[Coffees] = TableQuery[Coffees]
+
+    val setupAction: DBIO[Unit] = DBIO.seq(
+      // Create the schema by combining the DDLs for the Suppliers and Coffees
+      // tables using the query interfaces
+      (suppliers.schema ++ coffees.schema).create,
+
+      // Insert some suppliers
+      suppliers += (101, "Acme, Inc.", "99 Market Street", "Groundsville", "CA", "95199"),
+      suppliers += ( 49, "Superior Coffee", "1 Party Place", "Mendocino", "CA", "95460"),
+      suppliers += (150, "The High Ground", "100 Coffee Lane", "Meadows", "CA", "93966")
+    )
+
+    val setupFuture: Future[Unit] = db.run(setupAction)
+    val f = setupFuture.flatMap { _ =>
+
+      //#insertAction
+      // Insert some coffees (using JDBC's batch insert feature)
+      val insertAction: DBIO[Option[Int]] = coffees ++= Seq (
+        ("Colombian",         101, 7.99, 0, 0),
+        ("French_Roast",       49, 8.99, 0, 0),
+        ("Espresso",          150, 9.99, 0, 0),
+        ("Colombian_Decaf",   101, 8.99, 0, 0),
+        ("French_Roast_Decaf", 49, 9.99, 0, 0)
+      )
+
+      val insertAndPrintAction: DBIO[Unit] = insertAction.map { coffeesInsertResult =>
+        // Print the number of rows inserted
+        coffeesInsertResult foreach { numRows =>
+          println(s"Inserted $numRows rows into the Coffees table")
+        }
+      }
+      //#insertAction
+
+      val allSuppliersAction: DBIO[Seq[(Int, String, String, String, String, String)]] =
+        suppliers.result
+
+      val combinedAction: DBIO[Seq[(Int, String, String, String, String, String)]] =
+        insertAndPrintAction andThen allSuppliersAction
+
+      val combinedFuture: Future[Seq[(Int, String, String, String, String, String)]] =
+        db.run(combinedAction)
+
+      combinedFuture.map { allSuppliers =>
+        allSuppliers.foreach(println)
+      }
+
+    }.flatMap { _ =>
+
+      /* Streaming */
+
+      val coffeeNamesAction: StreamingDBIO[Seq[String], String] =
+        coffees.map(_.name).result
+
+      val coffeeNamesPublisher: DatabasePublisher[String] =
+        db.stream(coffeeNamesAction)
+
+      coffeeNamesPublisher.foreach(println)
+
+    }.flatMap { _ =>
+
+      /* Filtering / Where */
+
+      // Construct a query where the price of Coffees is > 9.0
+      val filterQuery: Query[Coffees, (String, Int, Double, Int, Int), Seq] =
+        coffees.filter(_.price > 9.0)
+
+      // Print the SQL for the filter query
+      println("Generated SQL for filter query:\n" + filterQuery.result.statements)
+
+      // Execute the query and print the Seq of results
+      db.run(filterQuery.result.map(println))
+
+    }.flatMap { _ =>
+
+      /* Update */
+
+      // Construct an update query with the sales column being the one to update
+      val updateQuery: Query[Rep[Int], Int, Seq] = coffees.map(_.sales)
+
+      val updateAction: DBIO[Int] = updateQuery.update(1)
+
+      // Print the SQL for the Coffees update query
+      println("Generated SQL for Coffees update:\n" + updateQuery.updateStatement)
+
+      // Perform the update
+      db.run(updateAction.map { numUpdatedRows =>
+        println(s"Updated $numUpdatedRows rows")
+      })
+
+    }.flatMap { _ =>
+
+      /* Delete */
+
+      // Construct a delete query that deletes coffees with a price less than 8.0
+      val deleteQuery: Query[Coffees,(String, Int, Double, Int, Int), Seq] =
+        coffees.filter(_.price < 8.0)
+
+      val deleteAction = deleteQuery.delete
+
+      // Print the SQL for the Coffees delete query
+      println("Generated SQL for Coffees delete:\n" + deleteAction.statements)
+
+      // Perform the delete
+      db.run(deleteAction).map { numDeletedRows =>
+        println(s"Deleted $numDeletedRows rows")
+      }
+
+    }.flatMap { _ =>
+
+      /* Sorting / Order By */
+
+      val sortByPriceQuery: Query[Coffees, (String, Int, Double, Int, Int), Seq] =
+        coffees.sortBy(_.price)
+
+      println("Generated SQL for query sorted by price:\n" +
+        sortByPriceQuery.result.statements)
+
+      // Execute the query
+      db.run(sortByPriceQuery.result).map(println)
+
+    }.flatMap { _ =>
+
+      /* Query Composition */
+
+      val composedQuery: Query[Rep[String], String, Seq] =
+        coffees.sortBy(_.name).take(3).filter(_.price > 9.0).map(_.name)
+
+      println("Generated SQL for composed query:\n" +
+        composedQuery.result.statements)
+
+      // Execute the composed query
+      db.run(composedQuery.result).map(println)
+
+    }.flatMap { _ =>
+
+      /* Joins */
+
+      // Join the tables using the relationship defined in the Coffees table
+      val joinQuery: Query[(Rep[String], Rep[String]), (String, String), Seq] = for {
+        c <- coffees if c.price > 9.0
+        s <- c.supplier
+      } yield (c.name, s.name)
+
+      println("Generated SQL for the join query:\n" + joinQuery.result.statements)
+
+      // Print the rows which contain the coffee name and the supplier name
+      db.run(joinQuery.result).map(println)
+
+    }.flatMap { _ =>
+
+      /* Computed Values */
+
+      //#maxPrice
+      // Create a new scalar value that calculates the maximum price
+      val maxPrice: Rep[Option[Double]] = coffees.map(_.price).max
+      //#maxPrice
+
+      println("Generated SQL for max price column:\n" + maxPrice.result.statements)
+
+      // Execute the computed value query
+      db.run(maxPrice.result).map(println)
+
+    }.flatMap { _ =>
+
+      //#plainSql
+      /* Manual SQL / String Interpolation */
+
+      // A value to insert into the statement
+      val state = "CA"
+
+      // Construct a SQL statement manually with an interpolated value
+      val plainQuery = sql"select SUP_NAME from SUPPLIERS where STATE = $state".as[String]
+      //#plainSql
+
+      println("Generated SQL for plain query:\n" + plainQuery.statements)
+
+      // Execute the query
+      db.run(plainQuery).map(println)
+
+    }
+    Await.result(f, Duration.Inf)
+
+  } finally db.close
+}

--- a/samples/hello-slick/src/main/scala/QueryActions.scala
+++ b/samples/hello-slick/src/main/scala/QueryActions.scala
@@ -1,0 +1,75 @@
+import slick.jdbc.H2Profile.api._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+
+// Demonstrates various ways of reading data
+object QueryActions extends App {
+
+  // A simple dictionary table with keys and values
+  class Dict(tag: Tag) extends Table[(Int, String)](tag, "INT_DICT") {
+    def key = column[Int]("KEY", O.PrimaryKey)
+    def value = column[String]("VALUE")
+    def * = (key, value)
+  }
+  val dict = TableQuery[Dict]
+
+  val db = Database.forConfig("h2mem1")
+  try {
+
+    //#upTo
+    // Define a pre-compiled parameterized query for reading all key/value
+    // pairs up to a given key.
+    val upTo = Compiled { k: Rep[Int] =>
+      dict.filter(_.key <= k).sortBy(_.key)
+    }
+    //#upTo
+
+    // A second pre-compiled query which returns a Set[String]
+    val upToSet = upTo.map(_.andThen(_.to[Set]))
+
+    Await.result(db.run(DBIO.seq(
+
+      // Create the dictionary table and insert some data
+      dict.schema.create,
+      dict ++= Seq(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e"),
+
+      upTo(3).result.map { r =>
+        println("Seq (Vector) of k/v pairs up to 3")
+        println("- " + r)
+      },
+
+      upToSet(3).result.map { r =>
+        println("Set of k/v pairs up to 3")
+        println("- " + r)
+      },
+
+      dict.map(_.key).to[Array].result.map { r =>
+        println("All keys in an unboxed Array[Int]")
+        println("- " + r)
+      },
+
+      upTo(3).result.head.map { r =>
+        println("Only get the first result, failing if there is none")
+        println("- " + r)
+      },
+
+      upTo(3).result.headOption.map { r =>
+        println("Get the first result as an Option, or None")
+        println("- " + r)
+      }
+
+    )), Duration.Inf)
+
+    // The Publisher captures a Database plus a DBIO action.
+    // The action does not run until you consume the stream.
+    val p = db.stream(upTo(3).result)
+
+    println("Stream k/v pairs up to 3 via Reactive Streams")
+    Await.result(p.foreach { v =>
+      println("- " + v)
+    }, Duration.Inf)
+
+  } finally db.close
+}

--- a/samples/hello-slick/src/main/scala/Tables.scala
+++ b/samples/hello-slick/src/main/scala/Tables.scala
@@ -1,0 +1,37 @@
+import slick.jdbc.H2Profile.api._
+import slick.lifted.{ProvenShape, ForeignKeyQuery}
+
+// A Suppliers table with 6 columns: id, name, street, city, state, zip
+class Suppliers(tag: Tag)
+  extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
+
+  // This is the primary key column:
+  def id: Rep[Int] = column[Int]("SUP_ID", O.PrimaryKey)
+  def name: Rep[String] = column[String]("SUP_NAME")
+  def street: Rep[String] = column[String]("STREET")
+  def city: Rep[String] = column[String]("CITY")
+  def state: Rep[String] = column[String]("STATE")
+  def zip: Rep[String] = column[String]("ZIP")
+  
+  // Every table needs a * projection with the same type as the table's type parameter
+  def * : ProvenShape[(Int, String, String, String, String, String)] =
+    (id, name, street, city, state, zip)
+}
+
+// A Coffees table with 5 columns: name, supplier id, price, sales, total
+class Coffees(tag: Tag)
+  extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
+
+  def name: Rep[String] = column[String]("COF_NAME", O.PrimaryKey)
+  def supID: Rep[Int] = column[Int]("SUP_ID")
+  def price: Rep[Double] = column[Double]("PRICE")
+  def sales: Rep[Int] = column[Int]("SALES")
+  def total: Rep[Int] = column[Int]("TOTAL")
+  
+  def * : ProvenShape[(String, Int, Double, Int, Int)] =
+    (name, supID, price, sales, total)
+  
+  // A reified foreign key relation that can be navigated to create a join
+  def supplier: ForeignKeyQuery[Suppliers, (Int, String, String, String, String, String)] = 
+    foreignKey("SUP_FK", supID, TableQuery[Suppliers])(_.id)
+}

--- a/samples/hello-slick/src/test/scala/TablesSuite.scala
+++ b/samples/hello-slick/src/test/scala/TablesSuite.scala
@@ -1,0 +1,49 @@
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
+import slick.jdbc.H2Profile.api._
+import slick.jdbc.meta._
+
+class TablesSuite extends FunSuite with BeforeAndAfter with ScalaFutures {
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
+
+  val suppliers = TableQuery[Suppliers]
+  val coffees = TableQuery[Coffees]
+  
+  var db: Database = _
+
+  def createSchema() =
+    db.run((suppliers.schema ++ coffees.schema).create).futureValue
+  
+  def insertSupplier(): Int =
+    db.run(suppliers += (101, "Acme, Inc.", "99 Market Street", "Groundsville", "CA", "95199")).futureValue
+  
+  before { db = Database.forConfig("h2mem1") }
+  
+  test("Creating the Schema works") {
+    createSchema()
+    
+    val tables = db.run(MTable.getTables).futureValue
+
+    assert(tables.size == 2)
+    assert(tables.count(_.name.name.equalsIgnoreCase("suppliers")) == 1)
+    assert(tables.count(_.name.name.equalsIgnoreCase("coffees")) == 1)
+  }
+
+  test("Inserting a Supplier works") {
+    createSchema()
+    
+    val insertCount = insertSupplier()
+    assert(insertCount == 1)
+  }
+  
+  test("Query Suppliers works") {
+    createSchema()
+    insertSupplier()
+    val results = db.run(suppliers.result).futureValue
+    assert(results.size == 1)
+    assert(results.head._1 == 101)
+  }
+  
+  after { db.close }
+}

--- a/samples/override.sbt
+++ b/samples/override.sbt
@@ -1,0 +1,21 @@
+// Override settings of sample projects when they are used as subprojects of the main Slick build.
+//
+// The sample projects are packaged as standalone sbt projects via the Example Code Service
+// (https://example.lightbend.com) so they have to be complete and usable on their own and they must
+// not contain any unnecessary code that is only needed when they are run as part of the main build.
+// The settings here (which are loaded after build.sbt) ensure that the Scala version and the Slick
+// version match the ones of the main build.
+
+crossScalaVersions := (crossScalaVersions in LocalProject("slick")).value
+
+scalaVersion := (scalaVersion in LocalProject("slick")).value
+
+libraryDependencies := libraryDependencies.value.map { m =>
+  if(m.organization == (organization in LocalProject("slick")).value) m.copy(revision = slickVersion)
+  else m
+}
+
+unmanagedClasspath in Compile :=
+  Attributed.blank(baseDirectory.value.getParentFile / "resources") +: (unmanagedClasspath in Compile).value
+
+unmanagedClasspath in Compile ++= (products in config("macro") in LocalProject("slick")).value

--- a/samples/resources/application.conf
+++ b/samples/resources/application.conf
@@ -1,0 +1,4 @@
+# Overrides for application.conf in sample projects
+
+# change the relative path used by slick-plainsql:
+tsql.db.url = "jdbc:h2:mem:tsql1;INIT=runscript from 'samples/slick-plainsql/src/main/resources/create-schema.sql'"

--- a/samples/slick-multidb/COPYING
+++ b/samples/slick-multidb/COPYING
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/samples/slick-multidb/LICENSE
+++ b/samples/slick-multidb/LICENSE
@@ -1,0 +1,8 @@
+Slick sample code by Slick contributors
+
+To the extent possible under law, the person who associated CC0 with
+Slick sample code has waived all copyright and related or neighboring rights
+to Slick sample code.
+
+You should have received a copy of the CC0 legalcode along with this
+work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/samples/slick-multidb/README
+++ b/samples/slick-multidb/README
@@ -1,0 +1,2 @@
+This sample project is part of the Slick documentation.
+See http://slick.lightbend.com/docs/ for details.

--- a/samples/slick-multidb/build.sbt
+++ b/samples/slick-multidb/build.sbt
@@ -1,0 +1,12 @@
+scalaVersion := "2.12.1"
+
+libraryDependencies ++= List(
+  "com.typesafe.slick" %% "slick" % "3.2.0",
+  "org.slf4j" % "slf4j-nop" % "1.7.10",
+  "com.h2database" % "h2" % "1.4.187",
+  "org.xerial" % "sqlite-jdbc" % "3.8.7"
+)
+
+scalacOptions += "-deprecation"
+
+fork in run := true

--- a/samples/slick-multidb/project/build.properties
+++ b/samples/slick-multidb/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/samples/slick-multidb/src/main/resources/application.conf
+++ b/samples/slick-multidb/src/main/resources/application.conf
@@ -1,0 +1,25 @@
+h2 = {
+  url = "jdbc:h2:mem:test1"
+  driver = org.h2.Driver
+  connectionPool = disabled
+  keepAliveConnection = true
+}
+
+sqlite = {
+  url = "jdbc:sqlite::memory:"
+  driver = org.sqlite.JDBC
+  connectionPool = disabled
+  keepAliveConnection = true
+}
+
+#--doc-h2_db
+h2_dc {
+  profile = "slick.jdbc.H2Profile$"
+  db {
+    url = "jdbc:h2:mem:test1"
+    driver = org.h2.Driver
+    connectionPool = disabled
+    keepAliveConnection = true
+  }
+}
+#--doc-h2_db

--- a/samples/slick-multidb/src/main/scala/Util.scala
+++ b/samples/slick-multidb/src/main/scala/Util.scala
@@ -1,0 +1,11 @@
+import java.sql.DriverManager
+import scala.collection.JavaConverters._
+
+object Util {
+  /** A helper function to unload all JDBC drivers so we don't leak memory */
+  def unloadDrivers {
+    DriverManager.getDrivers.asScala.foreach { d =>
+      DriverManager.deregisterDriver(d)
+    }
+  }
+}

--- a/samples/slick-multidb/src/main/scala/basic/DAO.scala
+++ b/samples/slick-multidb/src/main/scala/basic/DAO.scala
@@ -1,0 +1,35 @@
+import scala.language.higherKinds
+import slick.jdbc.JdbcProfile
+
+/** All database code goes into the DAO (data access object) class which
+  * is parameterized by a Slick profile that extends JdbcProfile.
+  */
+//#dao
+class DAO(val profile: JdbcProfile) {
+  // Import the Scala API from the profile
+  import profile.api._
+//#dao
+
+  class Props(tag: Tag) extends Table[(String, String)](tag, "PROPS") {
+    def key = column[String]("KEY", O.PrimaryKey)
+    def value = column[String]("VALUE")
+    def * = (key, value)
+  }
+  val props = TableQuery[Props]
+
+  /** Create the database schema */
+  def create: DBIO[Unit] =
+    props.schema.create
+
+  /** Insert a key/value pair */
+  def insert(k: String, v: String): DBIO[Int] =
+    props += (k, v)
+
+  /** Get the value for the given key */
+  def get(k: String): DBIO[Option[String]] =
+    (for(p <- props if p.key === k) yield p.value).result.headOption
+
+  /** Get the first element for a Query from this DAO */
+  def getFirst[M, U, C[_]](q: Query[M, U, C]): DBIO[U] =
+    q.result.head
+}

--- a/samples/slick-multidb/src/main/scala/basic/DAOHelper.scala
+++ b/samples/slick-multidb/src/main/scala/basic/DAOHelper.scala
@@ -1,0 +1,13 @@
+import scala.language.higherKinds
+
+/** Common functionality that needs to work with types from the DAO
+  * but in a DAO-independent way.
+  */
+//#daohelper
+class DAOHelper(val dao: DAO) {
+  import dao.profile.api._
+
+  def restrictKey[C[_]](s: String, q: Query[DAO#Props, _, C]) =
+    q.filter(_.key === s)
+}
+//#daohelper

--- a/samples/slick-multidb/src/main/scala/basic/MultiDBExample.scala
+++ b/samples/slick-multidb/src/main/scala/basic/MultiDBExample.scala
@@ -1,0 +1,41 @@
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+//#imports
+import slick.dbio.DBIO
+import slick.jdbc.JdbcBackend.Database
+//#imports
+import slick.jdbc.{H2Profile, SQLiteProfile}
+
+/** Run SLICK code with multiple profiles. */
+object MultiDBExample extends App {
+
+  //#run
+  def run(dao: DAO, db: Database): Future[Unit] = {
+    val h = new DAOHelper(dao)
+    println("Using profile " + dao.profile)
+  //#run
+    db.run(DBIO.seq(
+      dao.create,
+      dao.insert("foo", "bar"),
+      dao.get("foo").map(r => println("- Value for key 'foo': " + r)),
+      dao.get("baz").map(r => println("- Value for key 'baz': " + r)),
+      h.dao.getFirst(h.restrictKey("foo", dao.props)).map(r => println("- Using the helper: " + r))
+    ).withPinnedSession)
+  }
+
+  try {
+    //#create
+    val f = {
+      val h2db = Database.forConfig("h2")
+      run(new DAO(H2Profile), h2db).andThen { case _ => h2db.close }
+    }.flatMap { _ =>
+      val sqlitedb = Database.forConfig("sqlite")
+      run(new DAO(SQLiteProfile), sqlitedb).andThen { case _ => sqlitedb.close }
+    }
+    //#create
+
+    Await.result(f, Duration.Inf)
+  } finally Util.unloadDrivers
+}

--- a/samples/slick-multidb/src/main/scala/cake/DAL.scala
+++ b/samples/slick-multidb/src/main/scala/cake/DAL.scala
@@ -1,0 +1,10 @@
+import slick.jdbc.JdbcProfile
+
+/** The Data Access Layer contains all components and a profile */
+class DAL(val profile: JdbcProfile)
+      extends UserComponent with PictureComponent with ProfileComponent {
+  import profile.api._
+
+  def create =
+    (users.schema ++ pictures.schema).create
+}

--- a/samples/slick-multidb/src/main/scala/cake/MultiDBCakeExample.scala
+++ b/samples/slick-multidb/src/main/scala/cake/MultiDBCakeExample.scala
@@ -1,0 +1,49 @@
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import slick.jdbc.{H2Profile, SQLiteProfile}
+import slick.jdbc.JdbcBackend.Database
+
+/** Run Slick code with multiple profiles using the Cake pattern. */
+object MultiDBCakeExample extends App {
+
+  def run(dal: DAL, db: Database): Future[Unit] = {
+    import dal.profile.api._
+
+    println("Running test against " + dal.profile)
+    val dbio = for {
+      _ <- dal.create
+
+      // Creating our default picture
+      defaultPic <- dal.insert(Picture("http://pics/default")): DBIOAction[Picture, NoStream, Effect.All]
+      _ = println("- Inserted picture: " + defaultPic)
+
+      // Inserting users
+      u1 <- dal.insert(User("name1", defaultPic))
+      _ = println("- Inserted user: " + u1)
+      u2 <- dal.insert(User("name2", Picture("http://pics/2")))
+      _ = println("- Inserted user: " + u2)
+      u3 <- dal.insert(User("name3", defaultPic))
+      _ = println("- Inserted user: " + u3)
+      pictures <- dal.pictures.result
+      _ = println("- All pictures: " + pictures)
+      users <- dal.users.result
+      _ = println("- All users: " + users)
+    } yield ()
+    db.run(dbio.withPinnedSession)
+  }
+
+  try {
+    val f = {
+      val h2db = Database.forConfig("h2")
+      run(new DAL(H2Profile), h2db).andThen { case _ => h2db.close }
+    }.flatMap { _ =>
+      val sqlitedb = Database.forConfig("sqlite")
+      run(new DAL(SQLiteProfile), sqlitedb).andThen { case _ => sqlitedb.close }
+    }
+
+    Await.result(f, Duration.Inf)
+  } finally Util.unloadDrivers
+
+}

--- a/samples/slick-multidb/src/main/scala/cake/PictureComponent.scala
+++ b/samples/slick-multidb/src/main/scala/cake/PictureComponent.scala
@@ -1,0 +1,24 @@
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/** A Picture contains an ID and a URL pointing to an image file */
+case class Picture(url: String, id: Option[Int] = None)
+
+/** PictureComponent provides database definitions for Picture objects */
+//#outline
+trait PictureComponent { this: ProfileComponent =>
+  import profile.api._
+//#outline
+
+  class Pictures(tag: Tag) extends Table[Picture](tag, "PICTURES") {
+    def id = column[Option[Int]]("PIC_ID", O.PrimaryKey, O.AutoInc)
+    def url = column[String]("PIC_URL")
+    def * = (url, id) <> (Picture.tupled, Picture.unapply)
+  }
+
+  val pictures = TableQuery[Pictures]
+
+  private val picturesAutoInc = pictures returning pictures.map(_.id)
+
+  def insert(picture: Picture): DBIO[Picture] =
+    (picturesAutoInc += picture).map(id => picture.copy(id = id))
+}

--- a/samples/slick-multidb/src/main/scala/cake/ProfileComponent.scala
+++ b/samples/slick-multidb/src/main/scala/cake/ProfileComponent.scala
@@ -1,0 +1,6 @@
+import slick.jdbc.JdbcProfile
+
+/** The slice of the cake which provides the Slick profile */
+trait ProfileComponent {
+  val profile: JdbcProfile
+}

--- a/samples/slick-multidb/src/main/scala/cake/UserComponent.scala
+++ b/samples/slick-multidb/src/main/scala/cake/UserComponent.scala
@@ -1,0 +1,31 @@
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/** A User contains a name, picture and ID */
+case class User(name: String, picture: Picture, id: Option[Int] = None)
+
+/** UserComponent provides database definitions for User objects */
+//#outline
+trait UserComponent { this: ProfileComponent with PictureComponent =>
+  import profile.api._
+//#outline
+
+  class Users(tag: Tag) extends Table[(String, Int, Option[Int])](tag, "USERS") {
+    def id = column[Option[Int]]("USER_ID", O.PrimaryKey, O.AutoInc)
+    def name = column[String]("USER_NAME")
+    def pictureId = column[Int]("PIC_ID")
+    def * = (name, pictureId, id)
+  }
+  val users = TableQuery[Users]
+
+  private val usersAutoInc =
+    users.map(u => (u.name, u.pictureId)) returning users.map(_.id)
+
+  def insert(user: User): DBIO[User] = for {
+    //#insert
+    pic <-
+      if(user.picture.id.isEmpty) insert(user.picture)
+      else DBIO.successful(user.picture)
+    //#insert
+    id <- usersAutoInc += (user.name, pic.id.get)
+  } yield user.copy(picture = pic, id = id)
+}

--- a/samples/slick-multidb/src/main/scala/databaseconfig/SimpleExample.scala
+++ b/samples/slick-multidb/src/main/scala/databaseconfig/SimpleExample.scala
@@ -1,0 +1,39 @@
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import slick.basic.DatabaseConfig
+import slick.jdbc.JdbcProfile
+
+object SimpleExample extends App {
+
+  //#dc
+  val dc = DatabaseConfig.forConfig[JdbcProfile]("h2_dc")
+
+  // Import the JdbcProfile API from the configured profile
+  import dc.profile.api._
+  //#dc
+
+  class Props(tag: Tag) extends Table[(String, String)](tag, "PROPS") {
+    def key = column[String]("KEY", O.PrimaryKey)
+    def value = column[String]("VALUE")
+    def * = (key, value)
+  }
+  val props = TableQuery[Props]
+
+  def get(key: String): DBIO[Option[String]] =
+    props.filter(_.key === key).map(_.value).result.headOption
+
+  try {
+    // Initialize the Database
+    val db = dc.db
+    val f = db.run(DBIO.seq(
+      props.schema.create,
+      props += ("foo", "bar"),
+      get("foo").map(r => println("- Value for key 'foo': " + r)),
+      get("baz").map(r => println("- Value for key 'baz': " + r))
+    ).withPinnedSession)
+    val f2 = f andThen { case _ => db.close }
+    Await.result(f2, Duration.Inf)
+  } finally Util.unloadDrivers
+}

--- a/samples/slick-multidb/src/main/scala/native/CallNativeDBFunction.scala
+++ b/samples/slick-multidb/src/main/scala/native/CallNativeDBFunction.scala
@@ -1,0 +1,57 @@
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+import java.sql.Date
+
+import slick.jdbc.H2Profile.api._
+
+/** This example shows how to lift a native database function
+  * to Slick's query language.
+  */
+object CallNativeDBFunction extends App {
+
+  class SalesPerDay(tag: Tag) extends Table[(Date, Int)](tag, "SALES_PER_DAY") {
+    def day = column[Date]("DAY", O.PrimaryKey)
+    def count = column[Int]("COUNT")
+    def * = (day, count)
+  }
+  val salesPerDay = TableQuery[SalesPerDay]
+
+  val dayOfWeek = SimpleFunction.unary[Date, Int]("day_of_week")
+
+  val dayOfWeek2 = SimpleFunction[Int]("day_of_week")
+
+  def dayOfWeek3(c: Rep[Date]) = dayOfWeek2(Seq(c))
+
+  // Use the lifted function in a query to group by day of week
+  val q1 = for {
+    (dow, q) <- salesPerDay
+      .map(s => (dayOfWeek(s.day), s.count))
+      .groupBy(_._1)
+  } yield (dow, q.map(_._2).sum)
+
+  val db = Database.forConfig("h2")
+  val f = db.run(DBIO.seq(
+    salesPerDay.schema.create,
+    salesPerDay ++= Seq(
+      (Date.valueOf("2011-04-01"), 3),
+      (Date.valueOf("2011-04-02"), 8),
+      (Date.valueOf("2011-04-03"), 0),
+      (Date.valueOf("2011-04-04"), 2),
+      (Date.valueOf("2011-04-05"), 1),
+      (Date.valueOf("2011-04-06"), 1),
+      (Date.valueOf("2011-04-07"), 2),
+      (Date.valueOf("2011-04-08"), 5),
+      (Date.valueOf("2011-04-09"), 4),
+      (Date.valueOf("2011-04-10"), 0),
+      (Date.valueOf("2011-04-11"), 2)
+    ),
+    q1.result.map { r =>
+      println("Day of week (1 = Sunday) -> Sales:")
+      r.foreach { case (dow, sum) => println("  " + dow + "\t->\t" + sum) }
+    }
+  ))
+
+  Await.result(f, Duration.Inf)
+  db.close()
+}

--- a/samples/slick-plainsql/COPYING
+++ b/samples/slick-plainsql/COPYING
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/samples/slick-plainsql/LICENSE
+++ b/samples/slick-plainsql/LICENSE
@@ -1,0 +1,8 @@
+Slick sample code by Slick contributors
+
+To the extent possible under law, the person who associated CC0 with
+Slick sample code has waived all copyright and related or neighboring rights
+to Slick sample code.
+
+You should have received a copy of the CC0 legalcode along with this
+work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/samples/slick-plainsql/README
+++ b/samples/slick-plainsql/README
@@ -1,0 +1,2 @@
+This sample project is part of the Slick documentation.
+See http://slick.lightbend.com/docs/ for details.

--- a/samples/slick-plainsql/build.sbt
+++ b/samples/slick-plainsql/build.sbt
@@ -1,0 +1,15 @@
+scalaVersion := "2.12.1"
+
+libraryDependencies ++= List(
+  "com.typesafe.slick" %% "slick" % "3.2.0",
+  "org.slf4j" % "slf4j-nop" % "1.7.10",
+  "com.h2database" % "h2" % "1.4.187"
+)
+
+scalacOptions += "-deprecation"
+
+fork in run := true
+
+libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+
+unmanagedClasspath in Compile ++= (unmanagedResources in Compile).value

--- a/samples/slick-plainsql/project/build.properties
+++ b/samples/slick-plainsql/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/samples/slick-plainsql/src/main/resources/application.conf
+++ b/samples/slick-plainsql/src/main/resources/application.conf
@@ -1,0 +1,15 @@
+h2mem1 = {
+  url = "jdbc:h2:mem:test1"
+  driver = org.h2.Driver
+  connectionPool = disabled
+  keepAliveConnection = true
+}
+
+tsql {
+  driver = "slick.jdbc.H2Profile$"
+  db {
+    connectionPool = disabled
+    driver = "org.h2.Driver"
+    url = "jdbc:h2:mem:tsql1;INIT=runscript from 'src/main/resources/create-schema.sql'"
+  }
+}

--- a/samples/slick-plainsql/src/main/resources/create-schema.sql
+++ b/samples/slick-plainsql/src/main/resources/create-schema.sql
@@ -1,0 +1,11 @@
+create table suppliers(
+  id int not null primary key,
+  name varchar not null,
+  street varchar not null,
+  city varchar not null,
+  state varchar not null,
+  zip varchar not null);
+
+insert into suppliers values(101, 'Acme, Inc.', '99 Market Street', 'Groundsville', 'CA', '95199');
+insert into suppliers values(49, 'Superior Coffee', '1 Party Place', 'Mendocino', 'CA', '95460');
+insert into suppliers values(150, 'The High Ground', '100 Coffee Lane', 'Meadows', 'CA', '93966');

--- a/samples/slick-plainsql/src/main/scala/Interpolation.scala
+++ b/samples/slick-plainsql/src/main/scala/Interpolation.scala
@@ -1,0 +1,84 @@
+import slick.jdbc.H2Profile.api._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait Interpolation { this: PlainSQL.type =>
+
+  def createCoffees: DBIO[Int] =
+    sqlu"""create table coffees(
+      name varchar not null,
+      sup_id int not null,
+      price double not null,
+      sales int not null,
+      total int not null,
+      foreign key(sup_id) references suppliers(id))"""
+
+  def createSuppliers: DBIO[Int] =
+    sqlu"""create table suppliers(
+      id int not null primary key,
+      name varchar not null,
+      street varchar not null,
+      city varchar not null,
+      state varchar not null,
+      zip varchar not null)"""
+
+  def insertSuppliers: DBIO[Unit] = DBIO.seq(
+    // Insert some suppliers
+    sqlu"insert into suppliers values(101, 'Acme, Inc.', '99 Market Street', 'Groundsville', 'CA', '95199')",
+    sqlu"insert into suppliers values(49, 'Superior Coffee', '1 Party Place', 'Mendocino', 'CA', '95460')",
+    sqlu"insert into suppliers values(150, 'The High Ground', '100 Coffee Lane', 'Meadows', 'CA', '93966')"
+  )
+
+  def insertCoffees: DBIO[Unit] = {
+    def insert(c: Coffee): DBIO[Int] =
+      sqlu"insert into coffees values (${c.name}, ${c.supID}, ${c.price}, ${c.sales}, ${c.total})"
+
+    // Insert some coffees. The SQL statement is the same for all calls:
+    // "insert into coffees values (?, ?, ?, ?, ?)"
+    val inserts: Seq[DBIO[Int]] = Seq(
+      Coffee("Colombian", 101, 7.99, 0, 0),
+      Coffee("French_Roast", 49, 8.99, 0, 0),
+      Coffee("Espresso", 150, 9.99, 0, 0),
+      Coffee("Colombian_Decaf", 101, 8.99, 0, 0),
+      Coffee("French_Roast_Decaf", 49, 9.99, 0, 0)
+    ).map(insert)
+
+    val combined: DBIO[Seq[Int]] = DBIO.sequence(inserts)
+    combined.map(_.sum)
+  }
+
+  def printAll: DBIO[Unit] =
+    // Iterate through all coffees and output them
+    sql"select * from coffees".as[Coffee].map { cs =>
+      println("Coffees:")
+      for(c <- cs)
+        println("* " + c.name + "\t" + c.supID + "\t" + c.price + "\t" + c.sales + "\t" + c.total)
+    }
+
+  def namesByPrice(price: Double): DBIO[Seq[(String, String)]] = sql"""
+    select c.name, s.name
+    from coffees c, suppliers s
+    where c.price < $price and s.id = c.sup_id""".as[(String, String)]
+
+  def supplierById(id: Int): DBIO[Seq[Supplier]] =
+    sql"select * from suppliers where id = $id".as[Supplier]
+
+  def printParameterized: DBIO[Unit] = {
+    // Perform a join to retrieve coffee names and supplier names for
+    // all coffees costing less than $9.00
+    namesByPrice(9.0).flatMap { l2 =>
+      println("Parameterized StaticQuery:")
+      for (t <- l2)
+        println("* " + t._1 + " supplied by " + t._2)
+      supplierById(49).map(s => println(s"Supplier #49: $s"))
+    }
+  }
+
+  def coffeeByName(name: String): DBIO[Option[Coffee]] = {
+    val table = "coffees"
+    sql"select * from #$table where name = $name".as[Coffee].headOption
+  }
+
+  def deleteCoffee(name: String): DBIO[Int] =
+    sqlu"delete from coffees where name = $name"
+}

--- a/samples/slick-plainsql/src/main/scala/PlainSQL.scala
+++ b/samples/slick-plainsql/src/main/scala/PlainSQL.scala
@@ -1,0 +1,36 @@
+import scala.concurrent.{Future, Await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import slick.jdbc.H2Profile.api._
+
+/** A simple example that uses plain SQL queries against an in-memory
+  * H2 database. The example data comes from Oracle's JDBC tutorial at
+  * http://download.oracle.com/javase/tutorial/jdbc/basics/tables.html. */
+object PlainSQL extends App with Interpolation with Transfer {
+  val db = Database.forConfig("h2mem1")
+  try {
+    val f: Future[_] = {
+
+      val a: DBIO[Unit] = DBIO.seq(
+        createSuppliers,
+        createCoffees,
+        insertSuppliers,
+        insertCoffees,
+        printAll,
+        printParameterized,
+        coffeeByName("Colombian").map { s =>
+          println(s"Coffee Colombian: $s")
+        },
+        deleteCoffee("Colombian").map { rows =>
+          println(s"Deleted $rows rows")
+        },
+        coffeeByName("Colombian").map { s =>
+          println(s"Coffee Colombian: $s")
+        }
+      )
+      db.run(a)
+
+    }
+    Await.result(f, Duration.Inf)
+  } finally db.close
+}

--- a/samples/slick-plainsql/src/main/scala/Transfer.scala
+++ b/samples/slick-plainsql/src/main/scala/Transfer.scala
@@ -1,0 +1,15 @@
+import slick.jdbc.H2Profile.api._
+import slick.jdbc.GetResult
+
+/** The Data Transfer Objects for the PlainSQL app */
+trait Transfer { this: PlainSQL.type =>
+
+  // Case classes for our data
+  case class Supplier(id: Int, name: String, street: String, city: String, state: String, zip: String)
+  case class Coffee(name: String, supID: Int, price: Double, sales: Int, total: Int)
+
+  // Result set getters
+  implicit val getSupplierResult = GetResult(r => Supplier(r.nextInt, r.nextString, r.nextString,
+    r.nextString, r.nextString, r.nextString))
+  implicit val getCoffeeResult = GetResult(r => Coffee(r.<<, r.<<, r.<<, r.<<, r.<<))
+}

--- a/samples/slick-plainsql/src/main/scala/TypedSQL.scala
+++ b/samples/slick-plainsql/src/main/scala/TypedSQL.scala
@@ -1,0 +1,28 @@
+import slick.driver.JdbcProfile
+
+import scala.concurrent.{Future, Await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import slick.backend.{DatabaseConfig, StaticDatabaseConfig}
+
+@StaticDatabaseConfig("#tsql")
+object TypedSQL extends App {
+  val dc = DatabaseConfig.forAnnotation[JdbcProfile]
+  import dc.driver.api._
+
+  def getSuppliers(id: Int): DBIO[Seq[(Int, String, String, String, String, String)]] =
+    tsql"select * from suppliers where id > $id"
+
+  val db = dc.db
+  try {
+
+    val a: DBIO[Unit] =
+      getSuppliers(50).map { s =>
+        println("All suppliers > 50:")
+        s.foreach(println)
+      }
+
+    val f: Future[Unit] = db.run(a)
+    Await.result(f, Duration.Inf)
+  } finally db.close
+}

--- a/samples/slick-testkit-example/COPYING
+++ b/samples/slick-testkit-example/COPYING
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/samples/slick-testkit-example/LICENSE
+++ b/samples/slick-testkit-example/LICENSE
@@ -1,0 +1,8 @@
+Slick sample code by Slick contributors
+
+To the extent possible under law, the person who associated CC0 with
+Slick sample code has waived all copyright and related or neighboring rights
+to Slick sample code.
+
+You should have received a copy of the CC0 legalcode along with this
+work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/samples/slick-testkit-example/README
+++ b/samples/slick-testkit-example/README
@@ -1,0 +1,2 @@
+This sample project is part of the Slick documentation.
+See http://slick.lightbend.com/docs/ for details.

--- a/samples/slick-testkit-example/build.sbt
+++ b/samples/slick-testkit-example/build.sbt
@@ -1,0 +1,19 @@
+scalaVersion := "2.12.1"
+
+libraryDependencies ++= List(
+  "com.typesafe.slick" %% "slick" % "3.2.0",
+  "com.typesafe.slick" %% "slick-testkit" % "3.2.0" % "test",
+  "com.novocode" % "junit-interface" % "0.11" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
+  "postgresql" % "postgresql" % "9.1-901.jdbc4" % "test"
+)
+
+scalacOptions += "-deprecation"
+
+parallelExecution in Test := false
+
+logBuffered := false
+
+fork in run := true
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a")

--- a/samples/slick-testkit-example/project/build.properties
+++ b/samples/slick-testkit-example/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/samples/slick-testkit-example/src/main/scala/MyPostgresProfile.scala
+++ b/samples/slick-testkit-example/src/main/scala/MyPostgresProfile.scala
@@ -1,0 +1,255 @@
+//#outline
+package com.example
+
+//#outline
+import java.util.UUID
+import java.sql.{PreparedStatement, ResultSet}
+
+import scala.concurrent.ExecutionContext
+
+import slick.ast._
+import slick.ast.Util._
+import slick.basic.Capability
+import slick.compiler.{Phase, CompilerState}
+import slick.dbio._
+import slick.jdbc._
+import slick.jdbc.meta.{MIndexInfo, MColumn, MTable}
+import slick.lifted._
+import slick.model.Model
+import slick.relational.RelationalProfile
+import slick.util.ConstArray
+import slick.util.MacroSupport.macroSupportInterpolation
+
+/** Slick profile for PostgreSQL.
+  *
+  * This profile implements [[slick.jdbc.JdbcProfile]]
+  * ''without'' the following capabilities:
+  *
+  * <ul>
+  *   <li>[[slick.jdbc.JdbcCapabilities.insertOrUpdate]]:
+  *     InsertOrUpdate operations are emulated on the server side with a single
+  *     JDBC statement executing multiple server-side statements in a transaction.
+  *     This is faster than a client-side emulation but may still fail due to
+  *     concurrent updates. InsertOrUpdate operations with `returning` are
+  *     emulated on the client side.</li>
+  *   <li>[[slick.jdbc.JdbcCapabilities.nullableNoDefault]]:
+  *     Nullable columns always have NULL as a default according to the SQL
+  *     standard. Consequently Postgres treats no specifying a default value
+  *     just as specifying NULL and reports NULL as the default value.
+  *     Some other dbms treat queries with no default as NULL default, but
+  *     distinguish NULL from no default value in the meta data.</li>
+  *   <li>[[slick.jdbc.JdbcCapabilities.supportsByte]]:
+  *     Postgres doesn't have a corresponding type for Byte.
+  *     SMALLINT is used instead and mapped to Short in the Slick model.</li>
+  * </ul>
+  *
+  * Notes:
+  *
+  * <ul>
+  *   <li>[[slick.relational.RelationalCapabilities.typeBlob]]:
+  *   The default implementation of the <code>Blob</code> type uses the
+  *   database type <code>lo</code> and the stored procedure
+  *   <code>lo_manage</code>, both of which are provided by the "lo"
+  *   extension in PostgreSQL.</li>
+  * </ul>
+  */
+//#outline
+trait MyPostgresProfile extends JdbcProfile {
+  // ...
+//#outline
+
+  override protected def computeCapabilities: Set[Capability] = (super.computeCapabilities
+    - JdbcCapabilities.insertOrUpdate
+    - JdbcCapabilities.nullableNoDefault
+    - JdbcCapabilities.supportsByte
+    )
+
+  class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
+    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable) {
+      override def schema = super.schema.filter(_ != "public") // remove default schema
+    }
+    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta) {
+      val NumericPattern = "^['(]?(-?[0-9]+\\.?[0-9]*)[')]?(?:::(?:numeric|bigint|integer))?".r
+      val TextPattern = "^'(.*)'::(?:bpchar|character varying|text)".r
+      val UUIDPattern = "^'(.*)'::uuid".r
+      override def default = meta.columnDef.map((_,tpe)).collect{
+        case ("true","Boolean")  => Some(Some(true))
+        case ("false","Boolean") => Some(Some(false))
+        case (TextPattern(str),"String") => Some(Some(str))
+        case ("NULL::bpchar", "String") => Some(None)
+        case (TextPattern(str),"Char") => str.length match {
+          case 0 => Some(Some(' ')) // Default to one space, as the char will be space padded anyway
+          case 1 => Some(Some(str.head))
+          case _ => None // This is invalid, so let's not supply any default
+        }
+        case ("NULL::bpchar", "Char") => Some(None)
+        case (NumericPattern(v),"Short") => Some(Some(v.toShort))
+        case (NumericPattern(v),"Int") => Some(Some(v.toInt))
+        case (NumericPattern(v),"Long") => Some(Some(v.toLong))
+        case (NumericPattern(v),"Float") => Some(Some(v.toFloat))
+        case (NumericPattern(v),"Double") => Some(Some(v.toDouble))
+        case (NumericPattern(v), "scala.math.BigDecimal") => Some(Some(BigDecimal(s"$v")))
+        case (UUIDPattern(v),"java.util.UUID") => Some(Some(java.util.UUID.fromString(v)))
+        case (_,"java.util.UUID") => None // The UUID is generated through a function - treat it as if there was no default.
+      }.getOrElse{
+        val d = super.default
+        if(meta.nullable == Some(true) && d == None){
+          Some(None)
+        } else d
+      }
+      override def length: Option[Int] = {
+        val l = super.length
+        if(tpe == "String" && varying && l == Some(2147483647)) None
+        else l
+      }
+      override def tpe = meta.typeName match {
+        case "bytea" => "Array[Byte]"
+        case "lo" if meta.sqlType == java.sql.Types.DISTINCT => "java.sql.Blob"
+        case "uuid" => "java.util.UUID"
+        case _ => super.tpe
+      }
+    }
+    override def createIndexBuilder(tableBuilder: TableBuilder, meta: Seq[MIndexInfo]): IndexBuilder = new IndexBuilder(tableBuilder, meta) {
+      override def columns = super.columns.map(_.stripPrefix("\"").stripSuffix("\""))
+    }
+  }
+
+  override def createModelBuilder(tables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext): JdbcModelBuilder =
+    new ModelBuilder(tables, ignoreInvalidDefaults)
+
+  override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] =
+    MTable.getTables(None, None, None, Some(Seq("TABLE")))
+
+  override val columnTypes = new JdbcTypes
+  override protected def computeQueryCompiler = super.computeQueryCompiler - Phase.rewriteDistinct
+  override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new QueryBuilder(n, state)
+  override def createUpsertBuilder(node: Insert): InsertBuilder = new UpsertBuilder(node)
+  override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new TableDDLBuilder(table)
+  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder = new ColumnDDLBuilder(column)
+  override protected lazy val useServerSideUpsert = true
+  override protected lazy val useTransactionForUpsert = true
+  override protected lazy val useServerSideUpsertReturning = false
+
+  override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
+    case java.sql.Types.VARCHAR =>
+      val size = sym.flatMap(_.findColumnOption[RelationalProfile.ColumnOption.Length])
+      size.fold("VARCHAR")(l => if(l.varying) s"VARCHAR(${l.length})" else s"CHAR(${l.length})")
+    case java.sql.Types.BLOB => "lo"
+    case java.sql.Types.DOUBLE => "DOUBLE PRECISION"
+    /* PostgreSQL does not have a TINYINT type, so we use SMALLINT instead. */
+    case java.sql.Types.TINYINT => "SMALLINT"
+    case _ => super.defaultSqlTypeName(tmd, sym)
+  }
+
+  class QueryBuilder(tree: Node, state: CompilerState) extends super.QueryBuilder(tree, state) {
+    override protected val concatOperator = Some("||")
+    override protected val quotedJdbcFns = Some(Vector(Library.Database, Library.User))
+
+    override protected def buildSelectModifiers(c: Comprehension): Unit = (c.distinct, c.select) match {
+      case (Some(ProductNode(onNodes)), Pure(ProductNode(selNodes), _)) if onNodes.nonEmpty =>
+        def eligible(a: ConstArray[Node]) = a.forall {
+          case _: PathElement => true
+          case _: LiteralNode => true
+          case _: QueryParameter => true
+          case _ => false
+        }
+        if(eligible(onNodes) && eligible(selNodes) &&
+          onNodes.iterator.collect[List[TermSymbol]] { case FwdPath(ss) => ss }.toSet ==
+            selNodes.iterator.collect[List[TermSymbol]] { case FwdPath(ss) => ss }.toSet
+        ) b"distinct " else super.buildSelectModifiers(c)
+      case _ => super.buildSelectModifiers(c)
+    }
+
+    override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {
+      case (Some(t), Some(d)) => b"\nlimit $t offset $d"
+      case (Some(t), None   ) => b"\nlimit $t"
+      case (None,    Some(d)) => b"\noffset $d"
+      case _ =>
+    }
+
+    override def expr(n: Node, skipParens: Boolean = false) = n match {
+      case Library.UCase(ch) => b"upper($ch)"
+      case Library.LCase(ch) => b"lower($ch)"
+      case Library.IfNull(ch, d) => b"coalesce($ch, $d)"
+      case Library.NextValue(SequenceNode(name)) => b"nextval('$name')"
+      case Library.CurrentValue(SequenceNode(name)) => b"currval('$name')"
+      case Library.CurrentDate() => b"current_date"
+      case Library.CurrentTime() => b"current_time"
+      case _ => super.expr(n, skipParens)
+    }
+  }
+
+  class UpsertBuilder(ins: Insert) extends super.UpsertBuilder(ins) {
+    override def buildInsert: InsertBuilderResult = {
+      val update = "update " + tableName + " set " + softNames.map(n => s"$n=?").mkString(",") + " where " + pkNames.map(n => s"$n=?").mkString(" and ")
+      val nonAutoIncNames = nonAutoIncSyms.map(fs => quoteIdentifier(fs.name)).mkString(",")
+      val nonAutoIncVars = nonAutoIncSyms.map(_ => "?").mkString(",")
+      val cond = pkNames.map(n => s"$n=?").mkString(" and ")
+      val insert = s"insert into $tableName ($nonAutoIncNames) select $nonAutoIncVars where not exists (select 1 from $tableName where $cond)"
+      new InsertBuilderResult(table, s"$update; $insert", ConstArray.from(softSyms ++ pkSyms))
+    }
+
+    override def transformMapping(n: Node) = reorderColumns(n, softSyms ++ pkSyms ++ nonAutoIncSyms.toSeq ++ pkSyms)
+  }
+
+  class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {
+    override def createPhase1 = super.createPhase1 ++ columns.flatMap {
+      case cb: ColumnDDLBuilder => cb.createLobTrigger(table.tableName)
+    }
+    override def dropPhase1 = {
+      val dropLobs = columns.flatMap {
+        case cb: ColumnDDLBuilder => cb.dropLobTrigger(table.tableName)
+      }
+      if(dropLobs.isEmpty) super.dropPhase1
+      else Seq("delete from "+quoteIdentifier(table.tableName)) ++ dropLobs ++ super.dropPhase1
+    }
+  }
+
+  class ColumnDDLBuilder(column: FieldSymbol) extends super.ColumnDDLBuilder(column) {
+    override def appendColumn(sb: StringBuilder) {
+      sb append quoteIdentifier(column.name) append ' '
+      if(autoIncrement && !customSqlType) {
+        sb append (if(sqlType.toUpperCase == "BIGINT") "BIGSERIAL" else "SERIAL")
+      } else appendType(sb)
+      autoIncrement = false
+      appendOptions(sb)
+    }
+
+    def lobTrigger(tname: String) =
+      quoteIdentifier(tname+"__"+quoteIdentifier(column.name)+"_lob")
+
+    def createLobTrigger(tname: String): Option[String] =
+      if(sqlType == "lo") Some(
+        "create trigger "+lobTrigger(tname)+" before update or delete on "+
+          quoteIdentifier(tname)+" for each row execute procedure lo_manage("+quoteIdentifier(column.name)+")"
+      ) else None
+
+    def dropLobTrigger(tname: String): Option[String] =
+      if(sqlType == "lo") Some(
+        "drop trigger "+lobTrigger(tname)+" on "+quoteIdentifier(tname)
+      ) else None
+  }
+
+  class JdbcTypes extends super.JdbcTypes {
+    override val byteArrayJdbcType = new ByteArrayJdbcType
+    override val uuidJdbcType = new UUIDJdbcType
+
+    class ByteArrayJdbcType extends super.ByteArrayJdbcType {
+      override val sqlType = java.sql.Types.BINARY
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "BYTEA"
+    }
+
+    class UUIDJdbcType extends super.UUIDJdbcType {
+      override def sqlTypeName(sym: Option[FieldSymbol]) = "UUID"
+      override def setValue(v: UUID, p: PreparedStatement, idx: Int) = p.setObject(idx, v, sqlType)
+      override def getValue(r: ResultSet, idx: Int) = r.getObject(idx).asInstanceOf[UUID]
+      override def updateValue(v: UUID, r: ResultSet, idx: Int) = r.updateObject(idx, v)
+      override def valueToSQLLiteral(value: UUID) = "'" + value + "'"
+      override def hasLiteralForm = true
+    }
+  }
+//#outline
+}
+
+object MyPostgresProfile extends MyPostgresProfile
+//#outline

--- a/samples/slick-testkit-example/src/test/resources/logback-test.xml
+++ b/samples/slick-testkit-example/src/test/resources/logback-test.xml
@@ -1,0 +1,54 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>*** \(%logger{30}\)%green(%X{debugId}) %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="${log.root:-info}">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="slick.basic.BasicBackend.action"          level="${log.action:-info}" />
+    <logger name="slick.basic.BasicBackend.stream"          level="${log.stream:-info}" />
+    <logger name="slick.compiler"                           level="${log.qcomp:-info}" />
+    <logger name="slick.compiler.QueryCompiler"             level="${log.qcomp.phases:-inherited}" />
+    <logger name="slick.compiler.QueryCompilerBenchmark"    level="${log.qcomp.bench:-inherited}" />
+    <logger name="slick.compiler.Inline"                    level="${log.qcomp.inline:-inherited}" />
+    <logger name="slick.compiler.AssignUniqueSymbols"       level="${log.qcomp.assignUniqueSymbols:-inherited}" />
+    <logger name="slick.compiler.InferTypes"                level="${log.qcomp.inferTypes:-inherited}" />
+    <logger name="slick.compiler.ExpandTables"              level="${log.qcomp.expandTables:-inherited}" />
+    <logger name="slick.compiler.EmulateOuterJoins"         level="${log.qcomp.emulateOuterJoins:-inherited}" />
+    <logger name="slick.compiler.ForceOuterBinds"           level="${log.qcomp.forceOuterBinds:-inherited}" />
+    <logger name="slick.compiler.RemoveMappedTypes"         level="${log.qcomp.removeMappedTypes:-inherited}" />
+    <logger name="slick.compiler.CreateResultSetMapping"    level="${log.qcomp.createResultSetMapping:-inherited}" />
+    <logger name="slick.compiler.ExpandSums"                level="${log.qcomp.expandSums:-inherited}" />
+    <logger name="slick.compiler.ExpandRecords"             level="${log.qcomp.expandRecords:-inherited}" />
+    <logger name="slick.compiler.ExpandConditionals"        level="${log.qcomp.expandConditionals:-inherited}" />
+    <logger name="slick.compiler.FlattenProjections"        level="${log.qcomp.flattenProjections:-inherited}" />
+    <logger name="slick.compiler.CreateAggregates"          level="${log.qcomp.createAggregates:-inherited}" />
+    <logger name="slick.compiler.RewriteJoins"              level="${log.qcomp.rewriteJoins:-inherited}" />
+    <logger name="slick.compiler.RemoveTakeDrop"            level="${log.qcomp.removeTakeDrop:-inherited}" />
+    <logger name="slick.compiler.ResolveZipJoins"           level="${log.qcomp.resolveZipJoins:-inherited}" />
+    <logger name="slick.compiler.HoistClientOps"            level="${log.qcomp.hoistClientOps:-inherited}" />
+    <logger name="slick.compiler.ReorderOperations"         level="${log.qcomp.reorderOperations:-inherited}" />
+    <logger name="slick.compiler.MergeToComprehensions"     level="${log.qcomp.mergeToComprehensions:-inherited}" />
+    <logger name="slick.compiler.OptimizeScalar"            level="${log.qcomp.optimizeScalar:-inherited}" />
+    <logger name="slick.compiler.FixRowNumberOrdering"      level="${log.qcomp.fixRowNumberOrdering:-inherited}" />
+    <logger name="slick.compiler.PruneProjections"          level="${log.qcomp.pruneProjections:-inherited}" />
+    <logger name="slick.compiler.RewriteDistinct"           level="${log.qcomp.rewriteDistinct:-inherited}" />
+    <logger name="slick.compiler.RewriteBooleans"           level="${log.qcomp.rewriteBooleans:-inherited}" />
+    <logger name="slick.compiler.SpecializeParameters"      level="${log.qcomp.specializeParameters:-inherited}" />
+    <logger name="slick.compiler.CodeGen"                   level="${log.qcomp.codeGen:-inherited}" />
+    <logger name="slick.compiler.RemoveFieldNames"          level="${log.qcomp.removeFieldNames:-inherited}" />
+    <logger name="slick.compiler.InsertCompiler"            level="${log.qcomp.insertCompiler:-inherited}" />
+    <logger name="slick.compiler.VerifyTypes"               level="${log.qcomp.verifyTypes:-inherited}" />
+    <logger name="slick.jdbc.DriverDataSource"              level="${log.jdbc.driver:-info}" />
+    <logger name="slick.jdbc.JdbcBackend.statement"         level="${log.jdbc.statement:-info}" />
+    <logger name="slick.jdbc.JdbcBackend.parameter"         level="${log.jdbc.parameter:-info}" />
+    <logger name="slick.jdbc.JdbcBackend.benchmark"         level="${log.jdbc.bench:-info}" />
+    <logger name="slick.jdbc.StatementInvoker.result"       level="${log.jdbc.result:-info}" />
+    <logger name="slick.jdbc.JdbcModelBuilder"              level="${log.createModel:-info}" />
+    <logger name="slick.memory.HeapBackend"                 level="${log.heap:-inherited}" />
+    <logger name="slick.memory.QueryInterpreter"            level="${log.interpreter:-inherited}" />
+    <logger name="slick.relational.ResultConverterCompiler" level="${log.resultConverter:-inherited}" />
+    <logger name="slick.util.AsyncExecutor"                 level="${log.asyncExecutor:-inherited}" />
+</configuration>

--- a/samples/slick-testkit-example/src/test/resources/testkit-reference.conf
+++ b/samples/slick-testkit-example/src/test/resources/testkit-reference.conf
@@ -1,0 +1,15 @@
+mypostgres {
+  baseURL = "jdbc:postgresql:"
+  user = postgres
+  adminDB = postgres
+  create = [
+    CREATE TABLESPACE slick_test LOCATION '${testkit.absTestDir}'
+    CREATE DATABASE ${testDB} "TEMPLATE = template0 TABLESPACE slick_test"
+  ]
+  postCreate = "create extension lo"
+  drop = [
+    DROP DATABASE IF EXISTS ${testDB}
+    DROP TABLESPACE IF EXISTS slick_test
+  ]
+  driver = org.postgresql.Driver
+}

--- a/samples/slick-testkit-example/src/test/scala/MyPostgresTest.scala
+++ b/samples/slick-testkit-example/src/test/scala/MyPostgresTest.scala
@@ -1,0 +1,30 @@
+package com.example
+
+import org.junit.runner.RunWith
+import com.typesafe.slick.testkit.util.{ExternalJdbcTestDB, TestDB, ProfileTest, Testkit}
+import scala.concurrent.ExecutionContext
+import slick.jdbc.ResultSetAction
+import slick.dbio.DBIO
+import slick.jdbc.GetResult._
+
+//#outline
+@RunWith(classOf[Testkit])
+class MyPostgresTest extends ProfileTest(MyPostgresTest.tdb)
+
+object MyPostgresTest {
+  //#tdb
+  def tdb = new ExternalJdbcTestDB("mypostgres") {
+  //#tdb
+    val profile = MyPostgresProfile
+    override def localTables(implicit ec: ExecutionContext): DBIO[Vector[String]] =
+      ResultSetAction[(String,String,String, String)](_.conn.getMetaData().getTables("", "public", null, null)).map { ts =>
+        ts.filter(_._4.toUpperCase == "TABLE").map(_._3).sorted
+      }
+    override def localSequences(implicit ec: ExecutionContext): DBIO[Vector[String]] =
+      ResultSetAction[(String,String,String, String)](_.conn.getMetaData().getTables("", "public", null, null)).map { ts =>
+        ts.filter(_._4.toUpperCase == "SEQUENCE").map(_._3).sorted
+      }
+    override def capabilities = super.capabilities - TestDB.capabilities.jdbcMetaGetFunctions
+  }
+}
+//#outline

--- a/samples/slick-testkit-example/test-dbs/testkit.conf
+++ b/samples/slick-testkit-example/test-dbs/testkit.conf
@@ -1,0 +1,8 @@
+# Enable the tests for mypostgres:
+mypostgres.enabled = true
+
+# Set the user name (default: "postgres")
+mypostgres.user = "postgres"
+
+# Set the password (default: no password)
+mypostgres.password = null

--- a/slick/src/main/scala/slick/basic/DatabaseConfig.scala
+++ b/slick/src/main/scala/slick/basic/DatabaseConfig.scala
@@ -124,7 +124,7 @@ object DatabaseConfig {
       else (s.substring(0, s.length-f.length-1), uri.getFragment)
     }
     val root =
-      if(base eq null) ConfigFactory.load()
+      if(base eq null) ConfigFactory.load(classLoader)
       else ConfigFactory.parseURL(new URL(base)).resolve()
     forConfig[P](path, root, classLoader)
   }

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -282,9 +282,10 @@ trait JdbcBackend extends RelationalBackend {
       * @param classLoader The ClassLoader to use to load any custom classes from. The default is to
       *                    try the context ClassLoader first and fall back to Slick's ClassLoader.
       */
-    def forConfig(path: String, config: Config = ConfigFactory.load(), driver: Driver = null,
+    def forConfig(path: String, config: Config = null, driver: Driver = null,
                   classLoader: ClassLoader = ClassLoaderUtil.defaultClassLoader): Database = {
-      val usedConfig = if(path.isEmpty) config else config.getConfig(path)
+      val initializedConfig = if(config eq null) ConfigFactory.load(classLoader) else config
+      val usedConfig = if(path.isEmpty) initializedConfig else initializedConfig.getConfig(path)
       val source = JdbcDataSource.forConfig(usedConfig, driver, path, classLoader)
       val poolName = usedConfig.getStringOr("poolName", path)
       val numThreads = usedConfig.getIntOr("numThreads", 20)


### PR DESCRIPTION
We can use Lightbend’s Example Code Service to make pre-packaged zip
files available for download. We need to move away from Activator
because it will be shut down soon.

I updated the sample code for 3.2 and tried to integrate the tutorials
back into the manual. Some more polishing could be done in order to
retire FirstExample.scala and PlainSQL.scala from doc/code and take
all snippets on gettingstarted.md and sql.md from the sample projects.