### PR TITLE
MySQL - Table meta data fix

### DIFF
--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -99,7 +99,7 @@ trait OracleProfile extends JdbcProfile {
   override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] = {
     for {
       user <- SimpleJdbcAction(_.session.metaData.getUserName)
-      mtables <- MTable.getTables(None, Some(user), None, Some(Seq("TABLE")))
+      mtables <- MTable.getTables(None, Some(user), Some("%"), Some(Seq("TABLE")))
     } yield mtables
   }
 

--- a/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
@@ -140,7 +140,7 @@ trait PostgresProfile extends JdbcProfile {
     new ModelBuilder(tables, ignoreInvalidDefaults)
 
   override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] =
-    MTable.getTables(None, None, None, Some(Seq("TABLE")))
+    MTable.getTables(None, None, Some("%"), Some(Seq("TABLE")))
 
   override val columnTypes = new JdbcTypes
   override protected def computeQueryCompiler = super.computeQueryCompiler - Phase.rewriteDistinct

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -118,7 +118,7 @@ trait SQLServerProfile extends JdbcProfile {
     new ModelBuilder(tables, ignoreInvalidDefaults)
 
   override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] = {
-    MTable.getTables(None, None, None, Some(Seq("TABLE"))).map(_.filter(!_.name.schema.contains("sys")))
+    MTable.getTables(None, None, Some("%"), Some(Seq("TABLE"))).map(_.filter(!_.name.schema.contains("sys")))
   }
 
   override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {

--- a/slick/src/main/scala/slick/jdbc/meta/MTable.scala
+++ b/slick/src/main/scala/slick/jdbc/meta/MTable.scala
@@ -23,6 +23,12 @@ case class MTable(
 }
 
 object MTable {
+  /**
+    * Some DatabaseMetaData methods take arguments that are String patterns. These arguments all have names such as fooPattern.
+    * Within a pattern String, "%" means match any substring of 0 or more characters, and "_" means match any one character.
+    * Only metadata entries matching the search pattern are returned.
+    * If a search pattern argument is set to null, that argument's criterion will be dropped from the search.
+    */
   def getTables(cat: Option[String], schemaPattern: Option[String], namePattern: Option[String],
     types: Option[Seq[String]]) = ResultSetAction[MTable](
       _.metaData.getTables(cat.orNull, schemaPattern.orNull, namePattern.orNull, types.map(_.toArray).orNull) ) { r =>


### PR DESCRIPTION
Fixes issue #1692 for MySQL.

Tests in `JdbcMetaTest` cover this change, since they call the method `defaultTables`.
This makes PR #1717 somewhat obsolete, at least in regards to MySQL.

[MySQL connector/J 8.x](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-properties-changed.html) has changed `nullCatalogMeansCurrent` to now default to false, so the MySQLProfile `defaultTables` now fetches the current catalog from the connection.

We currently only run the test suite on MySQL 5.x series, but I've tested locally with 6.x and 8.x as well.

I have not looked into #1485 yet, but I can see that the SQLServerProfile has its own override of `defaultTables`. I'll look into this separately.
