### PR TITLE
Log SQL with values for insert/update statements

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -471,11 +471,13 @@ trait JdbcBackend extends RelationalBackend {
     }
 
     protected def loggingStatement(st: Statement): Statement =
-      if(JdbcBackend.statementLogger.isDebugEnabled || JdbcBackend.benchmarkLogger.isDebugEnabled)
+      if(JdbcBackend.statementLogger.isDebugEnabled || JdbcBackend.benchmarkLogger.isDebugEnabled ||
+        JdbcBackend.statementAndParameterLogger.isDebugEnabled)
         new LoggingStatement(st) else st
 
     protected def loggingPreparedStatement(st: PreparedStatement): PreparedStatement =
-      if(JdbcBackend.statementLogger.isDebugEnabled || JdbcBackend.benchmarkLogger.isDebugEnabled || JdbcBackend.parameterLogger.isDebugEnabled)
+      if(JdbcBackend.statementLogger.isDebugEnabled || JdbcBackend.benchmarkLogger.isDebugEnabled ||
+        JdbcBackend.parameterLogger.isDebugEnabled || JdbcBackend.statementAndParameterLogger.isDebugEnabled)
         new LoggingPreparedStatement(st) else st
 
     /** Start a `transactionally` block */
@@ -575,6 +577,7 @@ object JdbcBackend extends JdbcBackend {
   protected[jdbc] lazy val statementLogger = new SlickLogger(LoggerFactory.getLogger(classOf[JdbcBackend].getName+".statement"))
   protected[jdbc] lazy val benchmarkLogger = new SlickLogger(LoggerFactory.getLogger(classOf[JdbcBackend].getName+".benchmark"))
   protected[jdbc] lazy val parameterLogger = new SlickLogger(LoggerFactory.getLogger(classOf[JdbcBackend].getName+".parameter"))
+  protected[jdbc] lazy val statementAndParameterLogger = new SlickLogger(LoggerFactory.getLogger(classOf[JdbcBackend].getName+".statementAndParameter"))
 
   protected[jdbc] def logStatement(msg: String, stmt: String) = if(statementLogger.isDebugEnabled) {
     val s = if(GlobalConfig.sqlIndent) msg + ":\n" + LogUtil.multilineBorder(stmt) else msg + ": " + stmt


### PR DESCRIPTION
Hi!

I want to try to close issue #1317, at first I saw pull request #1810 that will also close this issue, but for a long time the author doesn't reply to @d6y [comment](https://github.com/slick/slick/pull/1810#issuecomment-341989355). 

I [asked](https://github.com/slick/slick/pull/1810#issuecomment-401968551) if I can create a new PR with the changes asked by @d6y, after I get the go, I created this pull request.

So I created an additional logger `JdbcBackend.statementAndParameters` because we want to avoid changing the current behaviour of `JdbcBackend.statement`. Just like the original PR author @landlockedsurfer said. Adding the logger:

```
<logger name="slick.jdbc.JdbcBackend.statementAndParameter" level="DEBUG" />
```

will log executable SQL statements with real value instead of `?`


Cheers,
Fajr