### PR TITLE
Make ModelBuilders easier to customize via inner classes

### DIFF
--- a/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
@@ -94,7 +94,8 @@ trait DerbyProfile extends JdbcProfile {
   )
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
-    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable) {
+    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable)
+    class TableNamer(mTable: MTable) extends super.TableNamer(mTable) {
       override def schema = super.schema.filter(_ != "APP") // remove default schema
     }
   }

--- a/slick/src/main/scala/slick/jdbc/H2Profile.scala
+++ b/slick/src/main/scala/slick/jdbc/H2Profile.scala
@@ -53,10 +53,14 @@ trait H2Profile extends JdbcProfile {
   )
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
-    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable) {
+    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable)
+    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta)
+
+    class TableNamer(mTable: MTable) extends super.TableNamer(mTable) {
       override def schema = super.schema.filter(_ != "PUBLIC") // remove default schema
     }
-    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta) {
+
+    class ColumnBuilder(tableBuilder: TableBuilder, meta: MColumn) extends super.ColumnBuilder(tableBuilder, meta) {
       override def length = super.length.filter(_ != Int.MaxValue) // H2 sometimes show this value, but doesn't accept it back in the DBType
       override def default = rawDefault.map((_,tpe)).collect{
           case (v,"java.util.UUID") =>

--- a/slick/src/main/scala/slick/jdbc/HsqldbProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/HsqldbProfile.scala
@@ -45,7 +45,8 @@ trait HsqldbProfile extends JdbcProfile {
   )
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
-    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable) {
+    override def createTableNamer(mTable: MTable): TableNamer = new TableNamer(mTable)
+    class TableNamer(mTable: MTable) extends super.TableNamer(mTable) {
       override def schema = super.schema.filter(_ != "PUBLIC") // remove default schema
       override def catalog = super.catalog.filter(_ != "PUBLIC") // remove default catalog
     }

--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -81,7 +81,8 @@ trait OracleProfile extends JdbcProfile {
   override val columnOptions: ColumnOptions = new ColumnOptions {}
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
-    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta) {
+    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta)
+    class ColumnBuilder(tableBuilder: TableBuilder, meta: MColumn) extends super.ColumnBuilder(tableBuilder, meta) {
       override def tpe = meta.sqlType match {
         case 101 => "Double"
         case _ => super.tpe

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -89,7 +89,8 @@ trait SQLServerProfile extends JdbcProfile {
   override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder = new ColumnDDLBuilder(column)
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
-    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta) {
+    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta)
+    class ColumnBuilder(tableBuilder: TableBuilder, meta: MColumn) extends super.ColumnBuilder(tableBuilder, meta) {
       override def tpe = dbType match {
         case Some("date") => "java.sql.Date"
         case Some("time") => "java.sql.Time"

--- a/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
@@ -94,7 +94,10 @@ trait SQLiteProfile extends JdbcProfile {
   )
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
-    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta) {
+    override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder = new ColumnBuilder(tableBuilder, meta)
+    override def createPrimaryKeyBuilder(tableBuilder: TableBuilder, meta: Seq[MPrimaryKey]): PrimaryKeyBuilder = new PrimaryKeyBuilder(tableBuilder, meta)
+
+    class ColumnBuilder(tableBuilder: TableBuilder, meta: MColumn) extends super.ColumnBuilder(tableBuilder, meta) {
       /** Regex matcher to extract name and length out of a db type name with length ascription */
       final val TypePattern = "^([A-Z\\s]+)(\\(([0-9]+)\\))?$".r
       private val (_dbType,_size) = meta.typeName match {
@@ -134,7 +137,8 @@ trait SQLiteProfile extends JdbcProfile {
         case _ => super.tpe
       }
     }
-    override def createPrimaryKeyBuilder(tableBuilder: TableBuilder, meta: Seq[MPrimaryKey]): PrimaryKeyBuilder = new PrimaryKeyBuilder(tableBuilder, meta) {
+
+    class PrimaryKeyBuilder(tableBuilder: TableBuilder, meta: Seq[MPrimaryKey]) extends super.PrimaryKeyBuilder(tableBuilder, meta) {
       // in 3.7.15-M1:
       override def columns = super.columns.map(_.stripPrefix("\"").stripSuffix("\""))
     }


### PR DESCRIPTION
In particular, make the column builder easier to tweak by saving
it's many customizations in an inner class (rather than anonymous).