### PR TITLE
case class generation now independent of column count

### DIFF
--- a/doc/code/CodeGenerator.scala
+++ b/doc/code/CodeGenerator.scala
@@ -50,12 +50,10 @@ object CodeGenerator extends App {
 
       // override table generator
       override def Table = new Table(_){
-        // disable entity class generation and mapping
-        override def EntityType = new EntityType{
-          override def classEnabled = false
-        }
+        // disable entity class generation for tables with more than 22 columns
+        override def hugeClassEnabled = false
 
-         // override contained column generator
+        // override contained column generator
         override def Column = new Column(_){
           // use the data model member of this column to change the Scala type,
           // e.g. to a custom enum or anything else

--- a/doc/src/code-generation.md
+++ b/doc/src/code-generation.md
@@ -117,8 +117,8 @@ Please see the [api documentation](codegenapi:slick.codegen.SourceCodeGenerator)
 on all of the methods that can be overridden for customization.
 
 Here is an example for customizing the generator. Noteworthy, the line `override def hugeClassEnabled = false` 
-prevents generation of case classes for tables with more than 22 columns. A `HList` based type
-will be generated instead. This was also the default behaviour before the advent of Slick 3.3.
+disables generation of case classes for tables with more than 22 columns. A `HList` based type
+will be generated instead. So this way you get back the default behavior before the advent of Slick 3.3.
 
 ```scala src=../code/CodeGenerator.scala#customization
 ```

--- a/doc/src/code-generation.md
+++ b/doc/src/code-generation.md
@@ -10,8 +10,7 @@ Overview
 --------
 By default, the code generator generates `Table` classes, corresponding `TableQuery` values, which
 can be used in a collection-like manner, as well as case classes for holding complete
-rows of values. For tables with more than 22 columns the generator automatically switches
-to Slick's experimental `HList` implementation for overcoming Scala's tuple size limit.
+rows of values. 
 
 Parts of the generator are also explained in our
 [talk at Scala eXchange 2013](http://slick.typesafe.com/docs/#20131203_patterns_for_slick_database_applications_at_scala_exchange_2013).
@@ -117,7 +116,9 @@ be accessed to drive the code generation.
 Please see the [api documentation](codegenapi:slick.codegen.SourceCodeGenerator) for info
 on all of the methods that can be overridden for customization.
 
-Here is an example for customizing the generator:
+Here is an example for customizing the generator. Noteworthy, the line `override def hugeClassEnabled = false` 
+prevents generation of case classes for tables with more than 22 columns. A `HList` based type
+will be generated instead. This was also the default behaviour before the advent of Slick 3.3.
 
 ```scala src=../code/CodeGenerator.scala#customization
 ```

--- a/doc/src/code-generation.md
+++ b/doc/src/code-generation.md
@@ -10,7 +10,7 @@ Overview
 --------
 By default, the code generator generates `Table` classes, corresponding `TableQuery` values, which
 can be used in a collection-like manner, as well as case classes for holding complete
-rows of values. 
+rows of values. Since Slick 3.3 this is even true for tables with more than 22 columns. In order to accomplish the support of case classes with such a huge parameter count, despite Scala’s tuple size limit, some of the generated functions (like `def *` and `def ?`) use `HList`s internally and thus look somewhat different but behave the same as those for tables with less columns.
 
 Parts of the generator are also explained in our
 [talk at Scala eXchange 2013](http://slick.typesafe.com/docs/#20131203_patterns_for_slick_database_applications_at_scala_exchange_2013).

--- a/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
@@ -85,11 +85,14 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
      *  Uses HList if hlistEnabled else tuple.
      */
     def compoundValue(values: Seq[Code]): Code
-    /** If HList should be used as a compound type instead of tuples.
-     * override with "hlistEnabled = columns.size > 22" to get old behavior
+    /** If HList should be used as a compound type instead of tuples. Only if hugeClassEnabled is false.
         @group Basic customization now overrides */
-    @deprecated("HLists are now used internally when needed.", "3.3.0")
-    def hlistEnabled = false;
+    def hlistEnabled = !hugeClassEnabled && columns.size > 22;
+    /**
+       Default is true, i.e. a case class will be generated even if column.size > 22.
+       Override to false to get the code as before Slick 3.3, i.e. a HList based type will be generated instead.
+       @group Basic customization now overrides */
+    def hugeClassEnabled = true
     /** Indicates whether auto increment columns should be put last and made an Option with a None default.
         Please set to !hlistEnabled for switching this on.
         @group Basic customization overrides */
@@ -104,7 +107,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     def mappingEnabled = !hlistEnabled
     /** Indicates if table has more than 22 columns but still has to be mapped to a case class.
       */
-    final def isMappedToHugeClass = !hlistEnabled && mappingEnabled && EntityType.classEnabled && columns.size > 22
+    final def isMappedToHugeClass = hugeClassEnabled && mappingEnabled && EntityType.classEnabled && columns.size > 22
     /** Function that constructs an entity object from the unmapped values
         @group Basic customization overrides */
     def factory: Code

--- a/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
@@ -13,13 +13,13 @@ import slick.relational.RelationalProfile
  * The implementation follows the virtual class pattern, which allows flexible
  * customization by overriding the inner classes (following the pattern).
  * @see http://lampwww.epfl.ch/~odersky/papers/ScalableComponent.html
-*/
+ */
 abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
-                   extends GeneratorHelpers[Code,TermName,TypeName]{ codegen =>
+  extends GeneratorHelpers[Code,TermName,TypeName]{ codegen =>
   model.assertConsistency
 
   /** Enables DDL Generation. */
-   val ddlEnabled = true
+  val ddlEnabled = true
   /** Table code generators. */
   final lazy val tables: Seq[Table] = model.tables.map(Table).sortBy(_.TableClass.rawName.toLowerCase)
   /** Table code generators indexed by db table name. */
@@ -42,7 +42,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
    * Code generator for table related code
    * @group Basic customization overrides
    * @param model corresponding Slick meta model component
-  */
+   */
   abstract case class TableDef(val model: m.Table){
     table =>
     /** Column code generators in the order they appear in the model. */
@@ -85,9 +85,11 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
      *  Uses HList if hlistEnabled else tuple.
      */
     def compoundValue(values: Seq[Code]): Code
-    /** If HList should be used as a compound type instead of tuples. Default to true for > 22 columns.
-        @group Basic customization overrides */
-    def hlistEnabled = columns.size > 22
+    /** If HList should be used as a compound type instead of tuples.
+     * override with "hlistEnabled = columns.size > 22" to get old behavior
+        @group Basic customization now overrides */
+    @deprecated("HLists are now used internally when needed.", "3.3.0")
+    def hlistEnabled = false;
     /** Indicates whether auto increment columns should be put last and made an Option with a None default.
         Please set to !hlistEnabled for switching this on.
         @group Basic customization overrides */
@@ -100,6 +102,9 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     /** Indicates if this table should be mapped using factory and extractor or not, in which case tuples are used. (Consider overriding EntityType.enabled instead, which affects this, too.) Disabled by default when using hlists.
         @group Basic customization overrides */
     def mappingEnabled = !hlistEnabled
+    /** Indicates if table has more than 22 columns but still has to be mapped to a case class.
+      */
+    final def isMappedToHugeClass = !hlistEnabled && mappingEnabled && EntityType.classEnabled && columns.size > 22
     /** Function that constructs an entity object from the unmapped values
         @group Basic customization overrides */
     def factory: Code
@@ -124,7 +129,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
       def doc =
         if(classEnabled){
           s"Entity class storing rows of table ${TableValue.name}\n" +
-         columns.map(c => "@param "+c.name+" "+c.doc).mkString("\n")
+            columns.map(c => "@param "+c.name+" "+c.doc).mkString("\n")
         } else {
           s"Row type of table ${TableValue.name}\n"
         }
@@ -136,7 +141,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     /** Plain SQL GetResult mapper generator factory. Override for customization.
         @group Basic customization overrides */
     def PlainSqlMapper: PlainSqlMapper
-    /** Plain SQL GetResult mapper generator definition 
+    /** Plain SQL GetResult mapper generator definition
         @group Basic customization overrides */
     trait PlainSqlMapperDef extends TermDef{
       def doc = s"GetResult implicit for fetching ${EntityType.name} objects using plain SQL queries"
@@ -148,7 +153,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     /** Table class generator factory. Override for customization.
         @group Basic customization overrides */
     def TableClass: TableClass
-    /** Table class generator definition 
+    /** Table class generator definition
         @group Basic customization overrides */
     trait TableClassDef extends TypeDef{
       /** The type of the elements this table yields. */
@@ -196,7 +201,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     /** Table value generator factory. Override for customization.
         @group Basic customization overrides */
     def TableValue: TableValue
-    /** Table value generator definition (generates a collection-like value representing this database table). 
+    /** Table value generator definition (generates a collection-like value representing this database table).
         @group Basic customization overrides */
     trait TableValueDef extends TermDef{
       def doc = s"Collection-like TableQuery object for table ${TableValue.name}"
@@ -211,7 +216,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     def Column    : m.Column     => Column
     /**
      * Column related generator definition
-     * @group Basic customization overrides 
+     * @group Basic customization overrides
      * @param model corresponding Slick meta model component
      */
     abstract case class ColumnDef(val model: m.Column) extends TermDef{
@@ -268,7 +273,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     /**
      * PrimaryKey related generator definition
      * (Currently only used for composite primary keys.)
-     * @group Basic customization overrides 
+     * @group Basic customization overrides
      * @param model corresponding Slick meta model component
      */
     abstract case class PrimaryKeyDef(val model: m.PrimaryKey) extends TermDef{
@@ -292,7 +297,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     def ForeignKey: m.ForeignKey => ForeignKey
     /**
      * ForeignKey related generator definition
-     * @group Basic customization overrides 
+     * @group Basic customization overrides
      * @param model corresponding Slick meta model component
      */
     abstract case class ForeignKeyDef(val model: m.ForeignKey) extends TermDef{
@@ -334,7 +339,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
     def Index     : m.Index      => Index
     /**
      * Index related generator definition
-     * @group Basic customization overrides 
+     * @group Basic customization overrides
      * @param model corresponding Slick meta model component
      */
     abstract case class IndexDef(val model: m.Index) extends TermDef{
@@ -344,9 +349,9 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
       /** Name used in the db or a default name */
       val dbName = model.name.getOrElse(table.model.name.table+"_INDEX_"+id)
       def rawName = disambiguateTerm("index"+id)
-      def doc: String = 
+      def doc: String =
         (if(model.unique)"Uniqueness " else "")+
-        "Index over "+columns.map(_.name).mkString("(",",",")")+s" (database name ${dbName})"
+          "Index over "+columns.map(_.name).mkString("(",",",")")+s" (database name ${dbName})"
     }
 
     /** Common interface for any kind of definition within the generated code */
@@ -458,7 +463,7 @@ trait GeneratorHelpers[Code,TermName,TypeName]{
     final def uncapitalize: String = str(0).toString.toLowerCase + str.tail
 
     /**
-     * Capitalizes the first (16 bit) character of each word separated by one or more '_'. Lower cases all other characters. 
+     * Capitalizes the first (16 bit) character of each word separated by one or more '_'. Lower cases all other characters.
      * Removes one '_' from each sequence of one or more subsequent '_' (to avoid collision).
      * (Warning: Not unicode-safe, uses String#apply)
      */

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
@@ -24,7 +24,7 @@ object GenerateRoundtripSources {
     val a1 = profile.createModel(ignoreInvalidDefaults=false).map(m => new SourceCodeGenerator(m) {
       override def Table = new Table(_)
       {
-        override def hlistEnabled = columns.size > 22 // hlist type instead of case classes (old default before Slick 3.3)
+        override def hugeClassEnabled = false // HList type instead of case classes (like with Slick before 3.3)
       }
       override def tableName = {
         case n if n.toLowerCase == "null" => "null" // testing null as table name

--- a/slick-testkit/src/test/scala/slick/test/codegen/CodeGenRoundTrip3Test.scala
+++ b/slick-testkit/src/test/scala/slick/test/codegen/CodeGenRoundTrip3Test.scala
@@ -1,0 +1,79 @@
+package slick.test.codegen
+
+import com.typesafe.slick.testkit.util.StandardTestDBs._
+import com.typesafe.slick.testkit.util.{DBTest, DBTestObject, JdbcTestDB}
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object CodeGeneratorRoundTrip3Test extends DBTestObject(H2Mem, SQLiteMem, Postgres, MySQL, DerbyMem, HsqldbMem, SQLServerJTDS, SQLServerSQLJDBC)
+
+class CodeGeneratorRoundTrip3Test(val tdb: JdbcTestDB) extends DBTest {
+  import tdb.profile.quoteIdentifier
+
+  @Test def test: Unit = runBlocking {
+    object Tables extends roundtrip.Tables { val profile = tdb.profile }
+    import Tables._
+    import Tables.profile.api._
+    GetResultPostsRow
+    GetResultLargeRow
+
+    DBIO.seq(
+      schema.create,
+      Categories += CategoriesRow(1,"cat"),
+      Posts ++= Seq(
+        PostsRow(1,"post 1",Some(1)),
+        PostsRow(2,"post 2",Some(1)),
+        PostsRow(3,"post 3",Some(1))
+      ),
+      Categories += CategoriesRow(2,"cat"),
+      Posts.length.result.zip(Posts.filter(_.title =!= "post 1").map(_.title).to[List].result).map(res => assertEquals((3,List("post 2","post 3")), res)),
+      sql"""select * from #${quoteIdentifier("POSTS")} where #${quoteIdentifier("id")} = 2""".as[PostsRow].head.map(res => assertEquals(PostsRow(2,"post 2",Some(1)), res)),
+      {
+        import slick.jdbc.JdbcCapabilities
+        if(tdb.profile.capabilities.contains(JdbcCapabilities.forceInsert)){
+          DBIO.seq(
+            SelfRef.forceInsert(SelfRefRow(1,None)),
+            SelfRef.forceInsert(SelfRefRow(2,Some(1))))
+        }else
+          DBIO.seq()
+      },
+      SelfRef.result,
+      {
+        // Testing table larger 22 columns
+        val oData = LargeRow( 0L, 11, 12, 13, 14, 15, 16, 21, 22, 23, 24, 25, 26, 31, 32, 33, 34, 35, 36, 41, 42, 43, 44, 45, 46, 51, 52, 53, 54, 55, 56, 61, 62, 63, 64, 65, 66 )
+        val oData2 = LargeRow( 1L, p6i4 = 123, p1i5 = 456 )
+        DBIO.seq(
+          Large += oData,
+          Large += oData2,
+          sql"""select * from #${quoteIdentifier("LARGE")} where #${quoteIdentifier("id")} = 0""".as[LargeRow].head.map(res => assertEquals(oData, res))
+        )
+      },
+      (X.map(r => (r.pk,r.pk2,r.column,r.schemaNameXX,r.schemaNameX)) += (1,1,1,1.1,"test")).map { _ =>
+        // testing name and types especially in case of collisions
+        import slick.lifted._
+        X.map(r =>{(r.pk: Rep[Int]) == null})
+        X.map(r =>{(r.pk2: Rep[Int]) == null})
+        X.map(r =>{(r.`val`: Rep[Option[Int]]) == null})
+        X.map(r =>{(r.column: Rep[Int]) == null})
+        X.map(r =>{(r.schemaNameXX: Rep[Double]) == null})
+        X.map(r =>{(r.schemaNameX: Rep[String]) == null})
+        X.map(r =>{(r.index1: Rep[Option[Int]]) == null})
+        X.map(r =>{(r.posts: Rep[Option[Int]]) == null})
+        X.map(r =>{(r.pkX: PrimaryKey) == null})
+        X.map(r =>{(r.postsFk: ForeignKeyQuery[Posts,PostsRow]) == null})
+        X.map(r =>{(r.categoriesFk2: ForeignKeyQuery[Categories,CategoriesRow]) == null})
+        X.map(r =>{(r.categoriesFk3: ForeignKeyQuery[Categories,CategoriesRow]) == null})
+        X.map(r =>{(r.index1X: Index) == null})
+        X.map(r =>{(r.index2: Index) == null})
+        X.map(r =>{(r.index1X: Index) == null})
+        X.map(r =>{(r.index2: Index) == null})
+        X.map(r =>{(r.index3: Index) == null})
+        X.map(r =>{(r.index4: Index) == null})
+
+        TypeTest.map(r =>{(r.pk: PrimaryKey) == null})
+      }
+    ).withPinnedSession
+  }
+}


### PR DESCRIPTION
For obsolete historic reasons, until now slick-codegen generates a case class for tables having up to 22 columns and only a type otherwise. With this change slick-codegen uniformly creates case classes no matter how many columns a table has.

Thanks for considering my pull request.