### PR TITLE
support scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
 scala:
   - 2.11.12
   - 2.12.8
+  - 2.13.0-RC1
 script:
 - admin/build.sh
 cache:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,15 +6,16 @@ object Dependencies {
   // NOTE: remember to change the version numbers in the sample projects
   // when changing them here
 
-  val scalaVersions = Seq("2.11.12", "2.12.8") // When updating these also update .travis.yml
+  val scalaVersions = Seq("2.11.12", "2.12.8", "2.13.0-RC1") // When updating these also update .travis.yml
 
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.25"
   val typesafeConfig = "com.typesafe" % "config" % "1.3.2"
   val reactiveStreamsVersion = "1.0.2"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
   val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "1.0.0"
 
-  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
+  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams, scalaCollectionCompat)
 
   val junit = Seq(
     "junit" % "junit-dep" % "4.11",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     "com.novocode" % "junit-interface" % "0.11"
   )
   def scalaTestFor(scalaVersion: String) = {
-    val v = "3.0.7"
+    val v = "3.0.8-RC2"
     "org.scalatest" %% "scalatest" % v
   }
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/samples/hello-slick/build.sbt
+++ b/samples/hello-slick/build.sbt
@@ -4,7 +4,7 @@ libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.2.3",
   "org.slf4j" % "slf4j-nop" % "1.7.25",
   "com.h2database" % "h2" % "1.4.191",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.7" % "test"
 )
 
 scalacOptions += "-deprecation"

--- a/samples/hello-slick/build.sbt
+++ b/samples/hello-slick/build.sbt
@@ -1,10 +1,10 @@
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.2.3",
   "org.slf4j" % "slf4j-nop" % "1.7.25",
   "com.h2database" % "h2" % "1.4.191",
-  "org.scalatest" %% "scalatest" % "3.0.7" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8-RC2" % "test"
 )
 
 scalacOptions += "-deprecation"

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -8,7 +8,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   import tdb.profile.api._
 
   def testSimpleActionAsFuture = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -27,7 +27,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testSessionPinning = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -70,7 +70,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testStreaming = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -114,7 +114,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   } else DBIO.successful(())
 
   def testOptionSequence = {
-    class T(tag: Tag) extends Table[Option[Int]](tag, u"t") {
+    class T(tag: Tag) extends Table[Option[Int]](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a.?
     }
@@ -138,7 +138,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testFlatten = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -155,7 +155,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testZipWith = {
-      class T(tag: Tag) extends Table[Int](tag, u"t") {
+      class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
         def a = column[Int]("a")
         def * = a
       }
@@ -173,7 +173,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
     }
 
   def testCollect = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
 
       def * = a

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -37,7 +37,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
       dst2.forceInsertExpr(q3),
       dst2.to[Set].result.map(_ shouldBe Set((1,"A"), (2,"B"), (42,"X"))),
       dst3comp.forceInsertQuery(q4comp),
-      dst3comp.result.map(v => v.to[Set] shouldBe Set((1,"A"), (2,"B")))
+      dst3comp.result.map(v => v.toSet shouldBe Set((1,"A"), (2,"B")))
     ))
   }
 
@@ -196,11 +196,12 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     val ts = TableQuery[T]
 
     for {
-      _ <- ts.schema.create
-      _ <- ts ++= Seq((1, "a"), (2, "b"))
-      _ <- ts.insertOrUpdate((3, "c")).map(_ shouldBe 1)
-      _ <- ts.insertOrUpdate((1, "d")).map(_ shouldBe 1)
-      _ <- ts.sortBy(_.id).result.map(_ shouldBe Seq((1, "d"), (2, "b"), (3, "c")))
+      // FIXME using underscores here causes a compile error, is this a scala 2.13.0-RC1 bug?
+      a <- ts.schema.create
+      b <- ts ++= Seq((1, "a"), (2, "b"))
+      c <- ts.insertOrUpdate((3, "c")).map(_ shouldBe 1)
+      d <- ts.insertOrUpdate((1, "d")).map(_ shouldBe 1)
+      e <- ts.sortBy(_.id).result.map(_ shouldBe Seq((1, "d"), (2, "b"), (3, "c")))
     } yield ()
   }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -51,7 +51,7 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
   }
 
   def testOverrideStatements = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def id = column[Int]("a")
       def * = id
     }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -107,7 +107,7 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
   }
 
   def testUUID =
-    roundTrip[UUID](List(UUID.randomUUID()), UUID.randomUUID)
+    roundTrip[UUID](List(UUID.randomUUID()), () => UUID.randomUUID())
 
   /**
     *
@@ -403,7 +403,7 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
       // of datetimes for each test zoneId
       (0 to 50).map(offset => baseLocalDateTime.plusMinutes(offset * 5500)).toList.
         flatMap(offsetLocalDateTime => zoneIds.map(zoneId => offsetLocalDateTime.atZone(ZoneId.of(zoneId)))),
-      generateTestZonedDateTime
+      () => generateTestZonedDateTime()
     )
   }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
@@ -146,7 +146,7 @@ class RelationalMapperTest extends AsyncTest[RelationalTestDB] {
 
     case class Row(id: String, escaped: Option[String])
 
-    class T(tag: Tag) extends Table[Row](tag, u"t") {
+    class T(tag: Tag) extends Table[Row](tag, "t".withUniquePostFix) {
       val id = column[String]("id", O.PrimaryKey)
       val name = column[Option[String]]("name")
       val upperName = name.shaped <> (toLower, toUpper)

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
@@ -22,8 +22,8 @@ class RelationalScalarFunctionTest extends AsyncTest[RelationalTestDB] {
       checkLit(-17.5),
       checkLit(17.5f),
       checkLit(-17.5f),
-      checkLit(42l),
-      checkLit(-42l),
+      checkLit(42L),
+      checkLit(-42L),
       checkLit("foo"),
 
       check("42".asColumnOf[Int], 42),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
@@ -206,7 +206,7 @@ class UnionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testMappedUnion = {
-    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, u"t") {
+    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, "t".withUniquePostFix) {
       def a = column[String]("a")
       def b = column[Int]("b")
       def c = column[String]("c")

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DBTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DBTest.scala
@@ -2,7 +2,7 @@ package com.typesafe.slick.testkit.util
 
 import slick.dbio.DBIO
 
-import scala.collection.JavaConversions
+import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -37,5 +37,5 @@ abstract class DBTestObject(dbs: TestDB*) {
     val s = getClass.getName
     s.substring(0, s.length-1)
   }
-  @Parameters def parameters = JavaConversions.seqAsJavaList(dbs.filter(_.isEnabled).map(to => Array(to)))
+  @Parameters def parameters: java.util.List[Array[TestDB]] = dbs.filter(_.isEnabled).map(to => Array(to)).asJava
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -144,9 +144,11 @@ sealed abstract class GenericTest[TDB >: Null <: TestDB](implicit TdbClass: Clas
     if(keepAliveSession ne null) keepAliveSession.close()
   }
 
-  implicit class StringContextExtensionMethods(s: StringContext) {
+  implicit class StringExtensionMethods(s: String) {
     /** Generate a unique name suitable for a database entity */
-    def u(args: Any*) = s.s(args) + "_" + unique.incrementAndGet()
+    def withUniquePostFix: String = {
+      s"${s}_${unique.incrementAndGet()}"
+    }
   }
 
   final def mark[T](id: String, f: => T): T = {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -29,6 +29,7 @@ import org.junit.Assert
 import org.slf4j.MDC
 
 import org.reactivestreams.{Subscription, Subscriber, Publisher}
+import scala.collection.compat._
 
 /** JUnit runner for the Slick driver test kit. */
 class Testkit(clazz: Class[_ <: ProfileTest], runnerBuilder: RunnerBuilder) extends SimpleParentRunner[TestMethod](clazz) {
@@ -145,7 +146,7 @@ sealed abstract class GenericTest[TDB >: Null <: TestDB](implicit TdbClass: Clas
 
   implicit class StringContextExtensionMethods(s: StringContext) {
     /** Generate a unique name suitable for a database entity */
-    def u(args: Any*) = s.standardInterpolator(identity, args) + "_" + unique.incrementAndGet()
+    def u(args: Any*) = s.s(args) + "_" + unique.incrementAndGet()
   }
 
   final def mark[T](id: String, f: => T): T = {
@@ -203,7 +204,7 @@ abstract class TestkitTest[TDB >: Null <: TestDB](implicit TdbClass: ClassTag[TD
     if(succeeded) Assert.fail("Exception expected")
   }
 
-  def assertAllMatch[T](t: TraversableOnce[T])(f: PartialFunction[T, _]) = t.foreach { x =>
+  def assertAllMatch[T](t: IterableOnce[T])(f: PartialFunction[T, _]) = t.foreach { x =>
     if(!f.isDefinedAt(x)) Assert.fail("Expected shape not matched by: "+x)
   }
 }
@@ -299,9 +300,11 @@ abstract class AsyncTest[TDB >: Null <: TestDB](implicit TdbClass: ClassTag[TDB]
         Thread.sleep(delay.toMillis)
         thunk
       }(ec)
-      f.onFailure { case t =>
-        pr.tryFailure(t)
-        sub.cancel()
+      f.onComplete {
+        case scala.util.Failure(t) =>
+          pr.tryFailure(t)
+          sub.cancel()
+        case _ => ()
       }
       f
     }
@@ -354,7 +357,7 @@ abstract class AsyncTest[TDB >: Null <: TestDB](implicit TdbClass: ClassTag[TDB]
     }
   }
 
-  implicit class CollectionAssertionExtensionMethods[T](v: TraversableOnce[T]) {
+  implicit class CollectionAssertionExtensionMethods[T](v: IterableOnce[T]) {
     private[this] val cln = getClass.getName
     private[this] def fixStack(f: => Unit): Unit = try f catch {
       case ex: AssertionError =>
@@ -362,7 +365,7 @@ abstract class AsyncTest[TDB >: Null <: TestDB](implicit TdbClass: ClassTag[TDB]
         throw ex
     }
 
-    def shouldAllMatch(f: PartialFunction[T, _]) = v.foreach { x =>
+    def shouldAllMatch(f: PartialFunction[T, _]) = v.iterator.foreach { x =>
       if(!f.isDefinedAt(x)) fixStack(Assert.fail("Value does not match expected shape: "+x))
     }
   }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
@@ -63,7 +63,7 @@ object TestkitConfig {
   def getStrings(config: Config, path: String): Option[Seq[String]] = {
     if(config.hasPath(path)) {
       config.getValue(path).unwrapped() match {
-        case l: java.util.List[_] => Some(l.asScala.map(_.toString))
+        case l: java.util.List[_] => Some(l.asScala.map(_.toString).toSeq)
         case o => Some(List(o.toString))
       }
     } else None

--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -667,7 +667,7 @@ final case class IfThenElse(clauses: ConstArray[Node]) extends SimplyTypedNode {
   def mapResultClauses(f: Node => Node, keepType: Boolean = false) =
     mapClauses(f, keepType, (i => i%2 == 1 || i == clauses.length-1))
   def ifThenClauses: Iterator[(Node, Node)] =
-    clauses.iterator.grouped(2).withPartial(false).map { case List(i, t) => (i, t) }
+    clauses.iterator.grouped(2).withPartial(false).map { case Seq(i, t) => (i, t) }
   def elseClause = clauses.last
 }
 

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -1,12 +1,14 @@
 package slick.ast
 
-import scala.language.{implicitConversions, higherKinds}
+import scala.language.{higherKinds, implicitConversions}
 import slick.SlickException
-import scala.collection.generic.CanBuild
-import scala.collection.mutable.{Builder, ArrayBuilder}
+
+import scala.collection.mutable.{ArrayBuilder, Builder}
 import scala.reflect.{ClassTag, classTag => mkClassTag}
 import scala.annotation.implicitNotFound
-import slick.util.{DumpInfo, Dumpable, TupleSupport, ConstArray}
+import slick.util.{ConstArray, DumpInfo, Dumpable, TupleSupport}
+
+import scala.collection.compat._
 
 /** Super-trait for all types */
 trait Type extends Dumpable {
@@ -174,10 +176,10 @@ abstract class TypedCollectionTypeConstructor[C[_]](val classTag: ClassTag[C[_]]
   }
 }
 
-class ErasedCollectionTypeConstructor[C[_]](canBuildFrom: CanBuild[Any, C[Any]], classTag: ClassTag[C[_]]) extends TypedCollectionTypeConstructor[C](classTag) {
+class ErasedCollectionTypeConstructor[C[_]](canBuildFrom: Factory[Any, C[Any]], classTag: ClassTag[C[_]]) extends TypedCollectionTypeConstructor[C](classTag) {
   val isSequential = classOf[scala.collection.Seq[_]].isAssignableFrom(classTag.runtimeClass)
   val isUnique = classOf[scala.collection.Set[_]].isAssignableFrom(classTag.runtimeClass)
-  def createBuilder[E : ClassTag] = canBuildFrom().asInstanceOf[Builder[E, C[E]]]
+  def createBuilder[E : ClassTag]: Builder[E, C[E]] = canBuildFrom.newBuilder.asInstanceOf[Builder[E, C[E]]]
 }
 
 object TypedCollectionTypeConstructor {
@@ -187,7 +189,7 @@ object TypedCollectionTypeConstructor {
   /** The standard TypedCollectionTypeConstructor for Set */
   def set = forColl[Set]
   /** Get a TypedCollectionTypeConstructor for an Iterable type */
-  implicit def forColl[C[X] <: Iterable[X]](implicit cbf: CanBuild[Any, C[Any]], tag: ClassTag[C[_]]): TypedCollectionTypeConstructor[C] =
+  implicit def forColl[C[X] <: Iterable[X]](implicit cbf: Factory[Any, C[Any]], tag: ClassTag[C[_]]): TypedCollectionTypeConstructor[C] =
     new ErasedCollectionTypeConstructor[C](cbf, tag)
   /** Get a TypedCollectionTypeConstructor for an Array type */
   implicit val forArray: TypedCollectionTypeConstructor[Array] = new TypedCollectionTypeConstructor[Array](arrayClassTag) {

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -19,6 +19,8 @@ import slick.SlickException
 import slick.dbio._
 import slick.util._
 
+import scala.collection.compat._
+
 /** Backend for the basic database and session handling features.
   * Concrete backends like `JdbcBackend` extend this type and provide concrete
   * types for `Database`, `DatabaseFactory` and `Session`. */
@@ -186,7 +188,7 @@ trait BasicBackend { self =>
 
           def run(pos: Int): Future[Any] = {
             if (pos == len) Future.successful {
-              val b = sa.cbf()
+              val b = sa.cbf.newBuilder
               var i = 0
               while (i < len) {
                 b += results.get(i)

--- a/slick/src/main/scala/slick/compiler/ExpandSums.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandSums.scala
@@ -7,6 +7,7 @@ import Util._
 import TypeUtil._
 
 import scala.collection.mutable
+import scala.collection.compat._
 
 /** Expand sum types and their catamorphisms to equivalent product type operations. */
 class ExpandSums extends Phase {
@@ -126,7 +127,7 @@ class ExpandSums extends Phase {
         case _ => Set.empty
       }
       def find(t: Type, path: List[TermSymbol]): Vector[List[TermSymbol]] = t.structural match {
-        case StructType(defs) => defs.toSeq.flatMap { case (s, t) => find(t, s :: path) }(collection.breakOut)
+        case StructType(defs) => defs.toSeq.iterator.flatMap { case (s, t) => find(t, s :: path) }.toVector
         case p: ProductType => p.elements.iterator.zipWithIndex.flatMap { case (t, i) => find(t, ElementSymbol(i+1) :: path) }.toVector
         case _: AtomicType => Vector(path)
         case _ => Vector.empty

--- a/slick/src/main/scala/slick/compiler/ExpandTables.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandTables.scala
@@ -40,7 +40,7 @@ class ExpandTables extends Phase {
       // structural type under a different identity when we are traversing the tree to modify it.
       val structs: Map[TypeSymbol, Type] = tree.collect[(TypeSymbol, (FieldSymbol, Type))] {
         case s @ Select(_ :@ (n: NominalType), sym: FieldSymbol) => baseIdentity(n.sourceNominalType.sym) -> (sym -> s.nodeType)
-      }.toSeq.groupBy(_._1).mapValues(v => StructType(ConstArray.from(v.map(_._2).toMap)))
+      }.toSeq.groupBy(_._1).mapValues(v => StructType(ConstArray.from(v.map(_._2).toMap))).toMap
       logger.debug("Found Selects for NominalTypes: "+structs.keySet.mkString(", "))
 
       val tables = new mutable.HashMap[TableIdentitySymbol, (TermSymbol, Node)]

--- a/slick/src/main/scala/slick/compiler/RewriteJoins.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteJoins.scala
@@ -210,7 +210,7 @@ class RewriteJoins extends Phase {
       val m2 = m.mapValues(_.replace({
         case Ref(s) :@ tpe if s == j.leftGen => Select(Ref(outsideRef) :@ j2.nodeType.asCollectionType.elementType, ElementSymbol(1)) :@ tpe
         case Ref(s) :@ tpe if s == j.rightGen => Select(Ref(outsideRef) :@ j2.nodeType.asCollectionType.elementType, ElementSymbol(2)) :@ tpe
-      }, keepType = true))
+      }, keepType = true)).toMap
       if(logger.isDebugEnabled) m2.foreach { case (p, n) =>
         logger.debug("Replacement for "+FwdPath.toString(p)+":", n)
       }
@@ -278,7 +278,7 @@ class RewriteJoins extends Phase {
       case n => b += n
     }
     f(n)
-    b
+    b.toIndexedSeq
   }
 
   def and(ns: IndexedSeq[Node]): Node =

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -5,7 +5,6 @@ import org.reactivestreams.Subscription
 import scala.collection.mutable.ArrayBuffer
 import scala.language.higherKinds
 
-import scala.collection.generic.{CanBuild, CanBuildFrom}
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import slick.SlickException
@@ -13,6 +12,7 @@ import slick.basic.BasicBackend
 import slick.util.{DumpInfo, Dumpable, ignoreFollowOnError}
 import scala.util.{Try, Failure, Success}
 import scala.util.control.NonFatal
+import scala.collection.compat._
 
 /** A Database I/O Action that can be executed on a database. The DBIOAction type allows a
   * separation of execution logic and resource usage management logic from composition logic.
@@ -152,11 +152,11 @@ object DBIOAction {
   /** Create a [[DBIOAction]] that always fails. */
   def failed(t: Throwable): DBIOAction[Nothing, NoStream, Effect] = FailureAction(t)
 
-  private[this] def groupBySynchronicity[R, E <: Effect](in: TraversableOnce[DBIOAction[R, NoStream, E]]): Vector[Vector[DBIOAction[R, NoStream, E]]] = {
+  private[this] def groupBySynchronicity[R, E <: Effect](in: IterableOnce[DBIOAction[R, NoStream, E]]): Vector[Vector[DBIOAction[R, NoStream, E]]] = {
     var state = 0 // no current = 0, sync = 1, async = 2
     var current: mutable.Builder[DBIOAction[R, NoStream, E], Vector[DBIOAction[R, NoStream, E]]] = null
     val total = Vector.newBuilder[Vector[DBIOAction[R, NoStream, E]]]
-    (in: TraversableOnce[Any]).foreach { a =>
+    (in: IterableOnce[Any]).foreach { a =>
       val msgState = if(a.isInstanceOf[SynchronousDatabaseAction[_, _, _, _]]) 1 else 2
       if(msgState != state) {
         if(state != 0) total += current.result()
@@ -176,13 +176,13 @@ object DBIOAction {
   }
 
   /** Transform a `TraversableOnce[ DBIO[R] ]` into a `DBIO[ TraversableOnce[R] ]`. */
-  def sequence[R, M[+_] <: TraversableOnce[_], E <: Effect](in: M[DBIOAction[R, NoStream, E]])(implicit cbf: CanBuildFrom[M[DBIOAction[R, NoStream, E]], R, M[R]]): DBIOAction[M[R], NoStream, E] = {
+  def sequence[R, M[+_] <: IterableOnce[_], E <: Effect](in: M[DBIOAction[R, NoStream, E]])(implicit cbf: Factory[R, M[R]]): DBIOAction[M[R], NoStream, E] = {
     implicit val ec = DBIO.sameThreadExecutionContext
     def sequenceGroupAsM(g: Vector[DBIOAction[R, NoStream, E]]): DBIOAction[M[R], NoStream, E] = {
       if(g.head.isInstanceOf[SynchronousDatabaseAction[_, _, _, _]]) { // fuse synchronous group
         new SynchronousDatabaseAction.Fused[M[R], NoStream, BasicBackend, E] {
           def run(context: BasicBackend#Context) = {
-            val b = cbf()
+            val b = cbf.newBuilder
             g.foreach(a => b += a.asInstanceOf[SynchronousDatabaseAction[R, NoStream, BasicBackend, E]].run(context))
             b.result()
           }
@@ -202,22 +202,22 @@ object DBIOAction {
       } else {
         if(g.head.isInstanceOf[SynchronousDatabaseAction[_, _, _, _]]) { // fuse synchronous group
           new SynchronousDatabaseAction.Fused[Seq[R], NoStream, BasicBackend, E] {
-            def run(context: BasicBackend#Context) = {
+            def run(context: BasicBackend#Context): IndexedSeq[R] = {
               val b = new ArrayBuffer[R](g.length)
               g.foreach(a => b += a.asInstanceOf[SynchronousDatabaseAction[R, NoStream, BasicBackend, E]].run(context))
-              b
+              b.toIndexedSeq
             }
             override def nonFusedEquivalentAction = SequenceAction[R, Seq[R], E](g)
           }
         } else SequenceAction[R, Seq[R], E](g)
       }
     }
-    val grouped = groupBySynchronicity[R, E](in.asInstanceOf[TraversableOnce[DBIOAction[R, NoStream, E]]])
+    val grouped = groupBySynchronicity[R, E](in.asInstanceOf[IterableOnce[DBIOAction[R, NoStream, E]]])
     grouped.length match {
-      case 0 => DBIO.successful(cbf().result())
+      case 0 => DBIO.successful(cbf.newBuilder.result())
       case 1 => sequenceGroupAsM(grouped.head)
       case n =>
-        grouped.foldLeft(DBIO.successful(cbf(in)): DBIOAction[mutable.Builder[R, M[R]], NoStream, E]) { (ar, g) =>
+        grouped.foldLeft(DBIO.successful(cbf.newBuilder): DBIOAction[mutable.Builder[R, M[R]], NoStream, E]) { (ar, g) =>
           for (r <- ar; ge <- sequenceGroupAsSeq(g)) yield r ++= ge
         } map (_.result)
     }
@@ -342,7 +342,7 @@ case class AndThenAction[R, +S <: NoStream, -E <: Effect](as: IndexedSeq[DBIOAct
 }
 
 /** A DBIOAction that represents a `sequence` or operation for sequencing in the DBIOAction monad. */
-case class SequenceAction[R, +R2, -E <: Effect](as: IndexedSeq[DBIOAction[R, NoStream, E]])(implicit val cbf: CanBuild[R, R2]) extends DBIOAction[R2, NoStream, E] {
+case class SequenceAction[R, +R2, -E <: Effect](as: IndexedSeq[DBIOAction[R, NoStream, E]])(implicit val cbf: Factory[R, R2]) extends DBIOAction[R2, NoStream, E] {
   def getDumpInfo = DumpInfo("sequence", children = as.zipWithIndex.map { case (a, i) => (String.valueOf(i+1), a) })
 }
 

--- a/slick/src/main/scala/slick/jdbc/Invoker.scala
+++ b/slick/src/main/scala/slick/jdbc/Invoker.scala
@@ -2,8 +2,8 @@ package slick.jdbc
 
 import scala.language.higherKinds
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.collection.generic.CanBuildFrom
 import slick.util.CloseableIterator
+import scala.collection.compat._
 
 /** Base trait for all statement invokers of result element type R. */
 trait Invoker[+R] { self =>
@@ -35,8 +35,8 @@ trait Invoker[+R] { self =>
   }
 
   /** Execute the statement and return a fully materialized collection. */
-  final def buildColl[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] = {
-    val b = canBuildFrom()
+  final def buildColl[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: Factory[R, C[R @uV]]): C[R @uV] = {
+    val b = canBuildFrom.newBuilder
     foreach({ x => b += x }, 0)
     b.result()
   }

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -9,6 +9,7 @@ import java.io.{InputStream, Reader}
 import java.util.Calendar
 import java.{sql => js}
 import java.sql.{PreparedStatement, Connection, SQLWarning, ResultSet, Statement, Timestamp}
+import scala.collection.compat._
 
 /** A wrapper for `java.sql.Statement` that logs statements and benchmark results
   * to the appropriate [[JdbcBackend]] loggers. */
@@ -49,7 +50,7 @@ class LoggingStatement(st: Statement) extends Statement {
     if(doStatementAndParameter && (sql ne null)) JdbcBackend.statementAndParameterLogger.debug("Executing "+what+": "+sql)
     if(doParameter && (paramss ne null) && paramss.nonEmpty) {
       // like s.groupBy but only group adjacent elements and keep the ordering
-      def groupBy[T](s: TraversableOnce[T])(f: T => AnyRef): IndexedSeq[IndexedSeq[T]] = {
+      def groupBy[T](s: IterableOnce[T])(f: T => AnyRef): scala.collection.IndexedSeq[scala.collection.IndexedSeq[T]] = {
         var current: AnyRef = null
         val b = new ArrayBuffer[ArrayBuffer[T]]
         s.foreach { v =>

--- a/slick/src/main/scala/slick/jdbc/PositionedResult.scala
+++ b/slick/src/main/scala/slick/jdbc/PositionedResult.scala
@@ -1,10 +1,10 @@
 package slick.jdbc
 
 import scala.language.higherKinds
-import scala.collection.generic.CanBuildFrom
 import java.sql.{ResultSet, Blob, Clob, Date, Time, Timestamp}
 import java.io.Closeable
 import slick.util.{ReadAheadIterator, CloseableIterator}
+import scala.collection.compat._
 
 /**
  * A database result positioned at a row and column.
@@ -147,8 +147,8 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable { outer =>
     view(discPos, discPos+1, { r => disc != null && disc == r.nextObject })
   }
 
-  final def build[C[_], R](gr: GetResult[R])(implicit canBuildFrom: CanBuildFrom[Nothing, R, C[R]]): C[R] = {
-    val b = canBuildFrom()
+  final def build[C[_], R](gr: GetResult[R])(implicit canBuildFrom: Factory[R, C[R]]): C[R] = {
+    val b = canBuildFrom.newBuilder
     while(nextRow) b += gr(this)
     b.result()
   }
@@ -156,7 +156,7 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable { outer =>
   final def to[C[_]] = new To[C]()
 
   final class To[C[_]] private[PositionedResult] () {
-    def apply[R](gr: GetResult[R])(implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R]]) =
+    def apply[R](gr: GetResult[R])(implicit session: JdbcBackend#Session, canBuildFrom: Factory[R, C[R]]) =
       build[C, R](gr)
   }
 }

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -4,6 +4,7 @@ import java.sql.PreparedStatement
 import slick.util.{TableDump, SlickLogger, CloseableIterator}
 import org.slf4j.LoggerFactory
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.compat._
 
 private[jdbc] object StatementInvoker {
   val maxLogResults = 5
@@ -41,10 +42,10 @@ abstract class StatementInvoker[+R] extends Invoker[R] { self =>
           val meta = rs.getMetaData
           Vector(
             1.to(meta.getColumnCount).map(_.toString),
-            1.to(meta.getColumnCount).map(idx => meta.getColumnLabel(idx)).to[ArrayBuffer]
+            1.to(meta.getColumnCount).map(idx => meta.getColumnLabel(idx))
           )
         } else null
-        val logBuffer = if(doLogResult) new ArrayBuffer[ArrayBuffer[Any]] else null
+        val logBuffer = if(doLogResult) new ArrayBuffer[IndexedSeq[Any]] else null
         var rowCount = 0
         val pr = new PositionedResult(rs) {
           def close() = {
@@ -60,7 +61,7 @@ abstract class StatementInvoker[+R] extends Invoker[R] { self =>
           def extractValue(pr: PositionedResult) = {
             if(doLogResult) {
               if(logBuffer.length < StatementInvoker.maxLogResults)
-                logBuffer += 1.to(logHeader(0).length).map(idx => rs.getObject(idx) : Any).to[ArrayBuffer]
+                logBuffer += 1.to(logHeader(0).length).map(idx => rs.getObject(idx) : Any)
               rowCount += 1
             }
             self.extractValue(pr)

--- a/slick/src/main/scala/slick/lifted/AbstractTable.scala
+++ b/slick/src/main/scala/slick/lifted/AbstractTable.scala
@@ -100,7 +100,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
   def index[T](name: String, on: T, unique: Boolean = false)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]) = new Index(name, this, ForeignKey.linearizeFieldRefs(shape.toNode(on)), unique)
 
   def indexes: Iterable[Index] = (for {
-      m <- getClass().getMethods.view
+      m <- getClass().getMethods.iterator
       if m.getReturnType == classOf[Index] && m.getParameterTypes.length == 0
-    } yield m.invoke(this).asInstanceOf[Index]).sortBy(_.name)
+    } yield m.invoke(this).asInstanceOf[Index]).toSeq.sortBy(_.name)
 }

--- a/slick/src/main/scala/slick/lifted/Constraint.scala
+++ b/slick/src/main/scala/slick/lifted/Constraint.scala
@@ -59,7 +59,7 @@ object ForeignKey {
         n.childrenForeach(f)
     }
     f(n)
-    sels
+    sels.toIndexedSeq
   }
 }
 

--- a/slick/src/main/scala/slick/lifted/SimpleFunction.scala
+++ b/slick/src/main/scala/slick/lifted/SimpleFunction.scala
@@ -25,7 +25,7 @@ object SimpleFunction {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]): Self = build(ch.toSeq)
     }
-    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.map(_.toNode)(collection.breakOut))) }
+    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
   def nullary[R : TypedType](fname: String, fn: Boolean = false): Rep[R] =
     apply(fname, fn).apply(Seq())
@@ -82,7 +82,7 @@ object SimpleExpression {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]) = build(ch.toSeq)
     }
-    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.map(_.toNode)(collection.breakOut))) }
+    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
 
   def nullary[R : TypedType](f: JdbcStatementBuilderComponent#QueryBuilder => Unit): Rep[R] = {

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -10,6 +10,7 @@ import slick.basic.BasicBackend
 import slick.util.Logging
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Try}
+import scala.collection.compat._
 
 /** The backend for DistributedProfile. */
 trait DistributedBackend extends RelationalBackend with Logging {
@@ -57,7 +58,7 @@ trait DistributedBackend extends RelationalBackend with Logging {
   class DatabaseFactoryDef {
     /** Create a new distributed database instance that uses the supplied ExecutionContext for
       * asynchronous execution of database actions. */
-    def apply(dbs: TraversableOnce[BasicBackend#DatabaseDef], executionContext: ExecutionContext): Database =
+    def apply(dbs: IterableOnce[BasicBackend#DatabaseDef], executionContext: ExecutionContext): Database =
       new DatabaseDef(dbs.toVector, executionContext)
   }
 

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 
 import org.reactivestreams.Subscriber
 
+import scala.collection.compat._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.concurrent.{Future, ExecutionContext}
 
@@ -116,7 +117,7 @@ trait HeapBackend extends RelationalBackend with Logging {
       logger.debug("Inserted ("+row.mkString(", ")+") into "+this)
     }
 
-    def createInsertRow: ArrayBuffer[Any] = columns.map(_.createDefault)(collection.breakOut)
+    def createInsertRow: ArrayBuffer[Any] = columns.iterator.map(_.createDefault).to(ArrayBuffer)
 
     override def toString = name + "(" + columns.map(_.sym.name).mkString(", ") + ")"
 

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -11,6 +11,7 @@ import slick.compiler._
 import slick.dbio._
 import slick.relational.{RelationalProfile, ResultConverterCompiler, ResultConverter, CompiledMapping}
 import slick.util.{DumpInfo, ??}
+import scala.collection.compat._
 
 /** A profile for interpreted queries on top of the in-memory database. */
 trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self: MemoryProfile =>
@@ -72,7 +73,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
   protected def createInterpreter(db: Backend#Database, param: Any): QueryInterpreter = new QueryInterpreter(db, param) {
     override def run(n: Node) = n match {
       case ResultSetMapping(_, from, CompiledMapping(converter, _)) :@ CollectionType(cons, el) =>
-        val fromV = run(from).asInstanceOf[TraversableOnce[Any]]
+        val fromV = run(from).asInstanceOf[IterableOnce[Any]]
         val b = cons.createBuilder(el.classTag).asInstanceOf[Builder[Any, Any]]
         b ++= fromV.map(v => converter.asInstanceOf[ResultConverter[MemoryResultConverterDomain, _]].read(v.asInstanceOf[QueryInterpreter.ProductValue]))
         b.result()
@@ -93,7 +94,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
       val htable = session.database.getTable(table.tableName)
       val buf = htable.createInsertRow
       converter.asInstanceOf[ResultConverter[MemoryResultConverterDomain, Any]].set(value, buf)
-      htable.append(buf)
+      htable.append(buf.toIndexedSeq)
     }
 
     def ++= (values: Iterable[T])(implicit session: Backend#Session): Unit =
@@ -118,7 +119,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
     protected[this] def getIterator(ctx: Backend#Context): Iterator[T] = {
       val inter = createInterpreter(ctx.session.database, param)
       val ResultSetMapping(_, from, CompiledMapping(converter, _)) = tree
-      val pvit = inter.run(from).asInstanceOf[TraversableOnce[QueryInterpreter.ProductValue]].toIterator
+      val pvit = inter.run(from).asInstanceOf[IterableOnce[QueryInterpreter.ProductValue]].toIterator
       pvit.map(converter.asInstanceOf[ResultConverter[MemoryResultConverterDomain, T]].read _)
     }
     def run(ctx: Backend#Context): R =

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -448,7 +448,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
     case t: ScalaType[_] => if(t.nullable) None else null
     case StructType(el) =>
       new StructValue(el.toSeq.map{ case (_, tpe) => createNullRow(tpe) },
-        el.toSeq.zipWithIndex.map{ case ((sym, _), idx) => (sym, idx) }(collection.breakOut): Map[TermSymbol, Int])
+        el.toSeq.zipWithIndex.iterator.map{ case ((sym, _), idx) => (sym, idx) }.toMap: Map[TermSymbol, Int])
     case ProductType(el) =>
       new ProductValue(el.toSeq.map(tpe => createNullRow(tpe)))
   }

--- a/slick/src/main/scala/slick/relational/ResultConverter.scala
+++ b/slick/src/main/scala/slick/relational/ResultConverter.scala
@@ -41,7 +41,7 @@ trait ResultConverterDomain {
 
 /** An efficient (albeit boxed) ResultConverter for Product/Tuple values. */
 final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product](elementConverters: ResultConverter[M, _]*) extends ResultConverter[M, T] {
-  private[this] val cha = elementConverters.to[Array]
+  private[this] val cha = elementConverters.toArray
   private[this] val len = cha.length
 
   val width = cha.foldLeft(0)(_ + _.width)
@@ -75,7 +75,7 @@ final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product
 
 /** Result converter that can write to multiple sub-converters and read from the first one */
 final case class CompoundResultConverter[M <: ResultConverterDomain, @specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean) T](width: Int, childConverters: ResultConverter[M, T]*) extends ResultConverter[M, T] {
-  private[this] val cha = childConverters.to[Array]
+  private[this] val cha = childConverters.toArray
   private[this] val len = cha.length
 
   def read(pr: Reader) = {

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -6,6 +6,7 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
+import scala.collection.compat._
 
 /** An efficient immutable array implementation which is used in the AST. Semantics are generally
   * the same as for Scala collections but for performance reasons it does not implement any
@@ -500,7 +501,7 @@ final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double =
     len += vslen
   }
 
-  def ++= (vs: TraversableOnce[T]): Unit = {
+  def ++= (vs: IterableOnce[T]): Unit = {
     if(vs.isInstanceOf[IndexedSeq[_]]) ensure(vs.size)
     vs.foreach(self += _)
   }
@@ -516,6 +517,6 @@ final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double =
 
   def + (v: T): this.type = { this += v; this }
   def ++ (vs: ConstArray[T]): this.type = { this ++= vs; this }
-  def ++ (vs: TraversableOnce[T]): this.type = { this ++= vs; this }
+  def ++ (vs: IterableOnce[T]): this.type = { this ++= vs; this }
   def ++ (vs: Option[T]): this.type = { this ++= vs; this }
 }

--- a/slick/src/main/scala/slick/util/TableDump.scala
+++ b/slick/src/main/scala/slick/util/TableDump.scala
@@ -11,12 +11,12 @@ class TableDump(maxColumnWidth: Int = 20) {
   protected[this] val dashes = Iterator.fill(maxColumnWidth+2)(box(0)).mkString
   protected[this] val spaces = Iterator.fill(maxColumnWidth+2)(' ').mkString
 
-  protected[this] def formatLine(line: IndexedSeq[Any]): IndexedSeq[String] = line.map { v =>
+  protected[this] def formatLine(line: scala.collection.IndexedSeq[Any]): scala.collection.IndexedSeq[String] = line.map { v =>
     val s = if(v == null) "NULL" else v.toString
     if(s == null) "NULL" else s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
   }
 
-  def apply(headers: IndexedSeq[IndexedSeq[String]], data: IndexedSeq[IndexedSeq[Any]]): IndexedSeq[String] = {
+  def apply(headers: scala.collection.IndexedSeq[scala.collection.IndexedSeq[String]], data: scala.collection.IndexedSeq[scala.collection.IndexedSeq[Any]]): IndexedSeq[String] = {
     val columns = headers(0).length
     val texts = headers.map(formatLine) ++ data.map(formatLine)
     val widths = 0.until(columns).map { idx => math.min(maxColumnWidth, texts.map(_.apply(idx).length).max) }
@@ -40,7 +40,7 @@ class TableDump(maxColumnWidth: Int = 20) {
       }
     }
     buf += cBlue + widths.map(l => dashes.substring(0, l+2)).mkString(box(7), box(8), box(9)) + cNormal
-    buf
+    buf.toIndexedSeq
   }
 
   /** Return the first `len` codepoints from a String */


### PR DESCRIPTION
Unfortunately scala-collection-compat has not yet been released for the 2.13.0-RC1. Therefore I did an attempt to upgrade to 2.13.0-M5.

This is my work so far. I have resoved all binary-compatibility issues/
I intend to upgrade to 2.13.0-RC1 as soon as scala-collection-compat has been released.

Todos
- [x] Upgrade to scala-collection-compat 1.0.0 as soon as it has been released
- [x] Upgrade to scala 2.13.0-RC1 (or later) as soon as scala-collection-compat has been released for this scala version
- [x] Fix travis issue: "The job exceeded the maximum time limit for jobs, and has been terminated."(perhaps we can build the different scala versions separately)
- [ ] Fix failing test on 2.13: com.typesafe.slick.testkit.tests.NestingTest.testNestedTuples