### PR TITLE
Add guide for upgrading wrt java.time

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -36,7 +36,7 @@ In other to support `createIfNotExists` and `dropIfExistsPhase`, the following c
 * slick.jdbc.JdbcStatementBuilderComponent#TableDDLBuilder.dropTable receives not a `ifExists: Boolean` as argument
 * slick.sql.SqlProfile#DDL.apply has two more arguments `createIfNotExists: Iterable[String]` and `dropIfExists: Iterable[String]`
 
-### Support for `javax.time` columns
+### Support for `java.time` columns
 
 Slick 3.3.0 profiles now supports `java.time` types as columns (for example, in `Table` `column` definitions).
 

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -51,11 +51,15 @@ The types are: `Instant`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetTime
 If you need to customise these formats,
 you can by extending a `Profile` and overriding the appropriate methods.
 For an example of this see: <https://github.com/d6y/instant-etc/blob/master/src/main/scala/main.scala#L9-L45>.
-Also of use will be an example of a full mapping, such as: <https://github.com/slick/slick/blob/v3.3.0/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala#L187-L365>,
-and the [approach Slick has taken](http://slick.lightbend.com/doc/3.3.0/datetimetypes.html) for these mappings.
+Also of use will be an example of a full mapping, such as: <https://github.com/slick/slick/blob/v3.3.0/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala#L187-L365>.
 
 If you wish to upgrade your application to use the new formats,
 you may need to migrate your database columns to match the Slick column formats.
+
+In the tables that follow there are many similarities between databases.
+However, not all databases can directly map the various `java.time` semantics.
+In these cases, a `VARCHAR` may have been used to store a formatted time representation.
+For more details see the [description of Slick's approach](http://slick.lightbend.com/doc/3.3.0/datetimetypes.html) to these mappings.
 
 #### `slick.jdbc.DB2Profile`
 

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -36,6 +36,143 @@ In other to support `createIfNotExists` and `dropIfExistsPhase`, the following c
 * slick.jdbc.JdbcStatementBuilderComponent#TableDDLBuilder.dropTable receives not a `ifExists: Boolean` as argument
 * slick.sql.SqlProfile#DDL.apply has two more arguments `createIfNotExists: Iterable[String]` and `dropIfExists: Iterable[String]`
 
+### Support for `javax.time` columns
+
+Slick 3.3.0 profiles now supports `java.time` types as columns (for example, in `Table` `column` definitions).
+
+If you already have [custom mappings](http://slick.lightbend.com/doc/3.3.0/userdefined.html#scalar-types) for these types,
+please review the formats in the tables below.
+These formats are the built-in Slick mappings,
+and they are the ones applied when you upgrade to Slick 3.3.0.
+That is, they take precedence over any `MappedColumnType` you may have defined for the `java.time` types.
+
+The types are: `Instant`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetTime`, `OffsetDateTime`, and `ZonedDateTime`.
+
+If you need to customise these formats,
+you can by extending a `Profile` and overriding the appropriate methods.
+For an example of this see: <https://github.com/d6y/instant-etc/blob/master/src/main/scala/main.scala#L9-L45>.
+Also of use will be an example of a full mapping, such as: <https://github.com/slick/slick/blob/v3.3.0/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala#L187-L365>,
+and the [approach Slick has taken](http://slick.lightbend.com/doc/3.3.0/datetimetypes.html) for these mappings.
+
+If you wish to upgrade your application to use the new formats,
+you may need to migrate your database columns to match the Slick column formats.
+
+#### `slick.jdbc.DB2Profile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `VARCHAR(254)` | `'2019-02-03T18:20:28.660Z'` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `VARCHAR(254)` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `'2019-02-03 18:20:28.661'` |
+| `java.time.OffsetTime` | `VARCHAR(254)` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z'` |
+| `java.time.ZonedDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.DerbyProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `VARCHAR(254)` | `'2019-02-03T18:20:28.660Z'` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `VARCHAR(254)` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `'2019-02-03 18:20:28.661'` |
+| `java.time.OffsetTime` | `VARCHAR(254)` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z'` |
+| `java.time.ZonedDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.H2Profile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `TIMESTAMP(9) WITH TIME ZONE` | `'2019-02-03T18:20:28.660Z'` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `VARCHAR` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `'2019-02-03 18:20:28.661'` |
+| `java.time.OffsetTime` | `VARCHAR` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `VARCHAR` | `'2019-02-03T18:20:28.661Z'` |
+| `java.time.ZonedDateTime` | `VARCHAR` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.HsqldbProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `TIMESTAMP(9) WITH TIME ZONE` | `'2019-02-03 18:20:28.66'` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `TIME(3)` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `'2019-02-03 18:20:28.661'` |
+| `java.time.OffsetTime` | `TIME(9) WITH TIME ZONE` | `'18:20:28.661+0:00'` |
+| `java.time.OffsetDateTime` | `TIMESTAMP(9) WITH TIME ZONE` | `'2019-02-03 18:20:28.661+0:00'` |
+| `java.time.ZonedDateTime` | `LONGVARCHAR` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.SQLServerProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `DATETIMEOFFSET(6)` | `(convert(datetimeoffset(6), '2019-02-03 18:20:28.66 '))` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `TIME(6)` | `(convert(time(6), '18:20:28.661'))` |
+| `java.time.LocalDateTime` | `DATETIME2(6)` | `'2019-02-03 18:20:28.661'` |
+| `java.time.OffsetTime` | `VARCHAR(MAX)` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `DATETIMEOFFSET(6)` | `(convert(datetimeoffset(6), '2019-02-03 18:20:28.661 '))` |
+| `java.time.ZonedDateTime` | `VARCHAR(MAX)` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.MySQLProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `TEXT` | `'2019-02-03T18:20:28.660Z'` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `TEXT` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TEXT` | `'2019-02-03T18:20:28.661'` |
+| `java.time.OffsetTime` | `TEXT` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `TEXT` | `'2019-02-03T18:20:28.661Z'` |
+| `java.time.ZonedDateTime` | `TEXT` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.OracleProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `TIMESTAMP(9) WITH TIME ZONE` | `TO_TIMESTAMP_TZ('2019-02-03 18:20:28.660 +00', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH')` |
+| `java.time.LocalDate` | `DATE` | `TO_DATE('2019-02-03', 'SYYYY-MM-DD')` |
+| `java.time.LocalTime` | `VARCHAR2(254)` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `TO_TIMESTAMP('2019-02-03 18:20:28.661', 'YYYY-MM-DD HH24:MI:SS.FF3')` |
+| `java.time.OffsetTime` | `TIMESTAMP(6) WITH TIME ZONE` | `TO_TIMESTAMP_TZ('1970-01-01 18:20:28.661 +0000', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM')` |
+| `java.time.OffsetDateTime` | `TIMESTAMP(6) WITH TIME ZONE` | `TO_TIMESTAMP_TZ('2019-02-03 18:20:28.661 +0000', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM')` |
+| `java.time.ZonedDateTime` | `TIMESTAMP(6) WITH TIME ZONE` | `TO_TIMESTAMP_TZ('2019-02-03 18:20:28.661 Europe/London', 'YYYY-MM-DD HH24:MI:SS.FF3 TZR')` |
+
+
+#### `slick.jdbc.PostgresProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `TIMESTAMP` | `'2019-02-03 18:20:28.66'` |
+| `java.time.LocalDate` | `DATE` | `'2019-02-03'` |
+| `java.time.LocalTime` | `TIME` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `'2019-02-03 18:20:28.661'` |
+| `java.time.OffsetTime` | `TIMETZ` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `VARCHAR` | `'2019-02-03T18:20:28.661Z'` |
+| `java.time.ZonedDateTime` | `VARCHAR` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
+
+#### `slick.jdbc.SQLiteProfile`
+
+| Java Type | SQL Type | Example SQL Literal |
+|-----------|----------|---------------------|
+| `java.time.Instant` | `TIMESTAMP` | `1549218028660` |
+| `java.time.LocalDate` | `DATE` | `1549152000000` |
+| `java.time.LocalTime` | `VARCHAR(254)` | `'18:20:28.661'` |
+| `java.time.LocalDateTime` | `TIMESTAMP` | `1549218028661` |
+| `java.time.OffsetTime` | `VARCHAR(254)` | `'18:20:28.661Z'` |
+| `java.time.OffsetDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z'` |
+| `java.time.ZonedDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
+
 
 Upgrade from 3.1 to 3.2
 -----------------------


### PR DESCRIPTION
This PR adds an upgrade note regarding the introduction of `java.time` mappings.

@smootoo (in particular) have I got this right?

It renders like this... but goes on for a bit with a table for each profile:

<img width="1066" alt="screenshot 2019-02-04 at 13 36 52" src="https://user-images.githubusercontent.com/102661/52211583-331e6400-2882-11e9-96a4-d4b4affad18f.png">
