### PR TITLE
Add null password support to DatabaseUrlDataSource

### DIFF
--- a/common-test-resources/application.conf
+++ b/common-test-resources/application.conf
@@ -57,6 +57,42 @@ databaseUrl {
   }
 }
 
+// HikariCP with DATABASE_URL parsing, no password
+databaseUrlNoPassword {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "slick.test.jdbc.MockDriver"
+    url = "postgres://user@host/dbname"
+    properties = {
+      foo = bar
+    }
+  }
+}
+
+// HikariCP with DATABASE_URL parsing, MySQL
+databaseUrlMySQL {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "slick.test.jdbc.MockDriver"
+    url = "mysql://user:pass@host/dbname"
+    properties = {
+      foo = bar
+    }
+  }
+}
+
+// HikariCP with DATABASE_URL parsing, MySQL and no password
+databaseUrlMySQLNoPassword {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "slick.test.jdbc.MockDriver"
+    url = "mysql://user@host/dbname"
+    properties = {
+      foo = bar
+    }
+  }
+}
+
 // Test alternative dsn for postgres
 altDatabaseUrl {
   dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"

--- a/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
@@ -45,6 +45,51 @@ class DataSourceTest {
     } finally db.close
   }
 
+  @Test def testDatabaseUrlDataSourceNoPassword: Unit = {
+    import slick.jdbc.H2Profile.api.actionBasedSQLInterpolation
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrlNoPassword")
+    try {
+      assertEquals(Some(100), db.source.maxConnections)
+      try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
+      val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
+      assertEquals("jdbc:postgresql://host/dbname", url)
+      assertEquals("user", info.getProperty("user"))
+      assertEquals(null, info.getProperty("password"))
+      assertEquals("bar", info.getProperty("foo"))
+    } finally db.close
+  }
+
+  @Test def testDatabaseUrlDataSourceMySQL: Unit = {
+    import slick.jdbc.H2Profile.api.actionBasedSQLInterpolation
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrlMySQL")
+    try {
+      assertEquals(Some(100), db.source.maxConnections)
+      try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
+      val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
+      assertEquals("jdbc:mysql://host/dbname?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci", url)
+      assertEquals("user", info.getProperty("user"))
+      assertEquals("pass", info.getProperty("password"))
+      assertEquals("bar", info.getProperty("foo"))
+    } finally db.close
+  }
+
+  @Test def testDatabaseUrlDataSourceMySQLNoPassword: Unit = {
+    import slick.jdbc.H2Profile.api.actionBasedSQLInterpolation
+    MockDriver.reset
+    val db = JdbcBackend.Database.forConfig("databaseUrlMySQLNoPassword")
+    try {
+      assertEquals(Some(100), db.source.maxConnections)
+      try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
+      val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
+      assertEquals("jdbc:mysql://host/dbname?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci", url)
+      assertEquals("user", info.getProperty("user"))
+      assertEquals(null, info.getProperty("password"))
+      assertEquals("bar", info.getProperty("foo"))
+    } finally db.close
+  }
+
   @Test def testAltDatabaseUrlDataSourceScheme: Unit = {
     import slick.jdbc.H2Profile.api.actionBasedSQLInterpolation
     MockDriver.reset

--- a/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DatabaseUrlDataSource.scala
@@ -6,8 +6,8 @@ package slick.jdbc
   */
 class DatabaseUrlDataSource extends DriverDataSource(null) {
 
-  private val PostgresFullUrl = "^(?:postgres|postgresql)://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
-  private val MysqlFullUrl = "^mysql://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
+  private val PostgresFullUrl = "^(?:postgres|postgresql)://([a-zA-Z0-9_]+)(?::([^@]+))?@([^/]+)/([^\\s]+)$".r
+  private val MysqlFullUrl = "^mysql://([a-zA-Z0-9_]+)(?::([^@]+))?@([^/]+)/([^\\s]+)$".r
   private val MysqlCustomProperties = ".*\\?(.*)".r
 
   @volatile private[this] var initialized = false


### PR DESCRIPTION
References issue #1804 

This allows null password support for the DatabaseUrlDataSource class. Previously, it was violating the spec by requiring a password with its regex but I was able to tweak them both slightly (and wrote some tests) to confirm that it properly parses the adjusted format. The regexes went from this format:
```
"^(?:postgres|postgresql)://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$"
```
to this format:
```
"^(?:postgres|postgresql)://([a-zA-Z0-9_]+)(?::([^@]+))?@([^/]+)/([^\\s]+)$"
```
The change was also applied to MySQL's URL format and accounted for with three new tests.