### PR TITLE
Friendly shape implement.

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
@@ -159,7 +159,7 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q1dt: Query[Rep[Option[Int]], _, Seq] = q1d
     val q1d2t: Query[Rep[Option[(Rep[Int], Rep[String], Rep[Option[Int]])]], _, Seq] = q1d2
     val q2dt: Query[Rep[Option[Int]], _, Seq] = q2d
-    val q3dt: Query[Rep[Option[(Rep[Int], Rep[Int], ConstColumn[Int])]], _, Seq] = q3d
+    val q3dt: Query[Rep[Option[(Rep[Int], Rep[Int], Rep[Int])]], _, Seq] = q3d
     val q4dt: Query[Rep[Option[Int]], _, Seq] = q4d
 
     lazy val t4 = seq(

--- a/slick-testkit/src/test/scala/slick/test/compile/NestedShapesTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/compile/NestedShapesTest.scala
@@ -17,14 +17,14 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), _, _]]
 
     // Flat and Nested alike, fully specified
-    implicitly[Shape[FlatShapeLevel, Int, Int, ConstColumn[Int]]]
-    implicitly[Shape[FlatShapeLevel, (Int, String), (Int, String), (ConstColumn[Int], ConstColumn[String])]]
-    implicitly[Shape[FlatShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], ConstColumn[Int])]]
-    implicitly[Shape[FlatShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (ConstColumn[Int], Rep[String]))]]
-    implicitly[Shape[NestedShapeLevel, Int, Int, ConstColumn[Int]]]
-    implicitly[Shape[NestedShapeLevel, (Int, String), (Int, String), (ConstColumn[Int], ConstColumn[String])]]
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], ConstColumn[Int])]]
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (ConstColumn[Int], Rep[String]))]]
+    implicitly[Shape[FlatShapeLevel, Int, Int, Rep[Int]]]
+    implicitly[Shape[FlatShapeLevel, (Int, String), (Int, String), (Rep[Int], Rep[String])]]
+    implicitly[Shape[FlatShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], Rep[Int])]]
+    implicitly[Shape[FlatShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (Rep[Int], Rep[String]))]]
+    implicitly[Shape[NestedShapeLevel, Int, Int, Rep[Int]]]
+    implicitly[Shape[NestedShapeLevel, (Int, String), (Int, String), (Rep[Int], Rep[String])]]
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], Rep[Int])]]
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (Rep[Int], Rep[String]))]]
 
     // Only Nested, only Mixed specified
     implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], _, _]] // 1
@@ -36,7 +36,7 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], Seq[Int], Query[Rep[Int], Int, Seq]]] // 5
     implicitly[Shape[NestedShapeLevel, Query[(Rep[Int], Rep[String]), (Int, String), Seq], Seq[(Int, String)], Query[(Rep[Int], Rep[String]), (Int, String), Seq]]] // 6
     implicitly[Shape[NestedShapeLevel, (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 7
-    implicitly[Shape[NestedShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (ConstColumn[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 8
+    implicitly[Shape[NestedShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 8
   }
 
   def illegal1 = ShouldNotTypecheck("""
@@ -68,6 +68,6 @@ class NestedShapesTest {
     """, "No matching Shape.*")
 
   def illegal8 = ShouldNotTypecheck("""
-      implicitly[Shape[FlatShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (ConstColumn[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 8
+      implicitly[Shape[FlatShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 8
     """, "No matching Shape.*")
 }

--- a/slick/src/main/scala/slick/basic/BasicProfile.scala
+++ b/slick/src/main/scala/slick/basic/BasicProfile.scala
@@ -49,8 +49,8 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
     @deprecated("User `slickProfile` instead of `slickDriver`", "3.2")
     val slickDriver: self.type = slickProfile
 
-    implicit final def anyToShapedValue[T, U](value: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, U, _]): ShapedValue[T, U] =
-      new ShapedValue[T, U](value, shape)
+    implicit final def anyToShapedValue[T, U, R](value: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, U, R]): ShapedValue[R, U] =
+      ShapedValue(value, shape)
 
     implicit def streamableQueryActionExtensionMethods[U, C[_]](q: Query[_,U, C]): StreamingQueryActionExtensionMethods[C[U], U] =
       createStreamingQueryActionExtensionMethods[C[U], U](queryCompiler.run(q.toNode).tree, ())
@@ -62,7 +62,7 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
     implicit def streamableAppliedCompiledFunctionActionExtensionMethods[R, RU, EU, C[_]](c: AppliedCompiledFunction[_, Query[R, EU, C], RU]): StreamingQueryActionExtensionMethods[RU, EU] =
       createStreamingQueryActionExtensionMethods[RU, EU](c.compiledQuery, c.param)
     implicit def recordQueryActionExtensionMethods[M, R](q: M)(implicit shape: Shape[_ <: FlatShapeLevel, M, R, _]): QueryActionExtensionMethods[R, NoStream] =
-      createQueryActionExtensionMethods[R, NoStream](queryCompiler.run(shape.toNode(q)).tree, ())
+      createQueryActionExtensionMethods[R, NoStream](queryCompiler.run(shape.toNode(shape.pack(q))).tree, ())
   }
 
   /** The API for using the query language with a single import

--- a/slick/src/main/scala/slick/collection/heterogeneous/HList.scala
+++ b/slick/src/main/scala/slick/collection/heterogeneous/HList.scala
@@ -129,7 +129,6 @@ final object HList {
 
   final class HListShape[Level <: ShapeLevel, M <: HList, U <: HList : ClassTag, P <: HList](val shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) extends MappedScalaProductShape[Level, HList, M, U, P] {
     def buildValue(elems: IndexedSeq[Any]) = elems.foldRight(HNil: HList)(_ :: _)
-    def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new HListShape(shapes)
   }
   implicit def hnilShape[Level <: ShapeLevel] = new HListShape[Level, HNil.type, HNil.type, HNil.type](Nil)
   implicit def hconsShape[Level <: ShapeLevel, M1, M2 <: HList, U1, U2 <: HList, P1, P2 <: HList](implicit s1: Shape[_ <: Level, M1, U1, P1], s2: HListShape[_ <: Level, M2, U2, P2]) =

--- a/slick/src/main/scala/slick/lifted/AbstractTable.scala
+++ b/slick/src/main/scala/slick/lifted/AbstractTable.scala
@@ -71,7 +71,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     val q = targetTableQuery.asInstanceOf[Query[TT, U, Seq]]
     val generator = new AnonSymbol
     val aliased = q.shaped.encodeRef(Ref(generator))
-    val fv = Library.==.typed[Boolean](unpackp.toNode(targetColumns(aliased.value)), unpackp.toNode(sourceColumns))
+    val fv = Library.==.typed[Boolean](unpackp.toNode(unpackp.pack(targetColumns(aliased.value))), unpackp.toNode(unpackp.pack(sourceColumns)))
     val fk = ForeignKey(name, toNode, q.shaped.asInstanceOf[ShapedValue[TT, _]],
       targetTable, unpackp, sourceColumns, targetColumns, onUpdate, onDelete)
     new ForeignKeyQuery[TT, U](Filter.ifRefutable(generator, q.toNode, fv), q.shaped, IndexedSeq(fk), q, generator, aliased.value)
@@ -82,7 +82,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     * key column but this method allows you to define compound primary keys
     * or give them user-defined names (when defining the database schema
     * with Slick). */
-  def primaryKey[T](name: String, sourceColumns: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]): PrimaryKey = PrimaryKey(name, ForeignKey.linearizeFieldRefs(shape.toNode(sourceColumns)))
+  def primaryKey[T](name: String, sourceColumns: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]): PrimaryKey = PrimaryKey(name, ForeignKey.linearizeFieldRefs(shape.toNode(shape.pack(sourceColumns))))
 
   def tableConstraints: Iterator[Constraint] = for {
       m <- getClass().getMethods.iterator
@@ -97,7 +97,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     tableConstraints.collect{ case k: PrimaryKey => k }.toIndexedSeq.sortBy(_.name)
 
   /** Define an index or a unique constraint. */
-  def index[T](name: String, on: T, unique: Boolean = false)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]) = new Index(name, this, ForeignKey.linearizeFieldRefs(shape.toNode(on)), unique)
+  def index[T](name: String, on: T, unique: Boolean = false)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]) = new Index(name, this, ForeignKey.linearizeFieldRefs(shape.toNode(shape.pack(on))), unique)
 
   def indexes: Iterable[Index] = (for {
       m <- getClass().getMethods.view

--- a/slick/src/main/scala/slick/lifted/Compiled.scala
+++ b/slick/src/main/scala/slick/lifted/Compiled.scala
@@ -102,7 +102,7 @@ object Executable {
   @inline implicit def tableQueryIsExecutable[B <: AbstractTable[_], BU, C[_]] = StreamingExecutable[Query[B, BU, C] with TableQuery[B], C[BU], BU]
   @inline implicit def baseJoinQueryIsExecutable[B1, B2, BU1, BU2, C[_], Ba1, Ba2] = StreamingExecutable[BaseJoinQuery[B1, B2, BU1, BU2, C, Ba1, Ba2], C[(BU1, BU2)], (BU1, BU2)]
   @inline implicit def scalarIsExecutable[R, U](implicit shape: Shape[_ <: FlatShapeLevel, R, U, _]): Executable[R, U] =
-    new Executable[R, U] { def toNode(value: R) = shape.toNode(value) }
+    new Executable[R, U] { def toNode(value: R) = shape.toNode(shape.pack(value)) }
 }
 
 /** Typeclass for types that can be executed as streaming queries, i.e. only

--- a/slick/src/main/scala/slick/lifted/Constraint.scala
+++ b/slick/src/main/scala/slick/lifted/Constraint.scala
@@ -44,9 +44,9 @@ object ForeignKey {
       onDelete,
       originalSourceColumns,
       originalTargetColumns.asInstanceOf[Any => Any],
-      linearizeFieldRefs(pShape.toNode(originalSourceColumns)),
-      linearizeFieldRefs(pShape.toNode(originalTargetColumns(targetTableShaped.value))),
-      linearizeFieldRefs(pShape.toNode(originalTargetColumns(originalTargetTable))),
+      linearizeFieldRefs(pShape.toNode(pShape.pack(originalSourceColumns))),
+      linearizeFieldRefs(pShape.toNode(pShape.pack(originalTargetColumns(targetTableShaped.value)))),
+      linearizeFieldRefs(pShape.toNode(pShape.pack(originalTargetColumns(originalTargetTable)))),
       targetTableShaped.value.tableNode,
       pShape
     )
@@ -80,7 +80,7 @@ class ForeignKeyQuery[E <: AbstractTable[_], U](
     val newFKs = fks ++ other.fks
     val conditions = newFKs.map { fk =>
       val sh = fk.columnsShape.asInstanceOf[Shape[FlatShapeLevel, Any, Any, Any]]
-      Library.==.typed[Boolean](sh.toNode(fk.targetColumns(aliasedValue)), sh.toNode(fk.sourceColumns))
+      Library.==.typed[Boolean](sh.toNode(sh.pack(fk.targetColumns(aliasedValue))), sh.toNode(sh.pack(fk.sourceColumns)))
     }.reduceLeft[Node]((a, b) => Library.And.typed[Boolean](a, b))
     val newDelegate = Filter.ifRefutable(generator, targetBaseQuery.toNode, conditions)
     new ForeignKeyQuery[E, U](newDelegate, base, newFKs, targetBaseQuery, generator, aliasedValue)

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -178,8 +178,8 @@ final class AnyOptionExtensionMethods[O <: Rep[_], P](val r: O) extends AnyVal {
   def fold[B, BP](ifEmpty: B)(f: P => B)(implicit shape: Shape[FlatShapeLevel, B, _, BP]): BP = {
     val gen = new AnonSymbol
     val mapv = f(OptionLift.baseValue[P, O](r, Ref(gen)))
-    val n = OptionFold(r.toNode, shape.toNode(ifEmpty), shape.toNode(mapv), gen)
-    shape.packedShape.encodeRef(shape.pack(mapv), n).asInstanceOf[BP]
+    val n = OptionFold(r.toNode, shape.toNode(shape.pack(ifEmpty)), shape.toNode(shape.pack(mapv)), gen)
+    shape.encodeRef(shape.pack(mapv), n)
   }
 
   /** Return the result of applying `f` to this Option's value if this Option is non-empty, otherwise None. */
@@ -210,10 +210,8 @@ final class AnyOptionExtensionMethods[O <: Rep[_], P](val r: O) extends AnyVal {
   }
 
   /** Get the value inside this Option, if it is non-empty, otherwise the supplied default. */
-  def getOrElse[M, P2 <: P](default: M)(implicit shape: Shape[FlatShapeLevel, M, _, P2], ol: OptionLift[P2, O]): P =
-    // P2 != P can only happen if M contains plain values, which pack to ConstColumn instead of Rep.
-    // Both have the same packedShape (RepShape), so we can safely cast here:
-    fold[P, P](shape.pack(default): P)(identity)(shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, P, _, P]])
+  def getOrElse[M](default: M)(implicit shape: Shape[FlatShapeLevel, M, _, P]): P =
+    fold[P, P](shape.pack(default): P)(identity)(shape.packedShape)
 
   /** Check if this Option is empty. */
   def isEmpty: Rep[Boolean] = fold(LiteralColumn(true))(_ => LiteralColumn(false))

--- a/slick/src/main/scala/slick/lifted/OptionMapper.scala
+++ b/slick/src/main/scala/slick/lifted/OptionMapper.scala
@@ -96,7 +96,7 @@ object OptionLift extends OptionLiftLowPriority {
 sealed trait OptionLiftLowPriority {
   final implicit def anyOptionLift[M, P](implicit shape: Shape[_ <: FlatShapeLevel, M, _, P]): OptionLift[M, Rep[Option[P]]] = new OptionLift[M, Rep[Option[P]]] {
     def lift(v: M): Rep[Option[P]] =
-      RepOption[P](ShapedValue(shape.pack(v), shape.packedShape), OptionApply(shape.toNode(v)))
+      RepOption[P](ShapedValue(shape.pack(v), shape.packedShape), OptionApply(shape.toNode(shape.pack(v))))
   }
 
   /** Get a suitably typed base value for a `Rep[Option[_]]` */

--- a/slick/src/main/scala/slick/lifted/OptionMapper.scala
+++ b/slick/src/main/scala/slick/lifted/OptionMapper.scala
@@ -96,7 +96,7 @@ object OptionLift extends OptionLiftLowPriority {
 sealed trait OptionLiftLowPriority {
   final implicit def anyOptionLift[M, P](implicit shape: Shape[_ <: FlatShapeLevel, M, _, P]): OptionLift[M, Rep[Option[P]]] = new OptionLift[M, Rep[Option[P]]] {
     def lift(v: M): Rep[Option[P]] =
-      RepOption[P](ShapedValue(shape.pack(v), shape.packedShape), OptionApply(shape.toNode(shape.pack(v))))
+      RepOption[P](ShapedValue(v, shape), OptionApply(shape.toNode(shape.pack(v))))
   }
 
   /** Get a suitably typed base value for a `Rep[Option[_]]` */

--- a/slick/src/main/scala/slick/lifted/Query.scala
+++ b/slick/src/main/scala/slick/lifted/Query.scala
@@ -157,7 +157,7 @@ sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
   /** Partition this query into a query of pairs of a key and a nested query
     * containing the elements for the key, according to some discriminator
     * function. */
-  def groupBy[K, T, G, P](f: E => K)(implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G], vshape: Shape[_ <: FlatShapeLevel, E, _, P]): Query[(G, Query[P, U, Seq]), (T, Query[P, U, Seq]), C] = {
+  def groupBy[K, T, G, P](f: E => K)(implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G], vshape: Shape[_ <: FlatShapeLevel, E, U, P]): Query[(G, Query[P, U, Seq]), (T, Query[P, U, Seq]), C] = {
     val sym = new AnonSymbol
     val key = ShapedValue(f(shaped.encodeRef(Ref(sym)).value), kshape)
     val value = ShapedValue(pack.to[Seq], RepShape[FlatShapeLevel, Query[P, U, Seq], Query[P, U, Seq]])
@@ -201,10 +201,10 @@ sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
   /** Test whether this query is non-empty. */
   def exists = Library.Exists.column[Boolean](toNode)
 
-  def pack[R](implicit packing: Shape[_ <: FlatShapeLevel, E, _, R]): Query[R, U, C] =
+  def pack[R](implicit packing: Shape[_ <: FlatShapeLevel, E, U, R]): Query[R, U, C] =
     new Query[R, U, C] {
-      val shaped: ShapedValue[_ <: R, U] = self.shaped.packedValue(packing)
-      def toNode = self.toNode
+      val shaped: ShapedValue[_ <: R, U] = ShapedValue(self.shaped.value, packing)
+      def toNode = shaped.toNode
     }
 
   /** Select the first `num` elements. */

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -24,6 +24,8 @@ import scala.reflect.ClassTag
  */
 @implicitNotFound(msg = "No matching Shape found.\nSlick does not know how to map the given types.\nPossible causes: T in Table[T] does not match your * projection,\n you use an unsupported type in a Query (e.g. scala List),\n or you forgot to import a driver api into scope.\n  Required level: ${Level}\n     Source type: ${Mixed_}\n   Unpacked type: ${Unpacked_}\n     Packed type: ${Packed_}\n")
 abstract class Shape[Level <: ShapeLevel, -Mixed_, Unpacked_, Packed_] {
+  self =>
+
   type Mixed = Mixed_ @uncheckedVariance
   type Unpacked = Unpacked_
   type Packed = Packed_
@@ -32,7 +34,12 @@ abstract class Shape[Level <: ShapeLevel, -Mixed_, Unpacked_, Packed_] {
   def pack(value: Mixed): Packed
 
   /** Return the fully packed Shape */
-  def packedShape: Shape[Level, Packed, Unpacked, Packed]
+  def packedShape: Shape[Level, Packed, Unpacked, Packed] = new Shape[Level, Packed, Unpacked, Packed] {
+    override def pack(value: self.Packed): self.Packed = value
+    override def buildParams(extract: Any => self.Unpacked): self.Packed = self.buildParams(extract)
+    override def encodeRef(value: self.Packed, path: Node): self.Packed = self.encodeRef(value, path)
+    override def toNode(value: self.Packed): Node = self.toNode(value)
+  }
 
   /** Build a packed representation containing QueryParameters that can extract
     * data from the unpacked representation later.
@@ -43,21 +50,13 @@ abstract class Shape[Level <: ShapeLevel, -Mixed_, Unpacked_, Packed_] {
   /** Encode a reference into a value of this Shape.
     * This method may not be available for shapes where Mixed and Packed are
     * different types. */
-  def encodeRef(value: Mixed, path: Node): Any
+  def encodeRef(value: Packed, path: Node): Packed
 
   /** Return an AST Node representing a mixed value. */
-  def toNode(value: Mixed): Node
+  def toNode(value: Packed): Node
 }
 
 object Shape extends ConstColumnShapeImplicits with AbstractTableShapeImplicits with TupleShapeImplicits {
-  implicit final def primitiveShape[T, Level <: ShapeLevel](implicit tm: TypedType[T]): Shape[Level, T, T, ConstColumn[T]] = new Shape[Level, T, T, ConstColumn[T]] {
-    def pack(value: Mixed) = LiteralColumn(value)
-    def packedShape = RepShape[Level, Packed, Unpacked]
-    def buildParams(extract: Any => Unpacked): Packed = new ConstColumn[T](new QueryParameter(extract, tm))(tm)
-    def encodeRef(value: Mixed, path: Node) =
-      throw new SlickException("Shape does not have the same Mixed and Packed type")
-    def toNode(value: Mixed): Node = pack(value).toNode
-  }
 
   @inline implicit final def unitShape[Level <: ShapeLevel]: Shape[Level, Unit, Unit, Unit] =
     unitShapePrototype.asInstanceOf[Shape[Level, Unit, Unit, Unit]]
@@ -67,11 +66,11 @@ object Shape extends ConstColumnShapeImplicits with AbstractTableShapeImplicits 
   @inline implicit def mappedProjectionShape[Level >: FlatShapeLevel <: ShapeLevel, T, P] = RepShape[Level, MappedProjection[T, P], T]
 
   val unitShapePrototype: Shape[FlatShapeLevel, Unit, Unit, Unit] = new Shape[FlatShapeLevel, Unit, Unit, Unit] {
-    def pack(value: Mixed) = ()
-    def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] = this
-    def buildParams(extract: Any => Unpacked) = ()
-    def encodeRef(value: Mixed, path: Node) = ()
-    def toNode(value: Mixed) = ProductNode(ConstArray.empty)
+    override def pack(value: Mixed): Packed = ()
+    override def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] = unitShapePrototype
+    override def buildParams(extract: Any => Unpacked): Packed = ()
+    override def encodeRef(value: Packed, path: Node): Packed = ()
+    override def toNode(value: Packed): Node = ProductNode(ConstArray.empty)
   }
 }
 
@@ -96,22 +95,33 @@ trait RepShapeImplicits extends OptionShapeImplicits {
     RepShape.asInstanceOf[Shape[Level, Rep[Option[M]], Option[U], Rep[Option[P]]]]
 }
 
-trait OptionShapeImplicits {
+trait OptionShapeImplicits extends PrimitiveShapeImplicits {
   /** A Shape for Option-valued non-Reps. */
   @inline implicit def anyOptionShape[M, U, P, Level <: ShapeLevel](implicit sh: Shape[_ <: Level, M, U, P]): Shape[Level, Rep[Option[M]], Option[U], Rep[Option[P]]] =
     RepShape.asInstanceOf[Shape[Level, Rep[Option[M]], Option[U], Rep[Option[P]]]]
+}
+
+trait PrimitiveShapeImplicits {
+  //Shape for literal value to rep must be the lowest priority to avoid some compilation issues (eg slick.lifted.OptionLift and slick.lifted.AnyOptionExtensionMethods)
+  implicit final def primitiveShape[T, Level <: ShapeLevel](implicit tm: TypedType[T]): Shape[Level, T, T, Rep[T]] = new Shape[Level, T, T, Rep[T]] {
+    override def pack(value: Mixed): Packed = LiteralColumn(value)
+    override def packedShape: Shape[Level, Packed, Unpacked, Packed] = RepShape[Level, Rep[T], T]
+    override def buildParams(extract: Any => Unpacked): Packed = new ConstColumn[T](new QueryParameter(extract, tm))(tm)
+    override def encodeRef(value: Packed, path: Node): Packed = value.encodeRef(path)
+    override def toNode(value: Packed): Node = value.toNode
+  }
 }
 
 /** Shape for Rep values (always fully packed) */
 object RepShape extends Shape[FlatShapeLevel, Rep[_], Any, Rep[_]] {
   def apply[Level <: ShapeLevel, MP <: Rep[_], U]: Shape[Level, MP, U, MP] = this.asInstanceOf[Shape[Level, MP, U, MP]]
 
-  def pack(value: Mixed): Packed = value
-  def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] = this
-  def buildParams(extract: Any => Unpacked): Packed =
+  override def pack(value: Mixed): Packed = value
+  override def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] = this
+  override def buildParams(extract: Any => Unpacked): Packed =
     throw new SlickException("Shape does not have the same Mixed and Unpacked type")
-  def encodeRef(value: Mixed, path: Node) = value.encodeRef(path)
-  def toNode(value: Mixed): Node = value.toNode
+  override def encodeRef(value: Packed, path: Node): Packed = value.encodeRef(path)
+  override def toNode(value: Packed): Node = value.toNode
 }
 
 /** Base class for Shapes of record values which are represented by
@@ -129,10 +139,6 @@ abstract class ProductNodeShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] 
   /** Build a record value represented by this Shape from its element values. */
   def buildValue(elems: IndexedSeq[Any]): Any
 
-  /** Create a copy of this Shape with new element Shapes. This is used for
-    * packing Shapes recursively. */
-  def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]): Shape[Level, _, _, _]
-
   /** Get the element value from a record value at the specified index. */
   def getElement(value: C, idx: Int): Any
 
@@ -141,33 +147,31 @@ abstract class ProductNodeShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] 
   def getIterator(value: C): Iterator[Any] =
     shapes.iterator.zipWithIndex.map(t => getElement(value, t._2))
 
-  def pack(value: Mixed) = {
+  override def pack(value: Mixed): Packed = {
     val elems = shapes.iterator.zip(getIterator(value)).map{ case (p, f) => p.pack(f.asInstanceOf[p.Mixed]) }
     buildValue(elems.toIndexedSeq).asInstanceOf[Packed]
   }
-  def packedShape: Shape[Level, Packed, Unpacked, Packed] =
-    copy(shapes.map(_.packedShape)).asInstanceOf[Shape[Level, Packed, Unpacked, Packed]]
-  def buildParams(extract: Any => Unpacked): Packed = {
+  override def buildParams(extract: Any => Unpacked): Packed = {
     val elems = shapes.iterator.zipWithIndex.map { case (p, idx) =>
       def chExtract(u: C): p.Unpacked = getElement(u, idx).asInstanceOf[p.Unpacked]
       p.buildParams(extract.andThen(chExtract))
     }
     buildValue(elems.toIndexedSeq).asInstanceOf[Packed]
   }
-  def encodeRef(value: Mixed, path: Node) = {
+  override def encodeRef(value: Packed, path: Node): Packed = {
     val elems = shapes.iterator.zip(getIterator(value)).zipWithIndex.map {
-      case ((p, x), pos) => p.encodeRef(x.asInstanceOf[p.Mixed], Select(path, ElementSymbol(pos + 1)))
+      case ((p, x), pos) => p.encodeRef(x.asInstanceOf[p.Packed], Select(path, ElementSymbol(pos + 1)))
     }
-    buildValue(elems.toIndexedSeq)
+    buildValue(elems.toIndexedSeq).asInstanceOf[Packed]
   }
-  def toNode(value: Mixed): Node = ProductNode(ConstArray.from(shapes.iterator.zip(getIterator(value)).map {
-    case (p, f) => p.toNode(f.asInstanceOf[p.Mixed])
+  override def toNode(value: Packed): Node = ProductNode(ConstArray.from(shapes.iterator.zip(getIterator(value)).map {
+    case (p, f) => p.toNode(f.asInstanceOf[p.Packed])
   }.toIterable))
 }
 
 /** Base class for ProductNodeShapes with a type mapping */
 abstract class MappedProductShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] extends ProductNodeShape[Level, C, M, U, P] {
-  override def toNode(value: Mixed) = TypeMapping(super.toNode(value), MappedScalaType.Mapper(toBase, toMapped, None), classTag)
+  override def toNode(value: Packed): Node = TypeMapping(super.toNode(value), MappedScalaType.Mapper(toBase, toMapped, None), classTag)
   def toBase(v: Any) = new ProductWrapper(getIterator(v.asInstanceOf[C]).toIndexedSeq)
   def toMapped(v: Any) = buildValue(TupleSupport.buildIndexedSeq(v.asInstanceOf[Product]))
   def classTag: ClassTag[U]
@@ -176,15 +180,14 @@ abstract class MappedProductShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C
 /** Base class for ProductNodeShapes with a type mapping to a type that extends scala.Product */
 abstract class MappedScalaProductShape[Level <: ShapeLevel, C <: Product, M <: C, U <: C, P <: C](implicit val classTag: ClassTag[U]) extends MappedProductShape[Level, C, M, U, P] {
   override def getIterator(value: C) = value.productIterator
-  def getElement(value: C, idx: Int) = value.productElement(idx)
+  override def getElement(value: C, idx: Int) = value.productElement(idx)
 }
 
 /** Shape for Scala tuples of all arities */
 final class TupleShape[Level <: ShapeLevel, M <: Product, U <: Product, P <: Product](val shapes: Shape[_ <: ShapeLevel, _, _, _]*) extends ProductNodeShape[Level, Product, M, U, P] {
   override def getIterator(value: Product) = value.productIterator
-  def getElement(value: Product, idx: Int) = value.productElement(idx)
-  def buildValue(elems: IndexedSeq[Any]) = TupleSupport.buildTuple(elems)
-  def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]])  = new TupleShape(shapes: _*)
+  override def getElement(value: Product, idx: Int) = value.productElement(idx)
+  override def buildValue(elems: IndexedSeq[Any]) = TupleSupport.buildTuple(elems)
 }
 
 /** A generic case class shape that can be used to lift a case class of
@@ -204,10 +207,9 @@ class CaseClassShape[P <: Product, LiftedTuple, LiftedCaseClass <: P, PlainTuple
    mapLifted: LiftedTuple => LiftedCaseClass, mapPlain: PlainTuple => PlainCaseClass)(
    implicit columnShapes: Shape[FlatShapeLevel, LiftedTuple, PlainTuple, LiftedTuple], classTag: ClassTag[PlainCaseClass])
 extends MappedScalaProductShape[FlatShapeLevel, P, LiftedCaseClass, PlainCaseClass, LiftedCaseClass] {
-  val shapes = columnShapes.asInstanceOf[TupleShape[_,_,_,_]].shapes
+  override val shapes = columnShapes.asInstanceOf[TupleShape[_,_,_,_]].shapes
   override def toMapped(v: Any) = mapPlain(v.asInstanceOf[PlainTuple])
-  def buildValue(elems: IndexedSeq[Any]) = mapLifted(TupleSupport.buildTuple(elems).asInstanceOf[LiftedTuple])
-  def copy(s: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new CaseClassShape(mapLifted, mapPlain) { override val shapes = s }
+  override def buildValue(elems: IndexedSeq[Any]) = mapLifted(TupleSupport.buildTuple(elems).asInstanceOf[LiftedTuple])
 }
 
 /** A generic Product class shape that can be used to lift a class of
@@ -247,8 +249,7 @@ class ProductClassShape[E <: Product,C <: Product](
   FlatShapeLevel, Product, C, E, C
 ]{
   override def toMapped(v: Any) = mapPlain(v.asInstanceOf[Product].productIterator.toSeq)
-  def buildValue(elems: IndexedSeq[Any]) = mapLifted(elems)
-  def copy(s: Seq[Shape[_ <: ShapeLevel, _, _, _]]) = new ProductClassShape(s, mapLifted, mapPlain)
+  override def buildValue(elems: IndexedSeq[Any]) = mapLifted(elems)
 }
 
 /** The level of a Shape, i.e. what kind of types it allows.
@@ -268,21 +269,23 @@ trait FlatShapeLevel extends NestedShapeLevel
 trait ColumnsShapeLevel extends FlatShapeLevel
 
 /** A value together with its Shape */
-case class ShapedValue[T, U](value: T, shape: Shape[_ <: FlatShapeLevel, T, U, _]) extends Rep[U] {
-  def encodeRef(path: Node): ShapedValue[T, U] = {
-    val fv = shape.encodeRef(value, path).asInstanceOf[T]
+class ShapedValue[T, U](val value: T, val shape: Shape[_ <: FlatShapeLevel, T, U, T]) extends Rep[U] {
+  override def encodeRef(path: Node): ShapedValue[T, U] = {
+    val fv = shape.encodeRef(shape.pack(value), path)
     if(fv.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this else new ShapedValue(fv, shape)
   }
-  def toNode = shape.toNode(value)
-  def packedValue[R](implicit ev: Shape[_ <: FlatShapeLevel, T, _, R]): ShapedValue[R, U] = ShapedValue(shape.pack(value).asInstanceOf[R], shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, R, U, _]])
+  override def toNode: Node = shape.toNode(shape.pack(value))
+  def packedValue[R](implicit ev: Shape[_ <: FlatShapeLevel, T, _, R]): ShapedValue[R, U] = ShapedValue(shape.pack(value).asInstanceOf[R], shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, R, U, R]])
   def zip[T2, U2](s2: ShapedValue[T2, U2]) = new ShapedValue[(T, T2), (U, U2)]((value, s2.value), Shape.tuple2Shape(shape, s2.shape))
-  def <>[R : ClassTag](f: (U => R), g: (R => Option[U])) = new MappedProjection[R, U](shape.toNode(value), MappedScalaType.Mapper(g.andThen(_.get).asInstanceOf[Any => Any], f.asInstanceOf[Any => Any], None), implicitly[ClassTag[R]])
+  def <>[R : ClassTag](f: (U => R), g: (R => Option[U])) = new MappedProjection[R, U](shape.toNode(shape.pack(value)), MappedScalaType.Mapper(g.andThen(_.get).asInstanceOf[Any => Any], f.asInstanceOf[Any => Any], None), implicitly[ClassTag[R]])
   @inline def shaped: ShapedValue[T, U] = this
 
   def mapTo[R <: Product with Serializable](implicit rCT: ClassTag[R]): MappedProjection[R, U] = macro ShapedValue.mapToImpl[R, U]
 }
 
 object ShapedValue {
+  def apply[T, U, R](value: T, shape: Shape[_ <: FlatShapeLevel, T, U, R]): ShapedValue[R, U] = new ShapedValue(shape.pack(value), shape.packedShape)
+
   def mapToImpl[R <: Product with Serializable, U](c: Context { type PrefixType = ShapedValue[_, U] })(rCT: c.Expr[ClassTag[R]])(implicit rTag: c.WeakTypeTag[R], uTag: c.WeakTypeTag[U]): c.Tree = {
     import c.universe._
     val rSym = symbolOf[R]
@@ -346,33 +349,34 @@ object ShapedValue {
   * has a valid shape. A ProvenShape has itself a Shape so it can be used in
   * place of the value that it wraps for purposes of packing and unpacking. */
 trait ProvenShape[U] {
-  def value: Any
-  val shape: Shape[_ <: FlatShapeLevel, _, U, _]
-  def packedValue[R](implicit ev: Shape[_ <: FlatShapeLevel, _, U, R]): ShapedValue[R, U]
-  def toNode = packedValue(shape).toNode
+  type Packed
+  def value: Packed
+  val shape: Shape[_ <: FlatShapeLevel, Packed, U, Packed]
+  def packedValue: ShapedValue[Packed, U] = ShapedValue(value, shape)
+  def toNode = packedValue.toNode
 }
 
 object ProvenShape {
   /** Convert an appropriately shaped value to a ProvenShape */
-  implicit def proveShapeOf[T, U](v: T)(implicit sh: Shape[_ <: FlatShapeLevel, T, U, _]): ProvenShape[U] =
+  implicit def proveShapeOf[T, U, R](v: T)(implicit sh: Shape[_ <: FlatShapeLevel, T, U, R]): ProvenShape[U] =
     new ProvenShape[U] {
-      def value = v
-      val shape: Shape[_ <: FlatShapeLevel, _, U, _] = sh
-      def packedValue[R](implicit ev: Shape[_ <: FlatShapeLevel, _, U, R]): ShapedValue[R, U] = ShapedValue(sh.pack(value).asInstanceOf[R], sh.packedShape.asInstanceOf[Shape[FlatShapeLevel, R, U, _]])
+      override type Packed = R
+      override def value: R = sh.pack(v)
+      override val shape: Shape[_ <: FlatShapeLevel, R, U, R] = sh.packedShape
     }
 
   /** The Shape for a ProvenShape */
   implicit def provenShapeShape[T, P](implicit shape: Shape[_ <: FlatShapeLevel, T, T, P]): Shape[FlatShapeLevel, ProvenShape[T], T, P] = new Shape[FlatShapeLevel, ProvenShape[T], T, P] {
-    def pack(value: Mixed): Packed =
-      value.shape.pack(value.value.asInstanceOf[value.shape.Mixed]).asInstanceOf[Packed]
-    def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] =
+    override def pack(value: Mixed): Packed =
+      value.shape.pack(value.value).asInstanceOf[Packed]
+    override def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] =
       shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, Packed, Unpacked, Packed]]
-    def buildParams(extract: Any => Unpacked): Packed =
+    override def buildParams(extract: Any => Unpacked): Packed =
       shape.buildParams(extract.asInstanceOf[Any => shape.Unpacked])
-    def encodeRef(value: Mixed, path: Node) =
-      value.shape.encodeRef(value.value.asInstanceOf[value.shape.Mixed], path)
-    def toNode(value: Mixed): Node =
-      value.shape.toNode(value.value.asInstanceOf[value.shape.Mixed])
+    override def encodeRef(value: Packed, path: Node): Packed =
+      shape.encodeRef(value, path)
+    override def toNode(value: Packed): Node =
+      shape.toNode(value)
   }
 }
 
@@ -380,7 +384,7 @@ class MappedProjection[T, P](child: Node, mapper: MappedScalaType.Mapper, classT
   type Self = MappedProjection[_, _]
   override def toString = "MappedProjection"
   override def toNode: Node = TypeMapping(child, mapper, classTag)
-  def encodeRef(path: Node): MappedProjection[T, P] = new MappedProjection[T, P](child, mapper, classTag) {
+  override def encodeRef(path: Node): MappedProjection[T, P] = new MappedProjection[T, P](child, mapper, classTag) {
     override def toNode = path
   }
   def genericFastPath(f: Function[Any, Any]) = new MappedProjection[T, P](child, mapper.copy(fastPath = Some(f)), classTag)

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -275,7 +275,6 @@ class ShapedValue[T, U](val value: T, val shape: Shape[_ <: FlatShapeLevel, T, U
     if(fv.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this else new ShapedValue(fv, shape)
   }
   override def toNode: Node = shape.toNode(shape.pack(value))
-  def packedValue[R](implicit ev: Shape[_ <: FlatShapeLevel, T, _, R]): ShapedValue[R, U] = ShapedValue(shape.pack(value).asInstanceOf[R], shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, R, U, R]])
   def zip[T2, U2](s2: ShapedValue[T2, U2]) = new ShapedValue[(T, T2), (U, U2)]((value, s2.value), Shape.tuple2Shape(shape, s2.shape))
   def <>[R : ClassTag](f: (U => R), g: (R => Option[U])) = new MappedProjection[R, U](shape.toNode(shape.pack(value)), MappedScalaType.Mapper(g.andThen(_.get).asInstanceOf[Any => Any], f.asInstanceOf[Any => Any], None), implicitly[ClassTag[R]])
   @inline def shaped: ShapedValue[T, U] = this


### PR DESCRIPTION
Since the work on [ubw](https://github.com/djx314/ubw), [hf](https://github.com/scalax/hf)(which is currently mentioned in the slick third-party library recommendation), [asuna](https://github.com/scalax/asuna) and [shino](https://github.com/scalax/shino)(will release a pre-release soon) in recent years, I have some ideas for modifying `Shape.scala` of the slick.
The source code for slick's `Shape.scala` is too hard to read and understand. So creating this pull request makes the type decision more friendly.  
Because the meaning of this pull request is difficult to understand, I will directly share the debugging process.

- 1.The first is the modification of the shape.

I changed it from
```scala
Shape[Level <: ShapeLevel, -Mixed, Unpacked, Packed] {
  def pack(value: Mixed): Packed
  def packedShape: Shape[Level, Packed, Unpacked, Packed]
  def buildParams(extract: Any => Unpacked): Packed
  def encodeRef(value: Mixed, path: Node): Any
  def toNode(value: Mixed): Node
}
```
to
```scala
Shape[Level <: ShapeLevel, -Mixed, Unpacked, Packed] {
  def pack(value: Mixed): Packed
  def packedShape: Shape[Level, Packed, Unpacked, Packed]
  def buildParams(extract: Any => Unpacked): Packed
  def encodeRef(value: Packed, path: Node): Packed
  def toNode(value: Packed): Node
}
```
Then I can provide the packedShape automatically.
This is the main modification of this pull request. In fact, slick always `pack` all the `Mixed` value before it does any operations.
Then I deleted most of the unnecessary `def packedShape` declaration code, including all the `def copy` in `ProductNodeShape` and it's sub class.
Then there was a lot of
```scala
java.lang.ClassCastException: slick.relational.RelationalTableComponent$Table$$anon$1 cannot be cast to slick.lifted.ConstColumn
```
in travis-ci.
Turning the primitiveShape from `Shape[FlatShapeLevel, T, T, ConstColumn[T]]` into `Shape[FlatShapeLevel, T, T, Rep[T]]` can fix this problem. I will mention the reason at the end, which involves a bug in slick.

- 2.Then compile failed with many `def getOrElse`

```scala
[error] /home/travis/build/djx314/slick/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala:268: No matching Shape found.
[error] Slick does not know how to map the given types.
[error] Possible causes: T in Table[T] does not match your * projection,
[error]  you use an unsupported type in a Query (e.g. scala List),
[error]  or you forgot to import a driver api into scope.
[error]   Required level: slick.lifted.FlatShapeLevel
[error]      Source type: Int
[error]    Unpacked type: Any
[error]      Packed type: P2
[error]         as.map(_.id).sum.getOrElse(0).asColumnOf[Option[Long]],
[error]                                   ^
```
This problem can be solved by lowering the priority of the `primitiveShape`. The shape of the literal value should be found at the end any time.
Then there is no `Shape[FlatShapeLevel, T, T, ConstColumn[T]]`, just `Shape[FlatShapeLevel, T, T, Rep[T]]`, so `Rep[Option[T]].getOrElse` is no need to define like

https://github.com/slick/slick/blob/42d787b4950fe876569b5fd68e98c4e0379ac83c/slick/src/main/scala/slick/lifted/ExtensionMethods.scala#L213

Just

https://github.com/slick/slick/blob/a297f820c58c4eded7284e97d8c12202f6fba752/slick/src/main/scala/slick/lifted/ExtensionMethods.scala#L213

is OK. And the warning comment can be removed.

- 3.More friendly type decision with `ShapeValue` and `ProvenShape`.

Now `shape` property of the `ShapedValue` always needs to be packed. So `def packedValue` in `ShapedValue` is no longer needed. But some improvements to the `Query.scala` are required.

Use dependent type in `ProvenShape` to make it easier to understand. Similarly the `shape` property of the `ProvenShape` always needs to be packed.

Now all test case works fine.

- 4.Why can not provide `Shape[FlatShapeLevel, T, T, ConstColumn[T]]`?

Because of the `ProvenShape.provenShapeShape`

https://github.com/slick/slick/blob/42d787b4950fe876569b5fd68e98c4e0379ac83c/slick/src/main/scala/slick/lifted/Shape.scala#L365

It provide `Shape[FlatShapeLeve, ProvenShape[(Int, String, Int)], (Int, String, Int), (ConstColumn[Int], ConstColumn[Int], ConstColumn[Int])]` for `ProvenShape[(Int, String, Int)]`. So I can easily break the travis-ci in current slick's master branch by changing nothing. Just

https://github.com/slick/slick/blob/42d787b4950fe876569b5fd68e98c4e0379ac83c/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NewQuerySemanticsTest.scala#L150-L153

to

```scala
val q2 = for {
  c <- coffees.filter(_.price < 900).map(_.*)
  s <- suppliers if {
    val value = c._2
    s.id === value
  }
} yield (c._1, s.name)
```
And it throws
```scala
java.lang.ClassCastException: slick.lifted.Rep$$anon$1 cannot be cast to slick.lifted.ConstColumn
```
Here is the test pull request([link](https://github.com/djx314/slick/pull/4)). Note that the first commit is already builded successful. Just the pr build is failed.

- 5.`constColumnShape` will not be deleted for some test cases.

- 6.About 8 `asInstanceOf` is removed in `Shape.scala`.

- 7.No more test case can provide. This pull request is only for optimization of type determination. If needed, I can add the change for point 5 to this pull request. If anyone have ideas for improving the test case, welcome to @ me.