### PR TITLE
New H2 jdbc library version to allow timestamp with timezone types.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,7 +37,7 @@ object SlickBuild extends Build {
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val hikariCP = "com.zaxxer" % "HikariCP" % "2.7.4"
     val mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
-    val h2 = "com.h2database" % "h2" % "1.4.191"
+    val h2 = "com.h2database" % "h2" % "1.4.197"
     val testDBs = Seq(
       h2,
       "org.apache.derby" % "derby" % "10.11.1.1",

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
@@ -81,7 +81,7 @@ class Tables(val profile: JdbcProfile){
   class X(tag: Tag) extends Table[(Int,Int,Option[Int],Int,Double,String,Option[Int],Option[Int],Option[String],Option[String],Option[String])](tag, "X") {
     def pk = column[Int]("pk")
     def pk2 = column[Int]("pk2")
-    def pkpk = primaryKey( "", (pk,pk2) ) // pk column collision
+    def pkpk = primaryKey( "primary_key2", (pk,pk2) ) // pk column collision
     def i1 = column[Option[Int]]("index_1") // scala keyword collision
     def c = column[Int]("column") // slick Table method with args collision
     def p = column[Option[Int]]("posts")


### PR DESCRIPTION
H2 handling of un-named db artifacts has changed. They now get a name of null and
so if there is more than one un-named db artifact, there will be a name
clash.