### PR TITLE
Throws an exception if `insertOrUpdate()` is called on a table without PK;

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -162,6 +162,26 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     } yield ()
   }
 
+  def testInsertOrUpdateNoPK = {
+    class T(tag: Tag) extends Table[(Int, String)](tag, "t_merge_no_pk") {
+      def id = column[Int]("id")
+      def name = column[String]("name")
+      def * = (id, name)
+      def ins = (id, name)
+    }
+    val ts = TableQuery[T]
+
+    val failed = try {
+      ts.insertOrUpdate((3, "c"))
+      false
+    }
+    catch {
+      case _: SlickException => true
+    }
+    if (!failed) throw new RuntimeException("Should fail since insertOrUpdate is not supported on a table without PK.")
+    DBIO.seq()
+  }
+
   def testInsertOrUpdatePlainWithFuncDefinedPK: DBIOAction[Unit, _, _] = {
     //FIXME remove this after fixed checkInsert issue
     if (tdb.profile.isInstanceOf[DerbyProfile]) return DBIO.successful(())


### PR DESCRIPTION
Fixes #1699. 
Throws an exception if no PK is found for a table in `insertOrUpdate()` action. Prevents invalid SQL statement to be generated and fail at runtime.