### PR TITLE
Remove Europe/Kaliningrad from the list of timezones we test with. Ka…

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -349,7 +349,6 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
     "America/Argentina/Cordoba",
     "America/Argentina/Salta",
     "Etc/GMT+7",
-    "Europe/Kaliningrad",
     "Antarctica/Davis",
     "Mexico/BajaSur",
     "Australia/ACT",


### PR DESCRIPTION
…liningrad change its DST in 2016 and so the Oracle docker image we test with and the JVM versions are out of sync with respect to timetone data. This is problematic when rendering literal zoneddatetimes.