### PR TITLE
Do not pass null to DatabaseMetaData.getTables

### DIFF
--- a/slick/src/main/scala/slick/jdbc/meta/MTable.scala
+++ b/slick/src/main/scala/slick/jdbc/meta/MTable.scala
@@ -30,5 +30,5 @@ object MTable {
       else MTable(MQName.from(r), r.<<, r.<<, None, None, None)
   }
   def getTables(namePattern: String): BasicStreamingAction[Vector[MTable], MTable, Effect.Read] = getTables(Some(""), Some(""), Some(namePattern), None)
-  def getTables: BasicStreamingAction[Vector[MTable], MTable, Effect.Read] = getTables(Some(""), Some(""), None, None)
+  def getTables: BasicStreamingAction[Vector[MTable], MTable, Effect.Read] = getTables(Some(""), Some(""), Some("%"), None)
 }


### PR DESCRIPTION
This uses "%" as a default value instead of null.

According to the API documentation for DatabaseMetaData:

> Some DatabaseMetaData methods take arguments that are String patterns.
> These arguments all have names such as fooPattern. Within a pattern
> String, "%" means match any substring of 0 or more characters, and "_"
> means match any one character.

Fixes #1692 

Another possible solution would be to change the no-arg version of `MTable.getTables` to pass `Some("%")`. That would retain the ability to explicitly pass `None` to the full method if you do want to use `null` for some reason, but I thought that the solution provided would be a more intuitive approach. Let me know if you'd like me to do it the other way.