### PR TITLE
When varchar length is unspecified, default to longvarchar in hsqldb

### DIFF
--- a/slick/src/main/scala/slick/jdbc/HsqldbProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/HsqldbProfile.scala
@@ -1,3 +1,4 @@
+
 package slick.jdbc
 
 import java.sql.Types
@@ -64,6 +65,13 @@ trait HsqldbProfile extends JdbcProfile {
   override protected lazy val useServerSideUpsertReturning = false
 
   override val scalarFrom = Some("(VALUES (0))")
+
+  override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
+    case java.sql.Types.VARCHAR =>
+      val size = sym.flatMap(_.findColumnOption[RelationalProfile.ColumnOption.Length])
+      size.fold("LONGVARCHAR")(l => if(l.varying) s"VARCHAR(${l.length})" else s"CHAR(${l.length})")
+    case _ => super.defaultSqlTypeName(tmd, sym)
+  }
 
   class QueryBuilder(tree: Node, state: CompilerState) extends super.QueryBuilder(tree, state) {
     override protected val concatOperator = Some("||")


### PR DESCRIPTION
Using `LONGVARCHAR` is roughly equivalent to using `VARCHAR` with no length argument or `TEXT` type in postgres. When length is unspecified, this is more reasonable and flexible than the default `VARCHAR(254)`
 
See hsqldb types here: http://hsqldb.org/doc/guide/sqlgeneral-chapt.html#sgc_char_types

