### PR TITLE
add documentation for O.Unique

### DIFF
--- a/doc/src/schemas.md
+++ b/doc/src/schemas.md
@@ -47,6 +47,8 @@ object. The following ones are defined for `JdbcProfile`:
 - `Default[T](defaultValue: T)`:  Specify a default value for inserting data into the table without this column.
   This information is only used for creating DDL statements so that the database can fill in the missing information.
 
+- `Unique`: Add a uniqueness constraint to the DDL statement for the column.
+
 - `SqlType(typeName: String)`: Use a non-standard database-specific type for the DDL statements (e.g.
   `SqlType("VARCHAR(20)")` for a `String` column).
 


### PR DESCRIPTION
Issue https://github.com/slick/slick/issues/118 (PR https://github.com/slick/slick/pull/1523) added `O.Unique` for 3.2, but we forgot to add it to the reference manual.  This PR fixes that.

Here's a screen grab of the rendering:

![schemas 2017-09-20 13-47-25](https://user-images.githubusercontent.com/102661/30644430-4200a004-9e0a-11e7-8d47-2570471946e2.png)
