### PR TITLE
Allow lifted values to be passed to "in" clauses

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,7 +1,7 @@
 import sbt._
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.core.{ProblemFilters, MissingClassProblem}
+import com.typesafe.tools.mima.core.{ProblemFilters, MissingClassProblem, ReversedMissingMethodProblem}
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaBinaryIssueFilters, mimaReportBinaryIssues}
 import com.typesafe.sbt.osgi.SbtOsgi.{osgiSettings, OsgiKeys}
 import com.typesafe.sbt.pgp.PgpKeys
@@ -44,7 +44,9 @@ object Settings {
         },
         mimaBinaryIssueFilters ++= Seq(
           ProblemFilters.exclude[MissingClassProblem]("slick.util.MacroSupportInterpolationImpl$"),
-          ProblemFilters.exclude[MissingClassProblem]("slick.util.MacroSupportInterpolationImpl")
+          ProblemFilters.exclude[MissingClassProblem]("slick.util.MacroSupportInterpolationImpl"),
+          // #1997 added new method ColumnExtensionMethods.in
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.in")
         ),
         ivyConfigurations += config("macro").hide.extend(Compile),
         unmanagedClasspath in Compile ++= (products in config("macro")).value,

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -113,12 +113,20 @@ class MainTest extends AsyncTest[JdbcTestDB] { mainTest =>
       ) yield (u.first, (LiteralColumn(1) + o.orderID, 1), o.product)
       q4d.result.statements.toSeq.length.should(_ >= 1)
 
+      val q4e = for (
+        u <- users if u.first inSetBind List("Homer", "Marge");
+        o <- orders if o.userID === u.id // in (u.id, u.id)
+      ) yield (u.first, o.orderID)
+      q4e.result.statements.toSeq.length.should(_ >= 1)
+
       db.run(for {
         r4 <- q4.to[Set].result.named("Latest Order per User")
         _ = r4 shouldBe Set(("Homer",2), ("Marge",4), ("Carl",6), ("Lenny",8), ("Santa's Little Helper",10))
         r4b <- q4b.to[Set].result.named("Latest Order per User, using maxOfPer")
         _ = r4b shouldBe Set(("Homer",2), ("Marge",4), ("Carl",6), ("Lenny",8), ("Santa's Little Helper",10))
         _ <- q4d.result.map(r => r.length shouldBe 4)
+        r4e <- q4e.to[Set].result.named("Orders matched using in(...) syntax")
+        _ = r4e shouldBe Set(("Homer",1), ("Homer",2), ("Marge",3), ("Marge",4))
       } yield ())
     }.flatMap { _ =>
       val b1 = orders.filter( o => o.shipped && o.shipped ).map( o => o.shipped && o.shipped )

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -115,7 +115,7 @@ class MainTest extends AsyncTest[JdbcTestDB] { mainTest =>
 
       val q4e = for (
         u <- users if u.first inSetBind List("Homer", "Marge");
-        o <- orders if o.userID === u.id // in (u.id, u.id)
+        o <- orders if o.userID in (u.id, u.id)
       ) yield (u.first, o.orderID)
       q4e.result.statements.toSeq.length.should(_ >= 1)
 

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -43,6 +43,8 @@ trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
 
   def in[P2, R, C[_]](e: Query[Rep[P2], _, C])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
     om.column(Library.In, n, e.toNode)
+  def in[P2, R](first: Rep[P2], second: Rep[P2], rest: Rep[P2]*)(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.In, n, ProductNode(ConstArray.from(first.toNode +: second.toNode +: rest.map(_.toNode))))
   def inSet[R](seq: Traversable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
     else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))


### PR DESCRIPTION
Add a new overloaded method ColumnExtensionMethods.in which takes a minimum of 2 lifted (Rep[T]) values and varargs after that.

If we only want to match on a single value we can just use `===`. For two or more values, using varargs allows a natural usage similar to how the SQL would appear:

```sql
where foo.value in (bar.col_1, bar.col_2, bar.col_3)
```

Fixes #1997