### PR TITLE
For MySQL DDL, add escaped schema name to ALTER TABLE DROP statements…

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/MySQLDDLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/MySQLDDLTest.scala
@@ -2,36 +2,52 @@ package slick.test.lifted
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import scala.collection.JavaConverters._
 
 /** Test case for the MySQL SQL DDL overrides */
-class MysqlDDLTest {
+@RunWith(classOf[Parameterized])
+class MysqlDDLTest(testSchema: Option[String]) {
   import slick.jdbc.MySQLProfile.api._
 
   @Test def testTablenameEscaped: Unit = {
-    class T(tag: Tag) extends Table[Int](tag, "mytable") {
+    class T(tag: Tag) extends Table[Int](tag, testSchema, "mytable") {
       def id = column[Int]("id", O.PrimaryKey)
 
       def * = id
     }
     val ts = TableQuery[T]
 
-    class T2(tag: Tag) extends Table[Int](tag, "mytable2") {
+    val table2Name = "mytable2"
+    val fkName = "t_test_fk"
+    class T2(tag: Tag) extends Table[Int](tag, testSchema, table2Name) {
       def id = column[Int]("id", O.PrimaryKey)
 
       def testFk = column[Int]("test_fk")
-      def fk = foreignKey("t_test_fk", testFk, ts)(_.id)
+      def fk = foreignKey(fkName, testFk, ts)(_.id)
 
       def * = id
     }
     val ts2 = TableQuery[T2]
 
-    val s1 = ts2.schema.createStatements.toList
-    assertTrue("DDL (create) must contain any SQL statements", s1.nonEmpty)
-    s1.foreach(s => assertTrue("DDL (create) uses escaped table name: " + s, s contains "`mytable2`"))
-    assertTrue("Fk name must be escaped", s1.exists(_.contains("`t_test_fk`")))
+    // if schema specified, add escaped schema name to qualify the table name
+    val escapedSchemaName = testSchema.map(name => s"`$name`.").getOrElse("")
+    val table2QualifiedName = s"$escapedSchemaName`$table2Name`"
+    val fkEscapedName = s"`$fkName`"
+    val t2CreateStatements = ts2.schema.createStatements.toList
+    assertTrue("DDL (create) must contain any SQL statements", t2CreateStatements.nonEmpty)
+    t2CreateStatements.foreach(s => assertTrue("DDL (create) uses escaped table name: " + s, s contains table2QualifiedName))
+    assertTrue("Fk name must be escaped", t2CreateStatements.exists(_.contains(fkEscapedName)))
 
-    val s2 = ts2.schema.dropStatements.toList
-    s2.foreach(s => assertTrue("DDL (drop) uses escaped table name: " + s, s contains "`mytable2`"))
-    assertTrue("Fk name must be escaped", s2.exists(_.contains("`t_test_fk`")))
+    val t2DropStatements = ts2.schema.dropStatements.toList
+    t2DropStatements.foreach(s => assertTrue("DDL (drop) uses escaped table name: " + s, s contains table2QualifiedName))
+    assertTrue("Fk name must be escaped", t2DropStatements.exists(_.contains(fkEscapedName)))
   }
+}
+
+object MysqlDDLTest {
+  @Parameterized.Parameters
+  // test with no schema defined and a schemaName specified
+  def testSchemaParameter = List[Option[String]](None, Some("schemaName")).map(Array(_)).asJava
 }

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -249,10 +249,10 @@ trait MySQLProfile extends JdbcProfile { profile =>
 
   class TableDDLBuilder(table: Table[_]) extends super.TableDDLBuilder(table) {
     override protected def dropForeignKey(fk: ForeignKey) = {
-      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP FOREIGN KEY " + quoteIdentifier(fk.name)
+      "ALTER TABLE " + quoteTableName(table.tableNode) + " DROP FOREIGN KEY " + quoteIdentifier(fk.name)
     }
     override protected def dropPrimaryKey(pk: PrimaryKey): String = {
-      "ALTER TABLE " + quoteIdentifier(table.tableName) + " DROP PRIMARY KEY"
+      "ALTER TABLE " + quoteTableName(table.tableNode) + " DROP PRIMARY KEY"
     }
   }
 


### PR DESCRIPTION
…, where a schema is specified

This is an alternative PR to #1898 for issue #1897 

I hope you don’t mind me having a stab at this PR. When I noticed it, it reminded me that we have this test `MySQLDDLTest` that was added at the same time the specializations for the TableDDL to the MySQL profile https://github.com/smootoo/slick/commit/1f493265ba3652a202763d1aaf8d4a83e4498770#diff-8bb527e7653e6ba433e09399c3a87877.
This test is less than ideal as it doesn’t actually run any of the commands, but it is what’s there right now. By updating this test, we can assert the expected command structure with and without schemas specified, that is fixed by @NicolasRouquette’s proposed change. It’s isn’t the cross database test of schema qualifaction that was attempted in PR #1898, but as was noted there, the test infrastructure isn’t in place to handle that. 
So this PR feels like an incremental improvement on what we have at the moment and exercises the change that @NicolasRouquette proposed.
