### PR TITLE
Added `filterOpt` and `filterIf` to `Query`.

### DIFF
--- a/doc/code/LiftedEmbedding.scala
+++ b/doc/code/LiftedEmbedding.scala
@@ -201,7 +201,7 @@ object LiftedEmbedding extends App {
       // building criteria using a "dynamic filter" e.g. from a webform.
       val criteriaColombian = Option("Colombian")
       val criteriaEspresso = Option("Espresso")
-      val criteriaRoast:Option[String] = None
+      val criteriaRoast: Option[String] = None
 
       val q4 = coffees.filter { coffee =>
         List(
@@ -215,11 +215,37 @@ object LiftedEmbedding extends App {
       //     from "COFFEES"
       //     where ("COF_NAME" = 'Colombian' or "COF_NAME" = 'Espresso')
 
+      // Conditional filtering with option e.g. from a webform.
+      val optionFromPrice = Option(20.0)
+      val optionToPrice: Option[Double]  = None
+
+      val q5 = coffees
+        .filterOpt(optionFromPrice)(_.price > _)
+        .filterOpt(optionToPrice)(_.price < _) // won't be added as a condition as `optionToPrice` evaluates to `None`
+      // compiles to SQL (simplified):
+      //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
+      //     from "COFFEES"
+      //     where "PRICE" > 20.0
+
+      // Conditional filtering with boolean e.g. from a webform.
+      val isRoast = true
+      val isEspresso = false
+
+      val q6 = coffees
+        .filterIf(isRoast)(_.price > 11.0)
+        .filterIf(isEspresso)(_.price > 11.0) // won't be added as a condition as `isEspresso` evaluates to `false`
+      // compiles to SQL (simplified):
+      //   select "COF_NAME", "SUP_ID", "PRICE", "SALES", "TOTAL"
+      //     from "COFFEES"
+      //     where "PRICE" > 11.0
+
       //#filtering
       println(q1.result.statements.head)
       println(q2.result.statements.head)
       println(q3.result.statements.head)
       println(q4.result.statements.head)
+      println(q5.result.statements.head)
+      println(q6.result.statements.head)
     }
 
     ;{

--- a/slick-testkit/src/test/scala/slick/test/lifted/QueryMethodTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/QueryMethodTest.scala
@@ -1,0 +1,47 @@
+package slick.test.lifted
+
+import org.junit.Assert._
+import org.junit.Test
+
+/** Test cases for filterIf and filterOpt */
+class QueryMethodTest {
+
+  @Test def testQueryMethod = {
+    import slick.jdbc.H2Profile.api._
+
+    class T(tag: Tag) extends Table[(Int, String, Option[String], Double)](tag, Some("myschema"), "mytable") {
+      def id = column[Int]("id")
+      def myString = column[String]("myString")
+      def optString = column[Option[String]]("optString")
+      def price = column[Double]("PRICE")
+      def * = (id, myString, optString, price)
+    }
+
+    val ts = TableQuery[T]
+
+    val s1 = ts.filterOpt(Option.empty[String])(_.myString === _).result.statements.head
+    println(s1)
+    assertTrue("filterOpt adds no condition when the given option is empty", s1 endsWith """from "myschema"."mytable"""")
+
+    val s2 = ts.filterOpt(Some("something"))(_.myString === _).result.statements.head
+    println(s2)
+    assertTrue("filterOpt adds a condition when the given option is present", s2 endsWith """where "myString" = 'something'""")
+    
+    val s3 = ts.filterOpt(Some("something"))(_.myString === _).filterOpt(Option.empty[String])(_.myString like _).filterOpt(Some("something"))(_.myString startsWith _).result.statements.head
+    println(s3)
+    assertTrue("filterOpt stacks", s3 endsWith """where ("myString" = 'something') and ("myString" like 'something%' escape '^')""")
+
+    val s4 = ts.filterIf(false)(_.myString == "wonderful").result.statements.head
+    println(s4)
+    assertTrue("filterIf adds no condition when the given option is present", s4 endsWith """from "myschema"."mytable"""")
+
+    val s5 = ts.filterIf(true)(_.myString startsWith "foo").result.statements.head
+    println(s5)
+    assertTrue("filterIf adds a condition when the given option is present", s5 endsWith """where "myString" like 'foo%' escape '^'""")
+
+    val s6 = ts.filterIf(false)(_.myString endsWith "nope").filterIf(true)(_.myString === "stack").filterIf(true)(_.myString endsWith "yes").result.statements.head
+    println(s6)
+    assertTrue("filterIf stacks", s6 endsWith """where ("myString" = 'stack') and ("myString" like '%yes' escape '^')""")
+
+  }
+}

--- a/slick/src/main/scala/slick/lifted/Query.scala
+++ b/slick/src/main/scala/slick/lifted/Query.scala
@@ -54,6 +54,16 @@ sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
   def filterNot[T <: Rep[_]](f: E => T)(implicit wt: CanBeQueryCondition[T]): Query[E, U, C] =
     filterHelper(f, node => Library.Not.typed(node.nodeType, node) )
 
+  /** Applies the given predicate, if the optional value is present,
+    * if the value is not present, the predicate will not be part of the query. */
+  def filterOpt[V, T <: Rep[_] : CanBeQueryCondition](optValue: Option[V])(f: (E, V) => T): Query[E, U, C] =
+    optValue.map(v => withFilter(a => f(a, v))).getOrElse(this)
+
+  /** Applies the given predicate, if the given boolean parameter evaluates to true,
+    * if the value is not present, the predicate will not be part of the query. */
+  def filterIf(p: Boolean)(f: E => Rep[Boolean]): Query[E, U, C] =
+    if (p) withFilter(f) else this
+
   /** Select all elements of this query which satisfy a predicate. This method
     * is used when desugaring for-comprehensions over queries. There is no
     * reason to call it directly because it is the same as `filter`. */


### PR DESCRIPTION
Fixes #1820 

Added examples to the documentation.

Created a new test class(`QueryMethodTest`) for `filterOpt` and `filterIf`. I had a hard time finding a good place to put the tests, so I decided on a clean test class.