### PR TITLE
Backport #1745 to 3.2

### DIFF
--- a/common-test-resources/application.conf
+++ b/common-test-resources/application.conf
@@ -85,6 +85,17 @@ h2mem1 = {
   keepAliveConnection = true
 }
 
+h2mem-inuse = {
+  url = "jdbc:h2:mem:test1"
+  driver = org.h2.Driver
+  connectionPool = "HikariCP"
+  numThreads = 5
+  maxConnections = 5
+  keepAliveConnection = true
+  registerMbeans = true
+  poolName = "inUseCount"
+}
+
 // MBeans-enabled configuration, used by MBeansTest
 mbeans = {
   url = "jdbc:h2:mem:test_mbeans"

--- a/slick-testkit/src/test/scala/slick/test/jdbc/hikaricp/SlickInUseCountTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/hikaricp/SlickInUseCountTest.scala
@@ -1,0 +1,94 @@
+package slick.test.jdbc.hikaricp
+
+import java.lang.management.ManagementFactory
+import java.util.concurrent.TimeUnit
+import javax.management.ObjectName
+
+import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
+import org.junit.Assert.assertEquals
+import org.junit.{After, Before, Ignore, Test}
+import org.slf4j.LoggerFactory
+import slick.jdbc.H2Profile.api._
+import slick.lifted.{ProvenShape, TableQuery}
+import slick.util.SlickLogger
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class SlickInUseCountTest extends AsyncTest[JdbcTestDB] {
+
+  val poolName = "inUseCount"
+  val mbeanServer = ManagementFactory.getPlatformMBeanServer
+  val aeBeanName = new ObjectName(s"slick:type=AsyncExecutor,name=$poolName")
+  val poolBeanName = new ObjectName(s"com.zaxxer.hikari:type=Pool ($poolName)")
+
+  val logger = new SlickLogger(LoggerFactory.getLogger("slick.util.AsyncExecutor"))
+
+  class TestTable(tag: Tag) extends Table[(Int)](tag, "SDL") {
+
+    def id: Rep[Int] = column[Int]("ID")
+    def * : ProvenShape[(Int)] = id
+
+  }
+
+  var database: Database = _
+  val testTable: TableQuery[TestTable] = TableQuery[TestTable]
+
+  @Before
+  def openDatabase() = {
+    System.setProperty("com.zaxxer.hikari.housekeeping.periodMs", "5000")
+    database = Database.forConfig("h2mem-inuse")
+    Await.result(database.run(testTable.schema.create), Duration.Inf /*2.seconds*/)
+  }
+
+  @After
+  def closeDatabase() = {
+    Await.result(database.run(testTable.schema.drop), 2.seconds)
+    database.close()
+  }
+
+  @Test def slickInUseCount() {
+    val loops = 1000
+    val count = 100
+    1 to loops foreach { _ =>
+      val tasks = 1 to count map { i =>
+        val action = { testTable += i }
+          .flatMap { _ => testTable.length.result }
+          //.flatMap { _ => DBIO.successful(s"inserted value $i") }
+
+        database.run(action)
+      }
+      Await.result(Future.sequence(tasks), Duration(10, TimeUnit.SECONDS))
+
+    }
+    //we need to wait until there are no more active threads in the threadpool
+    //DBIOAction results might be available before the threads have completely finished their work
+    while (mbeanServer.getAttribute(aeBeanName, "ActiveThreads").asInstanceOf[Int] > 0) {
+      Thread.sleep(100)
+    }
+
+    assertEquals(0, inUseCount)
+
+  }
+
+  /**
+    * Use introspection to retrieve the inUseCount field of the ManagedArrayBlockingQueue
+    */
+  def inUseCount: Int = {
+    val asyncExecutorField = database.getClass.getDeclaredField("executor")
+    asyncExecutorField.setAccessible(true)
+    val asyncExecutor = asyncExecutorField.get(database)
+
+    val threadPoolExecutorField = asyncExecutor.getClass.getDeclaredField("slick$util$AsyncExecutor$$anon$$executor")
+    threadPoolExecutorField.setAccessible(true)
+    val threadPoolExecutor = threadPoolExecutorField.get(asyncExecutor)
+
+    val queue = threadPoolExecutor.getClass.getMethod("getQueue").invoke(threadPoolExecutor)
+    val inUseCountField = queue.getClass.getDeclaredField("slick$util$ManagedArrayBlockingQueue$$inUseCount")
+    inUseCountField.setAccessible(true)
+
+    inUseCountField.get(queue).asInstanceOf[Int]
+  }
+
+
+}

--- a/slick-testkit/src/test/scala/slick/test/jdbc/hikaricp/SlickInUseCountTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/hikaricp/SlickInUseCountTest.scala
@@ -14,6 +14,7 @@ import slick.util.SlickLogger
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.util.{Try, Success}
 
 class SlickInUseCountTest extends AsyncTest[JdbcTestDB] {
 
@@ -84,7 +85,11 @@ class SlickInUseCountTest extends AsyncTest[JdbcTestDB] {
     val threadPoolExecutor = threadPoolExecutorField.get(asyncExecutor)
 
     val queue = threadPoolExecutor.getClass.getMethod("getQueue").invoke(threadPoolExecutor)
-    val inUseCountField = queue.getClass.getDeclaredField("slick$util$ManagedArrayBlockingQueue$$inUseCount")
+    val inUseCountField = Seq("inUseCount", "slick$util$ManagedArrayBlockingQueue$$inUseCount").collectFirst{name =>
+	Try(queue.getClass.getDeclaredField(name)) match{
+            case Success(field) => field
+        }
+    }.get
     inUseCountField.setAccessible(true)
 
     inUseCountField.get(queue).asInstanceOf[Int]

--- a/slick/src/main/scala/slick/util/AsyncExecutor.scala
+++ b/slick/src/main/scala/slick/util/AsyncExecutor.scala
@@ -83,9 +83,7 @@ object AsyncExecutor extends Logging {
         override def afterExecute(r: Runnable, t: Throwable): Unit = {
           super.afterExecute(r, t)
           (r, queue) match {
-            case (pr: PrioritizedRunnable, q: ManagedArrayBlockingQueue[Runnable]) =>
-              if (pr.connectionReleased && pr.priority != WithConnection) q.decreaseInUseCount()
-              pr.inUseCounterSet = false
+            case (pr: PrioritizedRunnable, q: ManagedArrayBlockingQueue[Runnable]) if pr.connectionReleased => q.decreaseInUseCount()
             case _ =>
           }
         }
@@ -152,7 +150,7 @@ object AsyncExecutor extends Logging {
   case object Fresh extends Priority
   /** Continuation is used for database actions that are a continuation of some previously executed actions */
   case object Continuation extends Priority
-  /** WithContinuation is used for database actions that already have a JDBC connection associated. */
+  /** WithConnection is used for database actions that already have a JDBC connection associated. */
   case object WithConnection extends Priority
 
   trait PrioritizedRunnable extends Runnable {


### PR DESCRIPTION
 fixes race-condition using unpinned/flatMapped DBIOActions, leading to missing decreaseInUseCount calls and possible stall of ManagedBlockingArrayQueue

See #1745 #1730