### PR TITLE
Log SQL with values for insert/update statements.

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -331,16 +331,12 @@ trait JdbcBackend extends RelationalBackend {
     }
 
     final def prepareInsertStatement(sql: String, columnNames: Array[String] = new Array[String](0)): PreparedStatement = {
-      if(JdbcBackend.statementLogger.isDebugEnabled)
-        JdbcBackend.logStatement("Preparing insert statement (returning: "+columnNames.mkString(",")+")", sql)
       val s = loggingPreparedStatement(decorateStatement(conn.prepareStatement(sql, columnNames)))
       if(fetchSize != 0) s.setFetchSize(fetchSize)
       s
     }
 
     final def prepareInsertStatement(sql: String, columnIndexes: Array[Int]): PreparedStatement = {
-      if(JdbcBackend.statementLogger.isDebugEnabled)
-        JdbcBackend.logStatement("Preparing insert statement (returning indexes: "+columnIndexes.mkString(",")+")", sql)
       val s = loggingPreparedStatement(decorateStatement(conn.prepareStatement(sql, columnIndexes)))
       if(fetchSize != 0) s.setFetchSize(fetchSize)
       s

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -150,9 +150,9 @@ class LoggingStatement(st: Statement) extends Statement {
   * to the appropriate [[JdbcBackend]] loggers. */
 class LoggingPreparedStatement(st: PreparedStatement) extends LoggingStatement(st) with PreparedStatement {
 
-  def execute(): Boolean = { pushParams; logged(null, "prepared statement") { st.execute() } }
+  def execute(): Boolean = { pushParams; logged(st.toString, "prepared statement") { st.execute() } }
   def executeQuery(): js.ResultSet = { pushParams; logged(null, "prepared query") { st.executeQuery() } }
-  def executeUpdate(): Int = { pushParams; logged(null, "prepared update") { st.executeUpdate() } }
+  def executeUpdate(): Int = { pushParams; logged(st.toString, "prepared update") { st.executeUpdate() } }
 
   def addBatch(): Unit = { pushParams; st.addBatch() }
   def clearParameters(): Unit = { clearParamss; st.clearParameters() }


### PR DESCRIPTION
Hi!
First of all thanks a lot to the Slick team for all the effort you put into developing this wonderful library!

Similar to @mdedetrich (see issue #1317) I also want to log the actual insert statements, that are run against the database (using Slick 3). Initially I was able to log the bound values using
```
<logger name="slick.jdbc.JdbcBackend.parameter" level="DEBUG" />
```
in my `logback.xml` file as mentioned [in the documentation](http://slick.lightbend.com/doc/3.2.0/config.html#logging). However the values are not logged directly in the insert statement (which logs a `?` for each bound value), but in a separate table also containing other useful information like types.

I dared to take a closer look at this issue since @cvogt has tagged it as easy. :wink: The result is this pull request to try to close issue #1317.

Adding the logger

```
<logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" />
```
will log executable SQL statements (i.e. with the actual values instead of `?`) relying on the `PreparedStatement`'s `toString` method to deliver the underlying SQL. Since `toString` might not always yield the underlying SQL it might be better to create an additional logger e.g. `slick.jdbc.JdbcBackend.execute` to explicitly enable this logger when the database driver is logging useful SQL. What do you think?

In this pull request I've also removed the logging of the prepared statements to be consistent with the logging of values bound in select queries (which show the bound values instead of `?`). That way the`slick.jdbc.JdbcBackend.statement` logger shows the output of the proposed `slick.jdbc.JdbcBackend.execute` logger.

Cheers,
Manfred