### PR TITLE
Updated JdbcActionComponent.scala

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -325,7 +325,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
         }
       }
     }
-    /** Get the statement usd by `update` */
+    /** Get the statement used by `update` */
     def updateStatement: String = sres.sql
   }
 


### PR DESCRIPTION
Corrected the spelling of 'used' in the documentation of updateStatement method.