### PR TITLE
Codegen output to multiple files (one per table) #906

### DIFF
--- a/doc/src/code-generation.md
+++ b/doc/src/code-generation.md
@@ -67,6 +67,7 @@ and provide the following values
 * `pkg`: Scala package the generated code should be places in
 * `user`: database connection user name
 * `password`: database connection password
+* `outputToMultipleFiles`: Boolean indicating if the generated output should be one big file or one file per table. Default is false.
 
 Integrated into sbt
 -------------------
@@ -79,6 +80,9 @@ By default, the code generator places a file `Tables.scala` in the given folder 
 to the package. The file contains an `object Tables` from which the code
 can be imported for use right away. Make sure you use the same profile.
 The file also contains a `trait Tables` which can be used in the cake pattern.
+
+If `outputToMultipleFiles` is set to true, the code generator will instead create a `trait` per table.
+`Tables.scala` then stacks all the generated tables. The advantage of this, is that you avoid a potentially huge file
 
 > {.warning}
 > When using the generated code, be careful *not* to mix different profiles accidentally. The

--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -25,6 +25,32 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
         "import slick.jdbc.{GetResult => GR}\n"
       } else ""
     ) +
+    codeForDDL +
+    tables.map(_.code.mkString("\n")).mkString("\n\n")
+  }
+
+  /** Generates code for the container class (not wrapped in a package yet)
+     @group Basic customization overrides */
+  def codeForContainer = {
+    "import slick.model.ForeignKeyAction\n" +
+      ( if(tables.exists(_.hlistEnabled)){
+            "import slick.collection.heterogeneous._\n"+
+              "import slick.collection.heterogeneous.syntax._\n"
+          } else ""
+        ) +
+      ( if(tables.exists(_.PlainSqlMapper.enabled)){
+            "// NOTE: GetResult mappers for plain SQL are only generated for tables where Slick knows how to map the types of all columns.\n"+
+              "import slick.jdbc.{GetResult => GR}\n"
+          } else ""
+        ) +
+      codeForDDL
+  }
+
+  /**
+   * Generates code for the DDL statement.
+   * @group Basic customization overrides
+   */
+  def codeForDDL: String = {
     (if(ddlEnabled){
       "\n/** DDL for all tables. Call .create to execute. */" +
       (
@@ -38,9 +64,30 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
       "\n@deprecated(\"Use .schema instead of .ddl\", \"3.0\")"+
       "\ndef ddl = schema" +
       "\n\n"
-    } else "") +
-    tables.map(_.code.mkString("\n")).mkString("\n\n")
+    } else "")
   }
+
+  /** Generates a map that associates the table name with its generated code (not wrapped in a package yet).
+   *  @group Basic customization overrides
+   */
+  def codePerTable: Map[String,String] = {
+    tables.map(table => {
+      val before="import slick.model.ForeignKeyAction\n" +
+        (if (table.hlistEnabled) {
+          "import slick.collection.heterogeneous._\n" +
+            "import slick.collection.heterogeneous.syntax._\n"
+        }
+        else "") +
+        (if (table.PlainSqlMapper.enabled) {
+          "// NOTE: GetResult mappers for plain SQL are only generated for tables where Slick knows how to map the types of all columns.\n" +
+            "import slick.jdbc.{GetResult => GR}\n"
+        }
+        else "")
+
+      (table.TableValue.name,table.code.mkString(before,"\n",""))
+    }).toMap
+  }
+
 
   protected def tuple(i: Int) = termName(s"_${i+1}")
 

--- a/slick-codegen/src/main/scala/slick/codegen/OutputHelpers.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/OutputHelpers.scala
@@ -10,7 +10,17 @@ trait OutputHelpers{
   /** The parent type of the generated main trait. This can be overridden in subclasses. */
   def parentType: Option[String] = None
 
-  /** Indents all but the first line of the given string.
+  /**
+   * The generated code stored in a map that associates the scala filename with the generated code (this map contains one entry per table).
+   */
+  def codePerTable: Map[String, String]
+
+  /**
+    * The generated code used to generate the container class.
+    */
+  def codeForContainer: String
+
+  /** Indents all but the first line of the given string
    *  No indent is added to empty lines.
    */
   def indent(code: String): String
@@ -48,6 +58,29 @@ trait OutputHelpers{
     writeStringToFile(packageCode(profile, pkg, container, parentType), folder, pkg, fileName)
   }
 
+   /**
+   * Generates code and writes it to multiple files.
+   * Creates a folder structure for the given package inside the given srcFolder
+   * and places the new files inside or overrides the existing one.
+   * @group Output
+   * @param folder target folder, in which the output files are placed
+   * @param profile Slick profile that is imported in the generated package (e.g. scala.slick.driver.H2Driver)
+   * @param pkg Scala package the generated code is placed in (a subfolder structure will be created within srcFolder)
+   * @param container The name of a trait and an object the generated code will be placed in within the specified package.
+   */
+  def writeToMultipleFiles(profile: String, folder: String, pkg: String, container: String = "Tables") {
+    // Write the container file (the file that contains the stand-alone object).
+    writeStringToFile(packageContainerCode(profile, pkg, container), folder, pkg, container + ".scala")
+    // Write one file for each table.
+    codePerTable.foreach {
+      case (tableName, tableCode) => writeStringToFile(packageTableCode(tableName, tableCode, pkg, container), folder, pkg, handleQuotedNamed(tableName)+".scala")
+    }
+  }
+
+  private def handleQuotedNamed(tableName: String) = {
+    if (tableName.endsWith("`")) s"${tableName.init}Table`" else s"${tableName}Table"
+  }
+
   /**
    * Generates code providing the data model as trait and object in a Scala package
    * @group Basic customization overrides
@@ -72,4 +105,55 @@ trait ${container}${parentType.map(t => s" extends $t").getOrElse("")} {
 }
       """.trim()
     }
+
+  /**
+   * Generates code providing the stand-alone slick data model for immediate use.
+   * @group Basic customization overrides
+   * @param profile Slick profile that is imported in the generated package (e.g. scala.slick.driver.H2Driver)
+   * @param pkg Scala package the generated code is placed in
+   * @param container The name of a trait and an object the generated code will be placed in within the specified package.
+   */
+  def packageContainerCode(profile: String, pkg: String, container: String = "Tables"): String = {
+    val mixinCode = codePerTable.keys.map(tableName => s"${handleQuotedNamed(tableName) }").mkString("extends ", " with ", "")
+    s"""
+package ${pkg}
+// AUTO-GENERATED Slick data model
+/** Stand-alone Slick data model for immediate use */
+object ${container} extends {
+  val profile = $profile
+} with ${container}
+
+/** Slick data model trait for extension, choice of backend or usage in the cake pattern. (Make sure to initialize this late.)
+    Each generated XXXXTable trait is mixed in this trait hence allowing access to all the TableQuery lazy vals.
+  */
+trait ${container}${parentType.map(t => s" extends $t").getOrElse("")} ${mixinCode} {
+  val profile: slick.jdbc.JdbcProfile
+  import profile.api._
+  ${indent(codeForContainer)}
+
+}
+      """.trim()
+  }
+
+  /**
+   * Generates code for the given table. The tableName and tableCode parameters should come from the #codePerTable map.
+   * @group Basic customization overrides
+   * @param tableName : the name of the table
+   * @param tableCode : the generated code for the table.
+   * @param pkg Scala package the generated code is placed in
+   * @param container The name of the container
+   */
+  def packageTableCode(tableName: String, tableCode: String, pkg: String, container: String): String = {
+    s"""
+package ${pkg}
+// AUTO-GENERATED Slick data model for table ${tableName}
+trait ${handleQuotedNamed(tableName) } {
+
+  self:${container}  =>
+
+  import profile.api._
+  ${indent(tableCode)}
+}
+      """.trim()
+  }
 }

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
@@ -40,6 +40,8 @@ object GenerateRoundtripSources {
     val pkg = "slick.test.codegen.roundtrip"
     gen.writeToFile( "slick.jdbc.H2Profile", args(0), pkg )
     gen2.writeToFile( "slick.jdbc.H2Profile", args(0), pkg+"2" )
+    gen.writeToMultipleFiles( "slick.jdbc.H2Profile", args(0), pkg+"multiplefiles" )
+    gen2.writeToMultipleFiles( "slick.jdbc.H2Profile", args(0), pkg+"multiplefiles2" )
   }
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestCodeGenerator.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestCodeGenerator.scala
@@ -24,6 +24,8 @@ trait TestCodeGenerator {
     new OutputHelpers {
       def indent(code: String): String = code
       def code: String = ""
+      def codePerTable:Map[String,String] = Map()
+      def codeForContainer:String = ""
     }.writeStringToFile(
       s"""
          |package $packageName

--- a/slick-testkit/src/test/scala/slick/test/codegen/CodeGeneratorAllTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/codegen/CodeGeneratorAllTest.scala
@@ -42,17 +42,17 @@ class CodeGeneratorAllTest(val tdb: JdbcTestDB) extends DBTest {
       // override mapped table and class name
       override def entityName = dbTableName => dbTableName.dropRight(1).toLowerCase.toCamelCase
       override def tableName  = dbTableName => dbTableName.toLowerCase.toCamelCase
-    
+
       // add some custom import
       override def code = "import foo.{MyCustomType,MyCustomTypeMapper}" + "\n" + super.code
-    
+
       // override table generator
       override def Table = new Table(_){
         // disable entity class generation and mapping
         override def EntityType = new EntityType{
           override def classEnabled = false
         }
-    
+
         // override contained column generator
         override def Column = new Column(_){
           // use the data model member of this column to change the Scala type, e.g. to a custom enum or anything else
@@ -64,5 +64,8 @@ class CodeGeneratorAllTest(val tdb: JdbcTestDB) extends DBTest {
 
     val codegen = Await.result(db.run((createA >> codegenA).withPinnedSession), Duration.Inf)
     codegen.writeToFile("slick.jdbc.H2Profile","target/slick-testkit-codegen-tests/","all.test",profileName+"Tables",profileName+".scala")
+    /// test write to multiple files
+    codegen.writeToMultipleFiles("slick.jdbc.H2Profile","target/slick-testkit-codegen-tests/","all.test.multiple",profileName+"Tables")
+
   }
 }


### PR DESCRIPTION
This is a continuation of [pull request 987](https://github.com/slick/slick/pull/987), solving issue #906

I've updated the code to work with 3.2.x, added multiple file out to the current test suites, i.e. CodeGeneratorRoundTripTest and CodeGeneratorAllTest. Everything should be working. I've added a new boolean to the run methods called `outputToMultipleFiles`, I've set the default value to false, it shouldn't break any existing behavior.