### PR TITLE
Remove repQueryActionExtensionMethods

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -20,7 +20,9 @@ class AggregateTest extends AsyncTest[RelationalTestDB] {
     ts.schema.create >>
       (ts ++= Seq((1, Some(1)), (1, Some(3)), (1, None))) >>
       q2_0.result.map(_ shouldBe (0, 0, 0, None, None, None)) >>
-      q2_1.result.map(_ shouldBe (3, 3, 2, Some(3), Some(4), Some(2)))
+      q2_1.result.map(_ shouldBe (3, 3, 2, Some(3), Some(4), Some(2))) >>
+      q2_0._1.result >>
+      q2_0._1.shaped.result
   }
 
   def testGroupBy = {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcScalarFunctionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcScalarFunctionTest.scala
@@ -7,8 +7,8 @@ class JdbcScalarFunctionTest extends AsyncTest[JdbcTestDB] {
   import tdb.profile.api._
 
   def test = {
-    def check[T](q: Rep[T], exp: T) = q.result.map(_ shouldBe exp)
-    def checkLit[T : ColumnType](v: T) = check(LiteralColumn(v), v)
+    def check[T : BaseColumnType](q: Rep[T], exp: T) = q.result.map(_ shouldBe exp)
+    def checkLit[T : BaseColumnType](v: T) = check(LiteralColumn(v), v)
 
     seq(
       checkLit(Date.valueOf("2011-07-15")),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
@@ -6,8 +6,8 @@ class RelationalScalarFunctionTest extends AsyncTest[RelationalTestDB] {
   import tdb.profile.api._
 
   def test = {
-    def check[T](q: Rep[T], exp: T) = q.result.map(_ shouldBe exp)
-    def checkLit[T : ColumnType](v: T) = check(LiteralColumn(v), v)
+    def check[T : BaseColumnType](q: Rep[T], exp: T) = q.result.map(_ shouldBe exp)
+    def checkLit[T : BaseColumnType](v: T) = check(LiteralColumn(v), v)
     val s = "abcdefghijklmnopqrstuvwxyz"
 
     seq(

--- a/slick/src/main/scala/slick/basic/BasicProfile.scala
+++ b/slick/src/main/scala/slick/basic/BasicProfile.scala
@@ -52,8 +52,6 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
     implicit final def anyToShapedValue[T, U](value: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, U, _]): ShapedValue[T, U] =
       new ShapedValue[T, U](value, shape)
 
-    implicit def repQueryActionExtensionMethods[U](rep: Rep[U]): QueryActionExtensionMethods[U, NoStream] =
-      createQueryActionExtensionMethods[U, NoStream](queryCompiler.run(rep.toNode).tree, ())
     implicit def streamableQueryActionExtensionMethods[U, C[_]](q: Query[_,U, C]): StreamingQueryActionExtensionMethods[C[U], U] =
       createStreamingQueryActionExtensionMethods[C[U], U](queryCompiler.run(q.toNode).tree, ())
     implicit def runnableCompiledQueryActionExtensionMethods[RU](c: RunnableCompiled[_, RU]): QueryActionExtensionMethods[RU, NoStream] =

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -62,6 +62,9 @@ object Shape extends ConstColumnShapeImplicits with AbstractTableShapeImplicits 
   @inline implicit final def unitShape[Level <: ShapeLevel]: Shape[Level, Unit, Unit, Unit] =
     unitShapePrototype.asInstanceOf[Shape[Level, Unit, Unit, Unit]]
 
+  // Needs to be of higher priority thatn repColumnShape, otherwise single-column ShapedValues are ambiguous
+  @inline implicit def shapedValueShape[T, U, Level <: ShapeLevel] = RepShape[Level, ShapedValue[T, U], U]
+
   val unitShapePrototype: Shape[FlatShapeLevel, Unit, Unit, Unit] = new Shape[FlatShapeLevel, Unit, Unit, Unit] {
     def pack(value: Mixed) = ()
     def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] = this
@@ -279,8 +282,6 @@ case class ShapedValue[T, U](value: T, shape: Shape[_ <: FlatShapeLevel, T, U, _
 }
 
 object ShapedValue {
-  @inline implicit def shapedValueShape[T, U, Level <: ShapeLevel] = RepShape[Level, ShapedValue[T, U], U]
-
   def mapToImpl[R <: Product with Serializable, U](c: Context { type PrefixType = ShapedValue[_, U] })(rCT: c.Expr[ClassTag[R]])(implicit rTag: c.WeakTypeTag[R], uTag: c.WeakTypeTag[U]): c.Tree = {
     import c.universe._
     val rSym = symbolOf[R]


### PR DESCRIPTION
As discovered in #1516, the old repQueryActionExtensionMethods is
fundamentally broken since the introduction of nested option types in
#939. We can safely remove it because all non-broken cases are
covered by recordQueryActionExtensionMethods.