### PR TITLE
Make sure the LocalDateTime in JDBCTypeTest is not going to have more…

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -215,17 +215,21 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
     * For more information about the MsSQL issue: https://sourceforge.net/p/jtds/feature-requests/73/
     */
   private[this] def generateTestLocalDateTime() : LocalDateTime = {
-    if (tdb.confName.contains("jtds")) {
-      val now = Instant.now
-      val offset = now.get(ChronoField.MILLI_OF_SECOND) % 10
-      LocalDateTime.ofInstant(now.plusMillis(-offset), ZoneOffset.UTC)
+    val now = Instant.now
+    val dbCompatibleInstant = if (tdb.confName.contains("jtds")) {
+      val offset = now.get(ChronoField.NANO_OF_SECOND) % 10000000
+      now.plusNanos(-offset)
     } else if (tdb.confName.contains("mysql")) {
-      val now = Instant.now
-      val msOffset = now.get(ChronoField.MILLI_OF_SECOND)
-      LocalDateTime.ofInstant(now.plusMillis(-msOffset), ZoneOffset.UTC)
-    } else
-      LocalDateTime.now(ZoneOffset.UTC)
-  }
+      // mysql has no subsecond resolution
+      now.`with`(ChronoField.NANO_OF_SECOND, 0)
+    } else {
+      // after JDK8, Instant.now uses a Clock that has greater than millis resolution. Most
+      // database timestamp implementations only have millis resolutions, so only
+      // roundtrip values which have no micro and nano parts
+      now.`with`(ChronoField.MILLI_OF_SECOND, now.get(ChronoField.MILLI_OF_SECOND))
+    }
+    LocalDateTime.ofInstant(dbCompatibleInstant, ZoneOffset.UTC)
+  }  
   val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
 
   // Test the java.sql.* types


### PR DESCRIPTION
… precision than the db can handle.

See here for java 9 time changes https://blog.joda.org/2017/02/java-time-jsr-310-enhancements-java-9.html

This addresses #1908 