### PR TITLE
Demonstrate a recent version of PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These are the databases and driver versions that have explicit automated tests.
 |Oracle 11g|[ojdbc7:12.1.0.2](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |DB2 10.5|[db2jcc4:4.19.20](http://www-01.ibm.com/support/docview.wss?uid=swg21363866)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |MySQL|mysql-connector-java:5.1.38|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
-|PostgreSQL|postgresql:42.2.2|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|PostgreSQL|postgresql:42.2.5|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |SQLite|sqlite-jdbc:3.8.11.2|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |Derby/JavaDB|derby:10.11.1.1|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |HSQLDB/HyperSQL|hsqldb:2.2.8|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|

--- a/doc/src/database.md
+++ b/doc/src/database.md
@@ -32,9 +32,17 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "{{version}}",
   "org.slf4j" % "slf4j-nop" % "1.6.4",
   "com.typesafe.slick" %% "slick-hikaricp" % "{{version}}",
-  "org.postgresql" % "postgresql" % "9.4-1206-jdbc42" //org.postgresql.ds.PGSimpleDataSource dependency
+  "org.postgresql" % "postgresql" % "42.2.5" //org.postgresql.ds.PGSimpleDataSource dependency
 )
 ``` 
+
+Note, some examples on the internet point to the 9.4.X versions of the
+PostgreSQL JDBC drivers. Those examples are incorrect and many years out of
+date. The 42.X development line has been the main line of development since
+February 2017. As noted on the Postgres site, "Unless you have unusual
+requirements (running old applications or JVMs), this is the driver you should
+be using." See https://jdbc.postgresql.org/download.html for more information
+about when you may want to use the 9.4 line.
 
 ##### MySQL
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "org.apache.derby" % "derby" % "10.11.1.1",
     "org.xerial" % "sqlite-jdbc" % "3.8.11.2",
     "org.hsqldb" % "hsqldb" % "2.2.8",
-    "org.postgresql" % "postgresql" % "42.2.2",
+    "org.postgresql" % "postgresql" % "42.2.5",
     "mysql" % "mysql-connector-java" % "5.1.46",
     "net.sourceforge.jtds" % "jtds" % "1.3.1"
   )

--- a/samples/slick-testkit-example/build.sbt
+++ b/samples/slick-testkit-example/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick-testkit" % "3.2.3" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
-  "org.postgresql" % "postgresql" % "42.1.4" % "test"
+  "org.postgresql" % "postgresql" % "42.2.5" % "test"
 )
 
 scalacOptions += "-deprecation"


### PR DESCRIPTION
Use a recent version of PostgreSQL JDBC on the examples page. The 9.4.X
line is out of date and the guidance from postgres is to follow the
42.2.X line of development.