### PR TITLE
Skip sourceDataType in ResultSet when reading an MColumn

### DIFF
--- a/slick/src/main/scala/slick/jdbc/meta/MColumn.scala
+++ b/slick/src/main/scala/slick/jdbc/meta/MColumn.scala
@@ -24,7 +24,7 @@ object MColumn {
           case _ => None
         }, r.<<, r.<<, r.skip.skip.<<, r.<<, DatabaseMeta.yesNoOpt(r),
         if(r.hasMoreColumns) MQName.optionalFrom(r) else None,
-        r.nextObjectOption(),
+        if(r.hasMoreColumns) r.nextObjectOption() else None,
         if(r.hasMoreColumns) DatabaseMeta.yesNoOpt(r) else None)
   }
 }


### PR DESCRIPTION
Oracle does not always return this column. Columns both before and
after it were already guarded with `if(r.hasMoreColumns)` in
`MColumn.getColumns`, so this looks like an oversight.