### PR TITLE
Add imports to more manual pages

### DIFF
--- a/doc/code/CodeGenerator.scala
+++ b/doc/code/CodeGenerator.scala
@@ -1,8 +1,10 @@
 package com.typesafe.slick.docs
 
+//#imports
 import scala.concurrent.ExecutionContext.Implicits.global
 import slick.jdbc.H2Profile.api._
 import slick.jdbc.H2Profile
+//#imports
 
 object CodeGenerator extends App {
   val uri = "#slick.db.default"

--- a/doc/code/Connection.scala
+++ b/doc/code/Connection.scala
@@ -1,5 +1,6 @@
 package com.typesafe.slick.docs
 
+//#imports
 import java.sql.Blob
 import javax.sql.rowset.serial.SerialBlob
 
@@ -13,6 +14,7 @@ import scala.language.higherKinds
 import scala.util.{Failure, Success}
 import slick.basic.DatabasePublisher
 import slick.jdbc.H2Profile.api._
+//#imports
 
 object Connection extends App {
   class Coffees(tag: Tag) extends Table[(String, Blob)](tag, "COFFEES") {

--- a/doc/code/LiftedEmbedding.scala
+++ b/doc/code/LiftedEmbedding.scala
@@ -1,10 +1,12 @@
 package com.typesafe.slick.docs
 
+//#imports
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import slick.jdbc.H2Profile.api._
 import java.sql.Date
 import scala.reflect.ClassTag
+//#imports
 
 object LiftedEmbedding extends App {
   // Simple Coffees for Rep types comparison

--- a/doc/src/code-generation.md
+++ b/doc/src/code-generation.md
@@ -35,6 +35,13 @@ For Maven projects add the following to your `<dependencies>`:
 </dependency>
 ```
 
+> {.note}
+> In the code examples below we assume the following imports:
+>```scala src=../code/CodeGenerator.scala#imports
+> ```
+> If you're new to Slick, please start with the [Getting Started](gettingstarted.md) page.
+
+
 Slick's code generator comes with a default runner that can be used from the command line or from Java/Scala. You can simply execute
 
 ```scala src=../code/CodeGenerator.scala#default-runner-uri

--- a/doc/src/dbio.md
+++ b/doc/src/dbio.md
@@ -15,6 +15,12 @@ In most cases you will want to use the type aliases [DBIO](api:slick.dbio.packag
 and [StreamingDBIO](api:slick.dbio.package@StreamingDBIO[+R,+T]:StreamingDBIO[R,T]) for non-streaming and
 streaming Database I/O Actions. They omit the optional *effect types* supported by <api:slick.dbio.DBIOAction>.
 
+> {.note}
+> In the code examples below we assume the following imports:
+>```scala src=../code/Connection.scala#imports
+> ```
+> If you're new to Slick, please start with the [Getting Started](gettingstarted.md) page.
+
 Executing Database I/O Actions {index="execute,Action;Action,execute"}
 ------------------------------
 

--- a/doc/src/queries.md
+++ b/doc/src/queries.md
@@ -2,7 +2,15 @@ Queries {index="lifted; Query"}
 =======
 
 This chapter describes how to write type-safe queries for selecting, inserting, updating and
-deleting data with Slick's Scala-based query API. The API for building queries is a
+deleting data with Slick's Scala-based query API.
+
+ > {.note}
+ > In the code examples below we assume the following imports:
+ >```scala src=../code/LiftedEmbedding.scala#imports
+ > ```
+ > If you're new to Slick, please start with the [Getting Started](gettingstarted.md) page.
+
+The API for building queries is a
 *lifted embedding*, which means that you are not working with standard Scala types but with types
 that are *lifted* into a <api:slick.lifted.Rep> type constructor. This becomes clearer when you
 compare the types of a simple Scala collections example

--- a/doc/src/schemas.md
+++ b/doc/src/schemas.md
@@ -6,6 +6,12 @@ them manually, which is useful when you start writing an application without a p
 If you already have a schema in the database, you can also use the [code generator](code-generation.md)
 to take this work off your hands.
 
+> {.note}
+> In the code examples below we assume the following imports:
+>```scala src=../code/LiftedEmbedding.scala#imports
+> ```
+> If you're new to Slick, please start with the [Getting Started](gettingstarted.md) page.
+
 Table Rows {index="table; row; ColumnOption; primary key; default; type; AutoInc; generated; identity; *; star projection; schema,name; name,schema"}
 ----------
 

--- a/doc/src/userdefined.md
+++ b/doc/src/userdefined.md
@@ -4,6 +4,12 @@ User-Defined Features {index="user-defined"}
 This chapter describes how to use custom data types and database functions
 with Slick's Scala API.
 
+> {.note}
+> In the code examples below we assume the following imports:
+>```scala src=../code/LiftedEmbedding.scala#imports
+> ```
+> If you're new to Slick, please start with the [Getting Started](gettingstarted.md) page.
+
 Scalar Database Functions {index="scalar,function,user-defined; function,scalar,user-defined"}
 -------------------------
 


### PR DESCRIPTION
Fixes #1732 

## This PR adds import information to the manual

This PR adds a note about imports to more pages: DBIO, Schemas, Queries, Schema Code Generation, and User-Defined Features.  It looks like this:

![queries 2017-09-29 12-21-22](https://user-images.githubusercontent.com/102661/31014138-5908717e-a511-11e7-8713-0f3976477ef7.png)

## This is done by referencing the example code

Rather than manually add the imports to the text, I thought it was safer to pull them in from the example source files. I've added a few more `//#imports` comments to do that.

## It's not perfect

A consequence is that the import notes aren't as nice as we might like. For example, in Schemas we note we're importing `ClassTag`, but that's not used until the User-Defined Features page.  But both pages use the same code (`LiftEmbedding.scala`).  If we like this PR, a further step could be to have an example Scala file per page where this kind of thing happens.
