### PR TITLE
[WIP] Add JDK 11 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 - docker ps
 jdk:
   - oraclejdk8
+  - openjdk11
 notifications:
   flowdock:
     secure: j3YP9TjiIcMRy2mvunF1AHBOFnz2H7mZAFVbHPBNkAjMCwSdBNvLpn33qv6ybr02c5snBDJTs0P70RJ/mh3YsqwnIeloQD9HUfnndKQD6ujxx1QWRI/lVDW4pfVRQEuPsXdW/3AiqxrSG5BS4thiyc3vj3LpnodHwNMUT+Nlmq0=

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These are the databases and driver versions that have explicit automated tests.
 |Database|JDBC Driver|Build status|
 |--------|-----------|-----------:|
 |SQLServer 2008, 2012, 2014, 2017|[jtds:1.2.8](http://sourceforge.net/projects/jtds/files/jtds/) and [msjdbc:4.2](https://www.microsoft.com/en-gb/download/details.aspx?id=11774)|[![Build status](https://ci.appveyor.com/api/projects/status/hcy6w0cp2qgw6ltt/branch/master?svg=true)](https://ci.appveyor.com/project/slick/slick)|
-|Oracle 11g|[ojdbc7:12.1.0.2](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|Oracle 11g|[ojdbc7:12.2.0.1](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |DB2 10.5|[db2jcc4:4.19.20](http://www-01.ibm.com/support/docview.wss?uid=swg21363866)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |MySQL|mysql-connector-java:5.1.23|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |PostgreSQL|postgresql:9.1-901.jdbc4|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,7 +36,14 @@ object SlickBuild extends Build {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
     val hikariCP = "com.zaxxer" % "HikariCP" % "2.7.4"
-    val mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
+    val jaxbVersion = "2.3.0"
+    val jaxb = Seq(
+      "javax.xml.bind" % "jaxb-api" % jaxbVersion % "provided",
+      "com.sun.xml.bind" % "jaxb-core" % jaxbVersion,
+      "com.sun.xml.bind" % "jaxb-impl" % jaxbVersion
+    )
+
+    val mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams) ++ jaxb
     val h2 = "com.h2database" % "h2" % "1.4.197"
     val testDBs = Seq(
       h2,
@@ -311,7 +318,8 @@ object SlickBuild extends Build {
         Dependencies.junit ++:
         (Dependencies.reactiveStreamsTCK % "test") +:
         (Dependencies.logback +: Dependencies.testDBs).map(_ % "test") ++:
-        (Dependencies.logback +: Dependencies.testDBs).map(_ % "codegen"),
+        (Dependencies.logback +: Dependencies.testDBs).map(_ % "codegen") ++: 
+        (Dependencies.jaxb),
       parallelExecution in Test := false,
       fork in run := true,
       //connectInput in run := true,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,7 +35,7 @@ object SlickBuild extends Build {
     val reactiveStreamsVersion = "1.0.2"
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
     val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
-    val hikariCP = "com.zaxxer" % "HikariCP" % "2.7.4"
+    val hikariCP = "com.zaxxer" % "HikariCP" % "2.7.8"
     val jaxbVersion = "2.3.0"
     val jaxb = Seq(
       "javax.xml.bind" % "jaxb-api" % jaxbVersion % "provided",

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -261,7 +261,7 @@ abstract class ExternalJdbcTestDB(confName: String) extends JdbcTestDB(confName)
   }
 }
 
-private object MyClassLoader extends URLClassLoader(Array.empty) {
+private object MyClassLoader extends URLClassLoader(Array.empty, getClass.getClassLoader) {
   override def addURL(url: URL): Unit = {
     super.addURL(url)
   }
@@ -278,9 +278,7 @@ object ExternalTestDB {
         val driverKlass = Class.forName(driverClass, true, MyClassLoader)
         driverKlass.getConstructor().newInstance().asInstanceOf[Driver]
       } catch {
-        case t: Throwable =>
-          t.printStackTrace()
-          throw new IOException(s"Error, could not add URL $url to classloader");
+        case t: Throwable => throw new IOException(s"Error, could not add URL $url to classloader", t);
       }
     })
   }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -267,7 +267,7 @@ object ExternalTestDB {
 
   def getCustomDriver(url: String, driverClass: String) = synchronized {
     val urls = Array(new URL(url))
-    val loader = URLClassLoader.newInstance(urls, getClass.getClassLoader)
+    val loader = URLClassLoader.newInstance(urls)
     val driverKlass = Class.forName(driverClass, true, loader)
     driverCache.getOrElseUpdate((url, driverClass), driverKlass.getConstructor().newInstance().asInstanceOf[Driver])
   }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -265,11 +265,13 @@ object ExternalTestDB {
   // A cache for custom drivers to avoid excessive reloading and memory leaks
   private[this] val driverCache = new mutable.HashMap[(String, String), Driver]()
 
-  private[this] val myClassLoader = new URLClassLoader(Array.empty) {
-   override def addURL(url: URL): Unit = {
+  private[this] class MyClassLoader extends URLClassLoader(Array.empty) {
+    override  def addURL(url: URL): Unit = {
       super.addURL(url)
     }
   }
+
+  private[this] val myClassLoader = new MyClassLoader()
 
   def getCustomDriver(url: String, driverClass: String) = synchronized {
     driverCache.getOrElseUpdate((url, driverClass), {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -261,7 +261,7 @@ abstract class ExternalJdbcTestDB(confName: String) extends JdbcTestDB(confName)
   }
 }
 
-private object MyClassLoader extends URLClassLoader(Array.empty, getClass.getClassLoader) {
+private object MyClassLoader extends URLClassLoader(Array.empty) {
   override def addURL(url: URL): Unit = {
     super.addURL(url)
   }

--- a/test-dbs/testkit.travis.conf
+++ b/test-dbs/testkit.travis.conf
@@ -1,6 +1,6 @@
 # Test database configuration for Travis CI build
 # ....
-# The Oracle profile config needs the non-free jdbc driver placed at file:./ojdbc7-12.1.0.2.jar
+# The Oracle profile config needs the non-free jdbc driver placed at file:./ojdbc7-12.2.0.1.jar
 # The DB2 profile config needs the non-free jdbc driver placed at file:./db2jcc4.jar
 testkit {
   # Set this high as travis agents are stressed and better to succeed slowly sometimes than fail intermittently
@@ -57,7 +57,7 @@ db2 {
 
 oracle {
   enabled = true
-  driverJar = "file:./ojdbc7-12.1.0.2.jar"
+  driverJar = "file:./ojdbc7-12.2.0.1.jar"
   driver=oracle.jdbc.OracleDriver
   baseURL = "jdbc:oracle:thin:@//localhost:49161/xe"
   testDB = ""

--- a/travis/extractNonPublicDeps
+++ b/travis/extractNonPublicDeps
@@ -12,4 +12,4 @@ export CxD=$(echo wraan | tr '[A-Za-z]' '[N-ZA-Mn-za-m]')
 openssl enc -in ${SCRIPTPATH}/mssql.enc -out ./sqljdbc42.jar -d -aes256  -pass env:CxD
 openssl enc -in ${SCRIPTPATH}/npj.enc -out ${SCRIPTPATH}/npj.tjz -d -aes256  -pass env:CxD
 tar xvjf ${SCRIPTPATH}/npj.tjz -C ${SCRIPTPATH}
-cp ${SCRIPTPATH}/nonpublicjars/${OJDBCDIR}/jars/ojdbc7-12.1.0.2.jar .
+cp ${SCRIPTPATH}/nonpublicjars/${OJDBCDIR}/jars/ojdbc7-12.2.0.1.jar .

--- a/travis/runcontainer.sh
+++ b/travis/runcontainer.sh
@@ -46,15 +46,16 @@ do
     RUNNING=$(docker inspect  --format="{{ .State.Running}}" ${CONTAINER_NAME}  2> /dev/null)
     if [ $? -eq 1 ]; then
       if [ "${CONTAINER_NAME}" = "oracleslick" ]; then
-	RESULT=$(docker run -d -p 49160:22 -p 49161:1521 --name ${CONTAINER_NAME} wnameless/oracle-xe-11g && echo -e "\n${SUCCESS_TOKEN}")
+	    RESULT=$(docker run -d -p 49160:22 -p 49161:1521 --name ${CONTAINER_NAME} wnameless/oracle-xe-11g && echo -e "\n${SUCCESS_TOKEN}")
       elif [ "${CONTAINER_NAME}" = "mssqlslicktest" ]; then
-	RESULT=$(docker run -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=Freeslick18' -p 1401:1433 --name mssqlslicktest -d microsoft/mssql-server-linux:2017-latest && echo -e "\n${SUCCESS_TOKEN}")
+	    RESULT=$(docker run -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=Freeslick18' -p 1401:1433 --name mssqlslicktest -d microsoft/mssql-server-linux:2017-latest && echo -e "\n${SUCCESS_TOKEN}")
       elif [ "${CONTAINER_NAME}" = "db2slick" ]; then
-	RESULT=$(docker run -d -p 50000:50000 --name ${CONTAINER_NAME} -e DB2INST1_PASSWORD=db2inst1-pwd -e LICENSE=accept  ibmcom/db2express-c:latest "db2start" &&
-	# Extract non-free db2 jdbc driver jar
-	docker cp ${CONTAINER_NAME}:/home/db2inst1/sqllib/java/db2jcc4.jar . &&
-	docker exec -i -u db2inst1 -t ${CONTAINER_NAME} bash -l -c "db2 create database $DB2NAME" &&
-	echo -e "\n${SUCCESS_TOKEN}")
+	    RESULT=$(docker run -d -p 50000:50000 --name db2slick -e DB2INST1_PASSWORD=db2inst1-pwd -e LICENSE=accept  ibmcom/db2express-c:latest "db2start" &&
+        # Extract non-free db2 jdbc driver jar
+        docker cp ${CONTAINER_NAME}:/home/db2inst1/sqllib/java/db2jcc4.jar . &&
+        docker cp db2slick:/home/db2inst1/sqllib/java/db2jcc4.jar . &&
+        docker exec -i -u db2inst1 -t ${CONTAINER_NAME} bash -l -c "db2 create database $DB2NAME" &&
+        echo -e "\n${SUCCESS_TOKEN}")
       fi
     elif [ "$RUNNING" = "false" ]; then
       echo "Container ${CONTAINER_NAME} exists, but stopped. Starting ..."


### PR DESCRIPTION
Addresses https://github.com/scala/community-builds/issues/796

* Add `openjdk11` to Travis build matrix.
* Add `jaxb` to dependencies, since those are separated from JDK 9 standard lib.
* Update `TestDB`'s class loader, since [the platform class loader is no longer URLClassLoader](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E).
* Updates `HikariCP` to [`2.7.8` that support JDK9+](https://github.com/brettwooldridge/HikariCP/blob/74b55aef05432191af76a3e1b288f03213443f79/CHANGES#L60).
