### PR TITLE
"val" modifier is redundant for parameter of case class primary const…

### DIFF
--- a/slick/src/main/scala/slick/ast/ClientSideOp.scala
+++ b/slick/src/main/scala/slick/ast/ClientSideOp.scala
@@ -27,7 +27,7 @@ object ClientSideOp {
 }
 
 /** Get the first element of a collection. For client-side operations only. */
-final case class First(val child: Node) extends UnaryNode with SimplyTypedNode with ClientSideOp {
+final case class First(child: Node) extends UnaryNode with SimplyTypedNode with ClientSideOp {
   type Self = First
   protected[this] def rebuild(ch: Node) = copy(child = ch)
   protected def buildType = child.nodeType.asCollectionType.elementType

--- a/slick/src/main/scala/slick/relational/RelationalProfile.scala
+++ b/slick/src/main/scala/slick/relational/RelationalProfile.scala
@@ -90,7 +90,7 @@ object RelationalProfile {
   /** Extra column options for RelationalProfile */
   object ColumnOption {
     /** Default value for the column. Needs to wrap an Option for nullable Columns. */
-    case class Default[T](val defaultValue: T) extends ColumnOption[T]
+    case class Default[T](defaultValue: T) extends ColumnOption[T]
 
     /** Number of unicode characters for string-like types. Unlike DBType this is portable
       * between different DBMS. Note that for DDL Slick currently picks type CHAR when

--- a/slick/src/main/scala/slick/sql/SqlProfile.scala
+++ b/slick/src/main/scala/slick/sql/SqlProfile.scala
@@ -119,7 +119,7 @@ object SqlProfile {
       *
       * Note that Slick uses VARCHAR or VARCHAR(254) in DDL for String columns if neither
       * ColumnOption DBType nor Length are given. */
-    case class SqlType(val typeName: String) extends ColumnOption[Nothing]
+    case class SqlType(typeName: String) extends ColumnOption[Nothing]
   }
 }
 


### PR DESCRIPTION
"val" modifier is redundant for parameter of case class primary constructor.