### PR TITLE
HikariCP default timeout alignment

### DIFF
--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -47,7 +47,7 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
 
     val numThreads = c.getIntOr("numThreads", 20)
 
-    hconf.setConnectionTimeout(c.getMillisecondsOr("connectionTimeout", 1000))
+    hconf.setConnectionTimeout(c.getMillisecondsOr("connectionTimeout", 30000))
     hconf.setIdleTimeout(c.getMillisecondsOr("idleTimeout", 600000))
     hconf.setMaxLifetime(c.getMillisecondsOr("maxLifetime", 1800000))
     c.getStringOpt("connectionTestQuery").foreach(hconf.setConnectionTestQuery)
@@ -81,7 +81,7 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
       .map("TRANSACTION_" + _)
       .foreach(hconf.setTransactionIsolation)
 
-    hconf.setValidationTimeout(c.getMillisecondsOr("validationTimeout", 1000))
+    hconf.setValidationTimeout(c.getMillisecondsOr("validationTimeout", 5000))
     hconf.setLeakDetectionThreshold(c.getMillisecondsOr("leakDetectionThreshold", 0))
 
     c.getStringOpt("schema").foreach(hconf.setSchema)

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -202,10 +202,9 @@ trait JdbcBackend extends RelationalBackend {
       *     <ul>
       *       <li>`autoCommit` (Boolean, optional, default: true): controls the default auto-commit
       *         behavior of connections returned from the pool.</li>
-      *       <li>`connectionTimeout` (Duration, optional, default: 1s): The maximum time to wait
-      *         before a call to getConnection is timed out. If this time is exceeded without a
-      *         connection becoming available, a SQLException will be thrown. 1000ms is the minimum
-      *         value.</li>
+      *       <li>`connectionTimeout` (Duration, optional, default: 30s): The maximum number of milliseconds that a
+      *         client (that's you) will wait for a connection from the pool. If this time is exceeded without a
+      *         connection becoming available, a SQLException will be thrown. Lowest acceptable connection timeout is 250 ms</li>
       *       <li>`idleTimeout` (Duration, optional, default: 10min): The maximum amount
       *         of time that a connection is allowed to sit idle in the pool. A value of 0 means that
       *         idle connections are never removed from the pool.</li>
@@ -259,8 +258,9 @@ trait JdbcBackend extends RelationalBackend {
       *       <li>`transactionIsolation` or `isolation` (String, optional): Transaction isolation level for new connections.
       *         Allowed values are: `NONE`, `READ_COMMITTED`, `READ_UNCOMMITTED`, `REPEATABLE_READ`,
       *         `SERIALIZABLE`.</li>
-      *       <li>`validationTimeout` (Duration, optional, default: 1s): The maximum amount of time
-      *         that a connection will be tested for aliveness. 1000ms is the minimum value.</li>
+      *       <li>`validationTimeout` (Duration, optional, default: 5s): The maximum amount of time that a connection will
+      *         be tested for aliveness. This value must be less than the connectionTimeout.
+      *         Lowest acceptable validation timeout is 250 ms.</li>
       *       <li>`leakDetectionThreshold` (Duration, optional, default: 0): The amount of time that a
       *         connection can be out of the pool before a message is logged indicating a possible
       *         connection leak. A value of 0 means leak detection is disabled. Lowest acceptable value


### PR DESCRIPTION
In the `HikariCPJdbcDataSource` the defaults for the `connectionTimeout`  and `validationTimeout` are both set to one second.

On one of our production systems these strict timeouts were causing problems. I think a connection validation may have failed after one second, this left no time to try the second connection.
The HikariCP documentation specifically states 
> `validationTimeout` [...] This value must be less than the `connectionTimeout`

In this PR I have changed the defaults of the `HikariCPJdbcDataSource` to the defaults as stated on the HikariCP documentation.

If there are specific reasons for using different default values, then I would love to hear these and I'd be happy to set a different default as long as the connection timeout will be larger than the validation timeout.