### PR TITLE
Support JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: scala
 before_install:
 # TZ needed for Oracle driver!
 - export TZ=Asia/Kamchatka
-- sh -v ./travis/extractNonPublicDeps
 - docker version
 - sh -v travis/runcontainer.sh oracle db2
 - docker ps
+- sh -v ./travis/extractNonPublicDeps
 jdk:
   - openjdk8
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 - sh -v ./travis/extractNonPublicDeps
 jdk:
   - openjdk8
+  - openjdk11
 notifications:
   flowdock:
     secure: j3YP9TjiIcMRy2mvunF1AHBOFnz2H7mZAFVbHPBNkAjMCwSdBNvLpn33qv6ybr02c5snBDJTs0P70RJ/mh3YsqwnIeloQD9HUfnndKQD6ujxx1QWRI/lVDW4pfVRQEuPsXdW/3AiqxrSG5BS4thiyc3vj3LpnodHwNMUT+Nlmq0=

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -4,7 +4,7 @@ Upgrade Guides {index="migration; 1.0; upgrading"}
 Compatibility Policy {index="source,compatibility; compatibility,source; binary,compatibility; compatibility,binary"}
 --------------------
 
-Slick 3.3.0 requires Scala 2.11 or 2.12 and Java 8.
+Slick 3.3.0 requires Scala 2.11 or 2.12 and Java 8 or 11.
 
 Slick version numbers consist of an epoch, a major and minor version, and possibly a qualifier
 (for milestone, RC and SNAPSHOT versions).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,13 +38,11 @@ object Dependencies {
     "net.sourceforge.jtds" % "jtds" % "1.3.1"
   )
 
-  val paxExamVersion = "4.6.0"
+  val paxExamVersion = "4.13.1"
   val paxExam = Seq(
     "org.ops4j.pax.exam"     % "pax-exam-container-native"  % paxExamVersion,
     "org.ops4j.pax.exam"     % "pax-exam-junit4"            % paxExamVersion,
     "org.ops4j.pax.exam"     % "pax-exam-link-assembly"     % paxExamVersion,
-    "org.ops4j.pax.url"      % "pax-url-aether"             % "1.6.0",
-    "org.ops4j.pax.swissbox" % "pax-swissbox-framework"     % "1.5.1",
-    "org.apache.felix"       % "org.apache.felix.framework" % "4.6.1"
+    "org.apache.felix"       % "org.apache.felix.framework" % "6.0.2"
   )
 }

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -156,7 +156,6 @@ db2 {
   adminConn.url = ${baseURL}
   user = db2admin
   driver = "com.ibm.db2.jcc.DB2Driver"
-  driverJar = "file:///C:/Program%20Files/IBM/SQLLIB/java/db2jcc4.jar"
 }
 
 sqlserver-jtds {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestDB.scala
@@ -229,7 +229,7 @@ abstract class ExternalJdbcTestDB(confName: String) extends JdbcTestDB(confName)
       .map(_.map(n => Class.forName(n).asInstanceOf[Class[_ <: GenericTest[_ >: Null <: TestDB]]]))
       .getOrElse(super.testClasses)
 
-  def databaseFor(path: String) = database.forConfig(path, config, loadCustomDriver().getOrElse(null))
+  def databaseFor(path: String) = database.forConfig(path, config)
 
   override def createDB() = databaseFor("testConn")
 
@@ -254,34 +254,5 @@ abstract class ExternalJdbcTestDB(confName: String) extends JdbcTestDB(confName)
         DBIO.seq(drop.map(s => sqlu"#$s"): _*).withPinnedSession
       ))
     }
-  }
-
-  def loadCustomDriver() = confOptionalString("driverJar").map { jar =>
-    ExternalTestDB.getCustomDriver(jar, jdbcDriver)
-  }
-}
-
-object ExternalTestDB {
-  // A cache for custom drivers to avoid excessive reloading and memory leaks
-  private[this] val driverCache = new mutable.HashMap[(String, String), Driver]()
-
-  def getCustomDriver(url: String, driverClass: String) = synchronized {
-    val sysloader = java.lang.ClassLoader.getSystemClassLoader
-    val sysclass = classOf[URLClassLoader]
-
-    // Add the supplied jar onto the system classpath
-    // Doing this allows Hikari to initialise the driver, if needed
-    try {
-        val method = sysclass.getDeclaredMethod("addURL", classOf[URL])
-        method.setAccessible(true)
-        method.invoke(sysloader, new URL(url))
-    } catch {
-      case t: Throwable =>
-        t.printStackTrace()
-        throw new IOException(s"Error, could not add URL $url to system classloader");
-    }
-    driverCache.getOrElseUpdate((url, driverClass),
-      new URLClassLoader(Array(new URL(url)), getClass.getClassLoader).loadClass(driverClass).getConstructor().newInstance().asInstanceOf[Driver]
-    )
   }
 }

--- a/test-dbs/README.md
+++ b/test-dbs/README.md
@@ -34,7 +34,7 @@ Oracle
 Oracle quick setup:
 - Install [Oracle Database Express Edition 11g Release 2](http://www.oracle.com/technetwork/products/express-edition/downloads/)
 - Change password in `oracle.password` to the database password you specified during installation
-- Verify that the path in `oracle.driverJar` is correct
+- Copy the oracle jdbc driver jar into the `slick-testkit/lib` directory
 - Set `oracle.enabled = true`
 
 DB2
@@ -45,7 +45,7 @@ DB2 quick setup:
 - Remove all entries for JARs from the system CLASSPATH that were added by the DB2 installer
 - Change the password in `db2.password` to the database password you specified during
   installation for the `db2admin` user
-- Verify that the path in `db2.driverJar` is correct
+- Copy the DB2 jdbc driver jar into the `slick-testkit/lib` directory
 - In the DB2 Command Line Processor, create the database for testing and
   grant permissions to the db2admin user:
 
@@ -78,7 +78,7 @@ SQL Server via JTDS quick setup:
 SQL Server via sqljdbc quick setup:
 - Install [SQL Server Express 2008 R2](http://www.microsoft.com/express/Database/InstallOptions.aspx)
 - Install [sqljdbc](http://www.microsoft.com/en-us/download/details.aspx?id=11774)
-- Enter the correct path to `sqljdbc4.jar` in `sqlserver-sqljdbc.driverJar`
+- Copy the sqljdbc driver jar into the `slick-testkit/lib` directory
 - Enter the password for the `sa` user in `sqlserver-sqljdbc.password`
   (use SQL Server Management Studio to set a password if necessary)
 - Ensure that the TCP transport on port 1433 is enabled (-> SQL Server Configuration Manager)
@@ -104,7 +104,6 @@ Example configuration
     oracle {
       enabled = true
       password = secret
-      driverJar = "file:///C:/oraclexe/app/oracle/product/11.2.0/server/jdbc/lib/ojdbc6.jar"
     }
 
     db2 {
@@ -119,5 +118,4 @@ Example configuration
     sqlserver-sqljdbc {
       enabled = true
       password = secret
-      driverJar = "file:///C:/sqljdbc_4.0/enu/sqljdbc4.jar"
     }

--- a/test-dbs/testkit.travis.conf
+++ b/test-dbs/testkit.travis.conf
@@ -21,7 +21,6 @@ postgres {
 
 db2 {
   enabled = true
-  driverJar = "file:./db2jcc4.jar"
   user = db2inst1
   schema = "SLICK_TEST"
   password = db2inst1-pwd
@@ -57,7 +56,6 @@ db2 {
 
 oracle {
   enabled = true
-  driverJar = "file:./ojdbc7-12.1.0.2.jar"
   driver=oracle.jdbc.OracleDriver
   baseURL = "jdbc:oracle:thin:@//localhost:49161/xe"
   testDB = ""

--- a/travis/extractNonPublicDeps
+++ b/travis/extractNonPublicDeps
@@ -8,8 +8,11 @@
 DIR="$( cd "$( dirname $0 )" && pwd )"
 SCRIPTPATH=$DIR/ZNonPublicDeps
 OJDBCDIR=ojdbc7
+OUTPUTDIR=${DIR}/../slick-testkit/lib
 export CxD=$(echo wraan | tr '[A-Za-z]' '[N-ZA-Mn-za-m]')
 openssl enc -in ${SCRIPTPATH}/mssql.enc -out ./sqljdbc42.jar -d -aes256  -pass env:CxD
 openssl enc -in ${SCRIPTPATH}/npj.enc -out ${SCRIPTPATH}/npj.tjz -d -aes256  -pass env:CxD
 tar xvjf ${SCRIPTPATH}/npj.tjz -C ${SCRIPTPATH}
 cp ${SCRIPTPATH}/nonpublicjars/${OJDBCDIR}/jars/ojdbc7-12.1.0.2.jar .
+mkdir -p ${OUTPUTDIR}
+cp -n ./*.jar ${OUTPUTDIR}


### PR DESCRIPTION
This PR ensures that the travis tests also run successfully using jdk-11. It turned out that slick 3.3.0 already supported java 11, with the exception of sqlite.

The following changes were needed for the jdk 11 support:
- Removed the jaxb code dependency for sqlite (already merged as part of #2008)
- The classloading mechanism used to load the non-public drivers is no longer supported in jdk 9 and later. I attempted to use a solution similar to what was attempted in #1959 however, the oracle driver is also accessed from the `OracleProfile` (using reflection). Supplying a custom classloader in the `OracleProfile` was not an easy thing to do. Instead I used the sbt mechanism to include jars in the `lib` directory on the classpath. The travis scripts ensure that the jars end up in the correct place, and users should download these drivers themselves if they want to run tests for these databases.
- pax-exam (used for the slick-osgi subproject) needed to be upgraded to the latest version
- The last thing I did was to include openjdk11 in travis.

this pr closes #1959 as it replaces the PR as a whole.

This should also address https://github.com/scala/community-builds/issues/796