### PR TITLE
Build the different scala versions separately in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ addons:
     - mysql-server-5.6
     - mysql-client-core-5.6
     - mysql-client-5.6
+scala:
+  - 2.11.12
+  - 2.12.8
 script:
 - admin/build.sh
 cache:

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -20,7 +20,7 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9-]+)? ]]; then
   openssl aes-256-cbc -K $encrypted_c3c0a1170361_key -iv $encrypted_c3c0a1170361_iv -in secrets.tar.enc -out secrets.tar -d
   myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
   publishVersion='set every version := "'$myVer'"'
-  extraTarget="+publishSigned doc"
+  extraTarget="publishSigned doc"
   publish_docs=1
   cp admin/publish-settings.sbt ./
   echo "Contents of secrets.tar:"
@@ -31,7 +31,7 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9-]+)? ]]; then
   ls -l *.sbt project/*.scala
 fi
 
-sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf "$publishVersion" +testAll $extraTarget
+sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf "$publishVersion" ++$TRAVIS_SCALA_VERSION testAll $extraTarget
 
 if test "$publish_docs" = "1" ; then
   slick_dir=$(pwd)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   // NOTE: remember to change the version numbers in the sample projects
   // when changing them here
 
-  val scalaVersions = Seq("2.11.12", "2.12.8")
+  val scalaVersions = Seq("2.11.12", "2.12.8") // When updating these also update .travis.yml
 
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.25"
   val typesafeConfig = "com.typesafe" % "config" % "1.3.2"


### PR DESCRIPTION
As I was investigating if slick could be upgraded to scala 2.13, it turned out that building 3 scala versions in sequence caused the travis build to take too long.

This change significantly reduces the build time.

One thing that should be carefully reviewed is what the consequences are on the release process. (as I do not know how the slick release process works I am not able to test this)