### PR TITLE
Remove custom string interpolator in tests for 2.13 compatibility

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -8,7 +8,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   import tdb.profile.api._
 
   def testSimpleActionAsFuture = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -27,7 +27,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testSessionPinning = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -70,7 +70,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testStreaming = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -114,7 +114,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   } else DBIO.successful(())
 
   def testOptionSequence = {
-    class T(tag: Tag) extends Table[Option[Int]](tag, u"t") {
+    class T(tag: Tag) extends Table[Option[Int]](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a.?
     }
@@ -138,7 +138,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testFlatten = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -155,7 +155,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testZipWith = {
-      class T(tag: Tag) extends Table[Int](tag, u"t") {
+      class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
         def a = column[Int]("a")
         def * = a
       }
@@ -173,7 +173,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
     }
 
   def testCollect = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
 
       def * = a

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -51,7 +51,7 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
   }
 
   def testOverrideStatements = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def id = column[Int]("a")
       def * = id
     }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
@@ -146,7 +146,7 @@ class RelationalMapperTest extends AsyncTest[RelationalTestDB] {
 
     case class Row(id: String, escaped: Option[String])
 
-    class T(tag: Tag) extends Table[Row](tag, u"t") {
+    class T(tag: Tag) extends Table[Row](tag, "t".withUniquePostFix) {
       val id = column[String]("id", O.PrimaryKey)
       val name = column[Option[String]]("name")
       val upperName = name.shaped <> (toLower, toUpper)

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
@@ -206,7 +206,7 @@ class UnionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testMappedUnion = {
-    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, u"t") {
+    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, "t".withUniquePostFix) {
       def a = column[String]("a")
       def b = column[Int]("b")
       def c = column[String]("c")

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -143,9 +143,11 @@ sealed abstract class GenericTest[TDB >: Null <: TestDB](implicit TdbClass: Clas
     if(keepAliveSession ne null) keepAliveSession.close()
   }
 
-  implicit class StringContextExtensionMethods(s: StringContext) {
+  implicit class StringExtensionMethods(s: String) {
     /** Generate a unique name suitable for a database entity */
-    def u(args: Any*) = s.standardInterpolator(identity, args) + "_" + unique.incrementAndGet()
+    def withUniquePostFix: String = {
+      s"${s}_${unique.incrementAndGet()}"
+    }
   }
 
   final def mark[T](id: String, f: => T): T = {


### PR DESCRIPTION
The tests use a string interpolator which has the sole purpose of adding a unique postfix to ensure that table names in tests are unique.

The odd thing is that no parameters are ever provided to the strings, therefore the string interpolator can easily be replaced by an extension method using an `implicit class`.

Doing so saves us from having to maintain separate sources for scala 2.13 due to internal changes in the s"" string interpolator.

Note: there is a pull request which restores some of the old scala 2.11/2.12 functionality in 2.13 see https://github.com/scala/scala/pull/7983 . However I believe that there is still no reason to use a string interpolator over an extension method in this specific case.