### PR TITLE
Extend docu for update queries

### DIFF
--- a/doc/code/LiftedEmbedding.scala
+++ b/doc/code/LiftedEmbedding.scala
@@ -431,6 +431,21 @@ object LiftedEmbedding extends App {
     }
 
     ;{
+      //#update2
+      val q = coffees.filter(c.name === "Espresso").map(coffee => (coffee.name, coffee.price))
+      // A Lungo is more expensive:
+      val updateAction = q.update(("Espresso Lungo", 12.88))
+
+      // Get the statement without having to specify an updated value:
+      val sql = q.updateStatement
+
+      // compiles to SQL:
+      //   update "COFFEES" set "COF_NAME" = ?, "PRICE" = ? where "COFFEES"."COF_NAME" = 'Espresso'
+      //#update2
+      println(sql)
+    }
+
+    ;{
       Await.result(db.run(
         usersForInsert ++= Seq(
           User(None,"",""),

--- a/doc/code/LiftedEmbedding.scala
+++ b/doc/code/LiftedEmbedding.scala
@@ -432,7 +432,7 @@ object LiftedEmbedding extends App {
 
     ;{
       //#update2
-      val q = coffees.filter(c.name === "Espresso").map(coffee => (coffee.name, coffee.price))
+      val q = coffees.filter(_.name === "Espresso").map(coffee => (coffee.name, coffee.price))
       // A Lungo is more expensive:
       val updateAction = q.update(("Espresso Lungo", 12.88))
 

--- a/doc/src/queries.md
+++ b/doc/src/queries.md
@@ -281,6 +281,11 @@ updating are defined in
 There is currently no way to use scalar expressions or transformations of
 the existing data in the database for updates.
 
+When you want to update multiple columns at once, just map to a tuple first:
+
+```scala src=../code/LiftedEmbedding.scala#update2
+```
+
 Upserting
 ---------
 


### PR DESCRIPTION
Extending documentation example for update queries. Especially, how to update multiple columns at once.