### PR TITLE
Avoid extra .decreaseInUseCount() of issue #1856

### DIFF
--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -312,7 +312,14 @@ trait BasicBackend { self =>
               var state = initialState
               ctx.readSync
 
-              if(state eq null) acquireSession(ctx)
+              if(state eq null) {
+                try {
+                  acquireSession(ctx)
+                } catch { case NonFatal(ex) =>
+                  if (!ctx.isPinned) connectionReleased = true
+                  throw ex
+                }
+              }
               var demand = ctx.demandBatch
               var realDemand = if(demand < 0) demand - Long.MinValue else demand
 
@@ -336,17 +343,18 @@ trait BasicBackend { self =>
 
                   if(state eq null) { // streaming finished and cleaned up
                     releaseSession(ctx, true)
+                    if (!ctx.isPinned) connectionReleased = true
                     ctx.streamingResultPromise.trySuccess(null)
                   }
 
                 } catch { case NonFatal(ex) =>
                   if(state ne null) try a.cancelStream(ctx, state) catch ignoreFollowOnError
                   releaseSession(ctx, true)
+                  if (!ctx.isPinned) connectionReleased = true
                   throw ex
 
                 } finally {
                   ctx.streamState = state
-                  if (!ctx.isPinned && ctx.priority(continuation) != WithConnection) connectionReleased = true
                   ctx.sync = 0
                 }
 
@@ -368,7 +376,6 @@ trait BasicBackend { self =>
             } catch {
               case NonFatal(ex) => ctx.streamingResultPromise.tryFailure(ex)
             } finally {
-              if (!ctx.isPinned && ctx.priority(continuation) != WithConnection) connectionReleased = true
               ctx.sync = 0
             }
         })


### PR DESCRIPTION
"count cannot be decreased" of issue #1856 seems to happen as follows:

1. `ctx.delivered(demand)` in a `PrioritizedRunnable` of `.scheduleSynchronousStreaming` returns 0.
2. A subscriber of `ctx` calls `ctx.request()`.
3. `ctx.request()` calls `.scheduleSynchronousStreaming` (via `.restartStreaming`) and it creates a new `PrioritizedRunnable`.
4. The new `PrioritizedRunnable` calls `releaseSession` and sets its `connectionReleased` true.
5. `PrioritizedRunnable` of the step 1 also sets its `connectionReleased` true because `ctx.currentSession` is released by step 4.
6. `decreaseInUseCount` is called twice because of the two `PrioritizedRunnable` with `connectionReleased`.

The above can be demonstrated by inserting something like `Thread.sleep(100L)` immediately after `while ((state ne null) && realDemand > 0)`.

This PR resolves the problem by preventing `PrioritizedRunnable` from setting `connectionReleased` unless it actually releases the session.

Whereas "count cannot be decreased" seems to [disappear on Travis CI](https://travis-ci.org/hirofumi/slick/builds/383487585), it was hard for me to add a unit test which covers the problem. I would appreciate any suggestions.
