### PR TITLE
Feature/fix invalid insertorupdate query

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/OracleDMLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/OracleDMLTest.scala
@@ -1,0 +1,59 @@
+package slick.test.lifted
+
+import org.junit.Assert._
+import org.junit.Test
+
+class OracleDMLTest {
+  import slick.jdbc.OracleProfile.api._
+
+  @Test def testOnlyPrimaryKeysComposite(): Unit = {
+    class TableWithOnlyIdColumns(tag: Tag) extends Table[(Int, Int)](tag, "mytable") {
+      def id = column[Int]("id")
+      def otherId = column[Int]("otherId")
+
+      def pk = primaryKey( "SampleCompositePk", ( id, otherId ) )
+      def * = (id, otherId)
+    }
+
+    assertFalse("When there are only primary keys columns there shouldn't be an update",
+      TableQuery[TableWithOnlyIdColumns].insertOrUpdate((1, 1)).statements.mkString.contains("when matched then update set"))
+  }
+
+  @Test def testCompositePrimaryKeyAndOtherColumns(): Unit = {
+    class TableWithOnlyIdColumns(tag: Tag) extends Table[(Int, Int, Option[String])](tag, "mytable") {
+      def id = column[Int]("id")
+      def otherId = column[Int]("otherId")
+      def optionalColumn = column[Option[String]]("optionalColumn")
+
+
+      def pk = primaryKey( "SampleCompositePk", ( id, otherId ) )
+      def * = (id, otherId, optionalColumn)
+    }
+
+    assertTrue("Should update columns besides those on the primary key ",
+      TableQuery[TableWithOnlyIdColumns].insertOrUpdate((1, 1, Some(""))).statements.mkString.contains("when matched then update set t.\"optionalColumn\"=s.\"optionalColumn\""))
+  }
+
+  @Test def testOnlyPrimaryKeysSinglePrimaryKey(): Unit = {
+    class TableWithOnlyIdColumns(tag: Tag) extends Table[Int](tag, "mytable") {
+      def id = column[Int]("id", O.PrimaryKey)
+
+      def * = id
+    }
+
+    assertFalse("When there are only primary keys columns there shouldn't be an update",
+      TableQuery[TableWithOnlyIdColumns].insertOrUpdate(1).statements.mkString.contains("when matched then update set"))
+  }
+
+  @Test def testPrimaryKeyAndOtherColumn(): Unit = {
+    class TableWithOnlyIdColumns(tag: Tag) extends Table[(Int, Option[String])](tag, "mytable") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def optionalColumn = column[Option[String]]("optionalColumn")
+
+      def * = (id,  optionalColumn)
+    }
+
+    assertTrue("Should update columns besides those on the primary key ",
+      TableQuery[TableWithOnlyIdColumns].insertOrUpdate((1, Some(""))).statements.mkString.contains("when matched then update set t.\"optionalColumn\"=s.\"optionalColumn\""))
+  }
+}

--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -559,11 +559,14 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
     protected def buildMergeStart: String = s"merge into $tableName t using ("
 
     protected def buildMergeEnd: String = {
-      val updateCols = softNames.map(n => s"t.$n=s.$n").mkString(", ")
+      val updateCols = softNames.toList match {
+        case Nil => ""
+        case list => s"when matched then update set ${list.map(n => s"t.$n=s.$n").mkString(", ")}"
+      }
       val insertCols = nonAutoIncNames /*.map(n => s"t.$n")*/ .mkString(", ")
       val insertVals = nonAutoIncNames.map(n => s"s.$n").mkString(", ")
       val cond = pkNames.map(n => s"t.$n=s.$n").mkString(" and ")
-      s") s on ($cond) when matched then update set $updateCols when not matched then insert ($insertCols) values ($insertVals)"
+      s") s on ($cond) $updateCols  when not matched then insert ($insertCols) values ($insertVals)"
     }
   }
 


### PR DESCRIPTION
This fixes the sintaxis of insertOrUpdate when there are only primary key columns.

Related issues:
https://github.com/slick/slick/issues/1728
https://github.com/slick/slick/issues/1627

Although they are closed, they still happen on other databases besides mysql (For example Oracle).

In the current implementation if there are only primary key columns, the generated sql includes:
when matched then update set  'empty string because there are no other columns besides those on the primary key'.

