### PR TITLE
Add support for postgresql as an alternative to DSN scheme

### DIFF
--- a/common-test-resources/application.conf
+++ b/common-test-resources/application.conf
@@ -57,6 +57,18 @@ databaseUrl {
   }
 }
 
+// Test alternative dsn for postgres
+altDatabaseUrl {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "slick.test.jdbc.MockDriver"
+    url = "postgresql://user:pass@host/dbname"
+    properties = {
+      foo = bar
+    }
+  }
+}
+
 distrib1 {
   profile = "slick.jdbc.H2Profile$"
   db {

--- a/doc/code/application.conf
+++ b/doc/code/application.conf
@@ -39,3 +39,13 @@ databaseUrl {
   }
 }
 //#dburl
+
+//#altdburl
+altDatabaseUrl {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "org.postgresql.Driver"
+    url = "postgresql://user:pass@host/dbname"
+  }
+}
+//#altdburl

--- a/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
@@ -6,7 +6,7 @@ package slick.jdbc
   */
 class DatabaseUrlDataSource extends DriverDataSource(null) {
 
-  private val PostgresFullUrl = "^postgres://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
+  private val PostgresFullUrl = "^(?:postgres|postgresql)://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
   private val MysqlFullUrl = "^mysql://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
   private val MysqlCustomProperties = ".*\\?(.*)".r
 


### PR DESCRIPTION
I've signed the CLA on lightbend under my github username.

---

This PR adds support for `postgresql` as an alternative for the existing `postgres` scheme. Both should map to the same jdbc setup.

Rationale for adding this? Some internal PaaS systems use `postgresql` as the scheme - crappy, I know - for legacy reasons. IIRC SQLAlchemy, a popular ORM for python, only supports this scheme, instead of the more compact, Heroku-championed version. Adding support for this scheme will allow easier adoption of Slick in certain legacy environments.

Not sure how to test this. I added what I *think* are tests for this functionality, but I didn't see anything in the contributing doc for running tests.

Happy to make any changes the maintainers think are necessary :)