### PR TITLE
 Fix #1614, Fix #1807: require and warn about bad configurations

### DIFF
--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -45,7 +45,7 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
     c.getStringOpt("connectionTestQuery").foreach(hconf.setConnectionTestQuery)
     c.getStringOpt("connectionInitSql").foreach(hconf.setConnectionInitSql)
     val numThreads = c.getIntOr("numThreads", 20)
-    hconf.setMaximumPoolSize(c.getIntOr("maxConnections", numThreads * 5))
+    hconf.setMaximumPoolSize(c.getIntOr("maxConnections", numThreads))
     hconf.setMinimumIdle(c.getIntOr("minConnections", numThreads))
     hconf.setPoolName(c.getStringOr("poolName", name))
     hconf.setRegisterMbeans(c.getBooleanOr("registerMbeans", false))

--- a/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
@@ -35,7 +35,7 @@ class DataSourceTest {
     MockDriver.reset
     val db = JdbcBackend.Database.forConfig("databaseUrl")
     try {
-      assertEquals(Some(100), db.source.maxConnections)
+      assertEquals(Some(20), db.source.maxConnections)
       try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
       val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
       assertEquals("jdbc:postgresql://host/dbname", url)
@@ -50,7 +50,7 @@ class DataSourceTest {
     MockDriver.reset
     val db = JdbcBackend.Database.forConfig("databaseUrlNoPassword")
     try {
-      assertEquals(Some(100), db.source.maxConnections)
+      assertEquals(Some(20), db.source.maxConnections)
       try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
       val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
       assertEquals("jdbc:postgresql://host/dbname", url)
@@ -65,7 +65,7 @@ class DataSourceTest {
     MockDriver.reset
     val db = JdbcBackend.Database.forConfig("databaseUrlMySQL")
     try {
-      assertEquals(Some(100), db.source.maxConnections)
+      assertEquals(Some(20), db.source.maxConnections)
       try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
       val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
       assertEquals("jdbc:mysql://host/dbname?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci", url)
@@ -80,7 +80,7 @@ class DataSourceTest {
     MockDriver.reset
     val db = JdbcBackend.Database.forConfig("databaseUrlMySQLNoPassword")
     try {
-      assertEquals(Some(100), db.source.maxConnections)
+      assertEquals(Some(20), db.source.maxConnections)
       try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
       val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
       assertEquals("jdbc:mysql://host/dbname?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci", url)
@@ -95,7 +95,7 @@ class DataSourceTest {
     MockDriver.reset
     val db = JdbcBackend.Database.forConfig("altDatabaseUrl")
     try {
-      assertEquals(Some(100), db.source.maxConnections)
+      assertEquals(Some(20), db.source.maxConnections)
       try Await.result(db.run(sqlu"dummy"), Duration.Inf) catch { case ex: SQLException => }
       val (url, info) = MockDriver.getLast.getOrElse(fail("No connection data recorded").asInstanceOf[Nothing])
       assertEquals("jdbc:postgresql://host/dbname", url)
@@ -132,7 +132,7 @@ class DataSourceTest {
         |""".stripMargin
     ))
     try {
-      assertEquals("maxConnections should be numThreads * 5", Some(50), db.source.maxConnections)
+      assertEquals("maxConnections should be numThreads", Some(10), db.source.maxConnections)
     } finally db.close
   }
 

--- a/slick-testkit/src/test/scala/slick/test/jdbc/MBeansTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/MBeansTest.scala
@@ -39,7 +39,7 @@ class MBeansTest {
       Await.result(db.run(sqlu"""create alias sleep for "java.lang.Thread.sleep""""), Duration(10, TimeUnit.SECONDS))
 
       assertEquals(1, mbeanServer.getAttribute(aeBeanName, "MaxThreads"))
-      mbeanServer.getAttribute(aeBeanName, "ActiveThreads") // we expect 0 but the returned number is only an estimate
+      mbeanServer.getAttribute(aeBeanName, "ActiveThreads") // we expect 1, since minThreads == maxThreads
       assertEquals(1000, mbeanServer.getAttribute(aeBeanName, "MaxQueueSize"))
       assertEquals(0, mbeanServer.getAttribute(aeBeanName, "QueueSize"))
 

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -186,7 +186,7 @@ trait JdbcBackend extends RelationalBackend {
       *     the JDBC driver. This is preferred over using `driver`. Note that `url` is ignored when
       *     this key is set (You have to use `properties` to configure the database
       *     connection instead).</li>
-      *   <li>`maxConnections` (Int, optional, default: `numThreads` * 5): The maximum number of
+      *   <li>`maxConnections` (Int, optional, default: `numThreads`): The maximum number of
       *     connections in the pool.</li>
       *   <li>`minConnections` (Int, optional, default: same as `numThreads`): The minimum number
       *     of connections to keep in the pool.</li>
@@ -287,7 +287,7 @@ trait JdbcBackend extends RelationalBackend {
       val source = JdbcDataSource.forConfig(usedConfig, driver, path, classLoader)
       val poolName = usedConfig.getStringOr("poolName", path)
       val numThreads = usedConfig.getIntOr("numThreads", 20)
-      val maxConnections = source.maxConnections.fold(numThreads*5)(identity)
+      val maxConnections = source.maxConnections.fold(numThreads)(identity)
       val registerMbeans = usedConfig.getBooleanOr("registerMbeans", false)
       val executor = AsyncExecutor(poolName, numThreads, numThreads, usedConfig.getIntOr("queueSize", 1000),
         maxConnections, registerMbeans = registerMbeans)

--- a/slick/src/main/scala/slick/util/AsyncExecutor.scala
+++ b/slick/src/main/scala/slick/util/AsyncExecutor.scala
@@ -56,19 +56,61 @@ object AsyncExecutor extends Logging {
 
     @volatile private[this] var executor: ThreadPoolExecutor = _
 
+    if (maxConnections > maxThreads) {
+      // NOTE: when using transactions or DB locks, it may happen that a task has a lock on the database but no thread
+      // to complete its action, while other tasks may have all the threads but are waiting for the first task to
+      // complete. This creates a deadlock.
+      logger.warn("Having maxConnection > maxThreads can result in deadlocks if transactions or database locks are used.")
+    }
+
     lazy val executionContext = {
       if(!state.compareAndSet(0, 1))
         throw new IllegalStateException("Cannot initialize ExecutionContext; AsyncExecutor already shut down")
       val queue: BlockingQueue[Runnable] = queueSize match {
-        case 0 => new SynchronousQueue[Runnable]
-        case -1 => new LinkedBlockingQueue[Runnable]
-        case n => new ManagedArrayBlockingQueue(maxConnections, n).asInstanceOf[BlockingQueue[Runnable]]
+        case 0 =>
+          // NOTE: SynchronousQueue does not schedule high-priority tasks before others and so it cannot be used when
+          // the number of connections is limited (lest high-priority tasks may be holding all connections and low/mid
+          // priority tasks all threads -- resulting in a deadlock).
+          require(maxConnections == Integer.MAX_VALUE, "When using queueSize == 0 (direct hand-off), maxConnections must be Integer.MAX_VALUE.")
+
+          new SynchronousQueue[Runnable]
+        case -1 =>
+          // NOTE: LinkedBlockingQueue does not schedule high-priority tasks before others and so it cannot be used when
+          // the number of connections is limited (lest high-priority tasks may be holding all connections and low/mid
+          // priority tasks all threads -- resulting in a deadlock).
+          require(maxConnections == Integer.MAX_VALUE, "When using queueSize == -1 (unlimited), maxConnections must be Integer.MAX_VALUE.")
+
+          new LinkedBlockingQueue[Runnable]
+        case n =>
+          // NOTE: The current implementation of ManagedArrayBlockingQueue is flawned. It makes the assumption that all
+          // tasks go through the queue (which is responsible for scheduling high-priority tasks first). However, that
+          // assumption is wrong since the ThreadPoolExecutor bypasses the queue when it creates new threads. This
+          // happens when ever it creates a new thread to run a task, i.e. when minThreads < maxThreads and the number
+          // of existing threads is < maxThreads.
+          //
+          // The only way to prevent problems is to have minThreads == maxThreads when using the
+          // ManagedArrayBlockingQueue.
+          require(minThreads == maxThreads, "When using queueSize > 0, minThreads == maxThreads is required.")
+
+          // NOTE: The current implementation of ManagedArrayBlockingQueue.increaseInUseCount implicitly `require`s that
+          // maxThreads <= maxConnections.
+          require(maxThreads <= maxConnections, "When using queueSize > 0, maxThreads <= maxConnections is required.")
+
+          // NOTE: Adding up the above rules
+          // - maxThreads >= maxConnections, to prevent database locking issues when using transactions
+          // - maxThreads <= maxConnections, required by ManagedArrayBlockingQueue
+          // - maxThreads == minThreads, ManagedArrayBlockingQueue
+          //
+          // We have maxThreads == minThreads == maxConnections as the only working configuration
+
+          new ManagedArrayBlockingQueue(maxConnections, n).asInstanceOf[BlockingQueue[Runnable]]
       }
       val tf = new DaemonThreadFactory(name + "-")
       executor = new ThreadPoolExecutor(minThreads, maxThreads, keepAliveTime.toMillis, TimeUnit.MILLISECONDS, queue, tf) {
 
         /** If the runnable/task is a low/medium priority item, we increase the items in use count, because first thing it will do
-          * is open a Jdbc connection from the pool. */
+          * is open a Jdbc connection from the pool.
+          */
         override def beforeExecute(t: Thread, r: Runnable): Unit = {
           (r, queue) match {
             case (pr: PrioritizedRunnable, q: ManagedArrayBlockingQueue[Runnable]) if pr.priority != WithConnection => q.increaseInUseCount(pr)

--- a/test-dbs/testkit.travis.conf
+++ b/test-dbs/testkit.travis.conf
@@ -69,7 +69,7 @@ oracle {
     connectionPool=HikariCP
     connectionTimeout=600000
     idleTimeout=60000
-    numThreads=1
+    numThreads=5
     tableTableSpace = "slick_data"
     indexTableSpace = "slick_index"
   }
@@ -80,7 +80,7 @@ oracle {
     connectionPool=HikariCP
     connectionTimeout=600000
     idleTimeout=60000
-    numThreads=3
+    numThreads=15
   }
   create = [
     """declare


### PR DESCRIPTION
Also adjusts the default maxConnections size to be in line with best practices as discussed in #1614 