### PR TITLE
added configuration example for MySQL to docs for issue #1861

### DIFF
--- a/doc/code/application.conf
+++ b/doc/code/application.conf
@@ -22,6 +22,16 @@ mydb = {
 }
 //#postgres
 
+//#mysql
+mydb = {
+  driver = "com.mysql.cj.jdbc.Driver",
+  url = "jdbc:mysql://127.0.0.1:3306/mydb?serverTimezone=UTC",
+  user = "user",
+  password = "pass",
+  connectionPool = disabled
+}
+//#mysql
+
 //#tsql
 tsql {
   profile = "slick.jdbc.H2Profile$"

--- a/doc/src/database.md
+++ b/doc/src/database.md
@@ -12,7 +12,16 @@ Using Typesafe Config
 The preferred way to configure database connections is through [Typesafe Config] in your
 `application.conf`, which is also used by [Play] and [Akka] for their configuration.
 
-For Postgres: 
+Such a configuration can be loaded with `Database.forConfig` (see the
+[API documentation](api:slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database)
+of this method for details on the configuration parameters).
+
+```scala src=../code/Connection.scala#forConfig
+```
+
+#### Examples
+
+##### PostgreSQL
 ```yaml src=../code/application.conf#postgres
 ```
 
@@ -27,11 +36,17 @@ libraryDependencies ++= Seq(
 )
 ``` 
 
-Such a configuration can be loaded with `Database.forConfig` (see the
-[API documentation](api:slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database)
-of this method for details on the configuration parameters).
+##### MySQL
 
-```scala src=../code/Connection.scala#forConfig
+Very simple example without a connection pool and using the driver directly:
+
+```yaml src=../code/application.conf#mysql
+```
+
+To use the MySQL driver, the following library dependency needs to be configured via SBT:
+
+```scala expandVars=true
+libraryDependencies += "mysql" % "mysql-connector-java" % "6.0.6"
 ```
 
 Using a JDBC URL {index=URL}


### PR DESCRIPTION
Added application.conf snippet and instructions how to set up MySQL without a connection pool. Also re-arranged the documentation page a bit and introduced sub-headings for the examples.

This was missing for #1861