### PR TITLE
Place each node of a union in parentheses

### DIFF
--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -114,6 +114,9 @@ mysql {
   create = CREATE DATABASE ${testDB}
   drop = DROP DATABASE IF EXISTS ${testDB}
   driver = com.mysql.jdbc.Driver
+  testClasses = ${testkit.testClasses} [
+    ${testkit.testPackage}.MySQLExtraTests
+  ]
 }
 
 oracle {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MySQLExtraTests.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MySQLExtraTests.scala
@@ -1,0 +1,67 @@
+package com.typesafe.slick.testkit.tests
+
+import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB, RelationalTestDB}
+import slick.jdbc.MySQLProfile
+
+class MySQLExtraTests extends AsyncTest[JdbcTestDB] {
+  lazy val mysqlProfile = tdb.profile.asInstanceOf[MySQLProfile]
+
+  import mysqlProfile.api._
+
+  class Managers(tag: Tag) extends Table[(Int, String, String)](tag, "managers") {
+    def id = column[Int]("id")
+
+    def name = column[String]("name")
+
+    def department = column[String]("department")
+
+    def * = (id, name, department)
+  }
+
+  lazy val managers = TableQuery[Managers]
+
+  class Employees(tag: Tag) extends Table[(Int, String, Int)](tag, "employees") {
+    def id = column[Int]("id")
+
+    def name = column[String]("name2")
+
+    def manager = column[Int]("manager")
+
+    def * = (id, name, manager)
+
+    // A convenience method for selecting employees by department
+    def departmentIs(dept: String) = manager in managers.filter(_.department === dept).map(_.id)
+  }
+
+  lazy val employees = TableQuery[Employees]
+
+  def testLimitWithUnion = {
+    val q1 = for (m <- managers drop 1 take 2) yield (m.id, m.name)
+    val q2 = for (e <- employees drop 1 take 3) yield (e.id, e.name)
+    val q3 = q1 union q2
+    (for {
+      _ <- (managers.schema ++ employees.schema).create
+      _ <- managers ++= Seq((1, "Peter", "HR"), (2, "Amy", "IT"), (3, "Steve", "IT"))
+      _ <- employees ++= Seq((4, "Leonard", 2), (5, "Jennifer", 1), (6, "Tom", 1), (7, "Ben", 1), (8, "Greg", 3))
+      _ <- mark("q1", q1.result).map(r => r.toSet shouldBe Set((2, "Amy"), (3, "Steve")))
+      _ <- mark("q2", q2.result).map(r => r.toSet shouldBe Set((5, "Jennifer"), (6, "Tom"), (7, "Ben")))
+      _ <- mark("q3", q3.result).map(_ shouldBe Vector((2, "Amy"), (3, "Steve"), (5, "Jennifer"), (6, "Tom"), (7, "Ben")))
+    } yield ()) andFinally (managers.schema ++ employees.schema).drop
+  }
+
+  def testOrderByWithUnion = {
+    val q1 = for (m <- managers sortBy (_.name)) yield (m.id, m.name)
+    val q2 = for (e <- employees sortBy (_.name)) yield (e.id, e.name)
+    val q3 = (q1 ++ q2) sortBy (_._2)
+    (for {
+      _ <- (managers.schema ++ employees.schema).create
+      _ <- managers ++= Seq((1, "Peter", "HR"), (2, "Amy", "IT"), (3, "Steve", "IT"))
+      _ <- employees ++= Seq((4, "Leonard", 2), (5, "Jennifer", 1), (6, "Tom", 1), (7, "Ben", 1), (8, "Greg", 3))
+      _ <- mark("q1", q1.result).map(r => r.toSet shouldBe Set((2, "Amy"), (1, "Peter"), (3, "Steve")))
+      _ <- mark("q2", q2.result).map(r => r.toSet shouldBe Set((7, "Ben"), (8, "Greg"), (5, "Jennifer"), (4, "Leonard"), (6, "Tom")))
+      _ <- mark("q3", q3.result).map(_ shouldBe Vector((2, "Amy"), (7, "Ben"), (8, "Greg"),
+        (5, "Jennifer"), (4, "Leonard"), (1, "Peter"), (3, "Steve"), (6, "Tom")
+      ))
+    } yield ()) andFinally (managers.schema ++ employees.schema).drop
+  }
+}

--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -424,9 +424,9 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
         b"\}"
       case Union(left, right, all) =>
         b"\{"
-        buildFrom(left, None, true)
+        buildFrom(left, None, false)
         if(all) b"\nunion all " else b"\nunion "
-        buildFrom(right, None, true)
+        buildFrom(right, None, false)
         b"\}"
       case SimpleLiteral(w) => b += w
       case s: SimpleExpression => s.toSQL(this)

--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -424,9 +424,9 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
         b"\}"
       case Union(left, right, all) =>
         b"\{"
-        buildFrom(left, None, false)
+        buildFrom(left, None, true)
         if(all) b"\nunion all " else b"\nunion "
-        buildFrom(right, None, false)
+        buildFrom(right, None, true)
         b"\}"
       case SimpleLiteral(w) => b += w
       case s: SimpleExpression => s.toSQL(this)

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -186,6 +186,12 @@ trait MySQLProfile extends JdbcProfile { profile =>
       case RowNum(sym, true) => b"(@`$sym := @`$sym + 1)"
       case RowNum(sym, false) => b"@`$sym"
       case RowNumGen(sym, init) => b"@`$sym := $init"
+      case Union(left, right, all) =>
+        b"\{"
+        buildFrom(left, None, false)
+        if(all) b"\nunion all " else b"\nunion "
+        buildFrom(right, None, false)
+        b"\}"
       case _ => super.expr(n, skipParens)
     }
 


### PR DESCRIPTION
Made `skipParens` to be false to place left and right nodes of a union query each in parentheses. This will fix the following exceptions when Slick is used along with MySQL.

> java.sql.SQLException: Incorrect usage of UNION and LIMIT

> java.sql.SQLException: Incorrect usage of UNION and ORDER BY

MySQL Error Code for above exceptions: 1221

