### PR TITLE
Log SQL with values for batch insert

### DIFF
--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -172,7 +172,14 @@ class LoggingPreparedStatement(st: PreparedStatement) extends LoggingStatement(s
     }
   }
 
-  def addBatch(): Unit = { pushParams; st.addBatch() }
+  def addBatch(): Unit = {
+    pushParams
+    if (JdbcBackend.statementAndParameterLogger.isDebugEnabled) {
+      logged(st.toString, "batch insert") { st.addBatch() }
+    } else {
+      st.addBatch()
+    }
+  }
   def clearParameters(): Unit = { clearParamss; st.clearParameters() }
 
   def getMetaData(): js.ResultSetMetaData = st.getMetaData


### PR DESCRIPTION
Using the new logger `statementAndParameters` we can log the values for batch insert

see @d6y [comments](https://github.com/slick/slick/pull/1936#issuecomment-405364703) and #1942 

Adding the logger:

```
<logger name="slick.jdbc.JdbcBackend.statementAndParameter" level="DEBUG" />
```

will log executable SQL statements with real value instead of `?`

cc: @trevorsibanda 

Thank you
