### PR TITLE
Case class mapping fix

### DIFF
--- a/slick/src/main/scala/slick/compiler/FlattenProjections.scala
+++ b/slick/src/main/scala/slick/compiler/FlattenProjections.scala
@@ -40,6 +40,8 @@ class FlattenProjections extends Phase {
         n.mapChildren { ch => tr(ch, topLevel && (ch ne n.from)) }
       case u: Union =>
         n.mapChildren { ch => tr(ch, true) }
+      case _: ClientSideOp =>
+        n.mapChildren { ch => tr(ch, topLevel) }
       case Library.SilentCast(ch) :@ tpe =>
         Library.SilentCast.typed(tpe.structuralRec, tr(ch, false))
       case n => n.mapChildren(tr(_, false))


### PR DESCRIPTION
This seems to be a fix for https://github.com/slick/slick/issues/1797.

I'm not sure if this is sufficient to prevent all instances of this error. My guess is that client-side operations should not be counted towards the topLevel analysis.