### PR TITLE
Dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ These are the databases and driver versions that have explicit automated tests.
 |DB2 10.5|[db2jcc4:4.19.20](http://www-01.ibm.com/support/docview.wss?uid=swg21363866)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |MySQL|mysql-connector-java:5.1.38|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |PostgreSQL|postgresql:42.2.5|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
-|SQLite|sqlite-jdbc:3.8.11.2|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
-|Derby/JavaDB|derby:10.11.1.1|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
-|HSQLDB/HyperSQL|hsqldb:2.2.8|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
-|H2|com.h2database.h2:1.4.197|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|SQLite|sqlite-jdbc:3.27.2.1|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|Derby/JavaDB|derby:10.14.2.0|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|HSQLDB/HyperSQL|hsqldb:2.4.1|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
+|H2|com.h2database.h2:1.4.199|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 
 Accessing other database systems is possible, with a reduced feature set.
 

--- a/doc/src/database.md
+++ b/doc/src/database.md
@@ -30,7 +30,7 @@ When specifying a dataSourceClass you will need to bring in the sbt dependency f
 ```scala expandVars=true
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "{{version}}",
-  "org.slf4j" % "slf4j-nop" % "1.6.4",
+  "org.slf4j" % "slf4j-nop" % "1.7.26",
   "com.typesafe.slick" %% "slick-hikaricp" % "{{version}}",
   "org.postgresql" % "postgresql" % "42.2.5" //org.postgresql.ds.PGSimpleDataSource dependency
 )

--- a/doc/src/gettingstarted.md
+++ b/doc/src/gettingstarted.md
@@ -38,7 +38,7 @@ build definition (`build.sbt` for [sbt] or `pom.xml` for Maven):
 ```scala expandVars=true tab=sbt
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "{{version}}",
-  "org.slf4j" % "slf4j-nop" % "1.6.4",
+  "org.slf4j" % "slf4j-nop" % "1.7.26",
   "com.typesafe.slick" %% "slick-hikaricp" % "{{version}}"
 )
 ```
@@ -55,7 +55,7 @@ libraryDependencies ++= Seq(
   <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-nop</artifactId>
-    <version>1.6.4</version>
+    <version>1.7.26</version>
   </dependency>
   <dependency>
     <groupId>com.typesafe.slick</groupId>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
 
   val scalaVersions = Seq("2.11.12", "2.12.8") // When updating these also update .travis.yml
 
-  val slf4j = "org.slf4j" % "slf4j-api" % "1.7.25"
-  val typesafeConfig = "com.typesafe" % "config" % "1.3.2"
+  val slf4j = "org.slf4j" % "slf4j-api" % "1.7.26"
+  val typesafeConfig = "com.typesafe" % "config" % "1.3.4"
   val reactiveStreamsVersion = "1.0.2"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
   val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
@@ -25,14 +25,14 @@ object Dependencies {
     "org.scalatest" %% "scalatest" % v
   }
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
-  val hikariCP = "com.zaxxer" % "HikariCP" % "3.2.0"
+  val hikariCP = "com.zaxxer" % "HikariCP" % "3.3.1"
 
-  val h2 = "com.h2database" % "h2" % "1.4.197"
+  val h2 = "com.h2database" % "h2" % "1.4.199"
   val testDBs = Seq(
     h2,
-    "org.apache.derby" % "derby" % "10.11.1.1",
-    "org.xerial" % "sqlite-jdbc" % "3.8.11.2",
-    "org.hsqldb" % "hsqldb" % "2.2.8",
+    "org.apache.derby" % "derby" % "10.14.2.0",
+    "org.xerial" % "sqlite-jdbc" % "3.27.2.1",
+    "org.hsqldb" % "hsqldb" % "2.4.1",
     "org.postgresql" % "postgresql" % "42.2.5",
     "mysql" % "mysql-connector-java" % "5.1.46",
     "net.sourceforge.jtds" % "jtds" % "1.3.1"

--- a/samples/hello-slick/build.sbt
+++ b/samples/hello-slick/build.sbt
@@ -2,8 +2,8 @@ scalaVersion := "2.12.7"
 
 libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.2.3",
-  "org.slf4j" % "slf4j-nop" % "1.7.25",
-  "com.h2database" % "h2" % "1.4.191",
+  "org.slf4j" % "slf4j-nop" % "1.7.26",
+  "com.h2database" % "h2" % "1.4.199",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )
 

--- a/samples/slick-multidb/build.sbt
+++ b/samples/slick-multidb/build.sbt
@@ -2,9 +2,9 @@ scalaVersion := "2.12.7"
 
 libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.2.3",
-  "org.slf4j" % "slf4j-nop" % "1.7.25",
-  "com.h2database" % "h2" % "1.4.191",
-  "org.xerial" % "sqlite-jdbc" % "3.8.11.2"
+  "org.slf4j" % "slf4j-nop" % "1.7.26",
+  "com.h2database" % "h2" % "1.4.199",
+  "org.xerial" % "sqlite-jdbc" % "3.27.2.1"
 )
 
 scalacOptions += "-deprecation"

--- a/samples/slick-plainsql/build.sbt
+++ b/samples/slick-plainsql/build.sbt
@@ -2,8 +2,8 @@ scalaVersion := "2.12.7"
 
 libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.2.3",
-  "org.slf4j" % "slf4j-nop" % "1.7.25",
-  "com.h2database" % "h2" % "1.4.191"
+  "org.slf4j" % "slf4j-nop" % "1.7.26",
+  "com.h2database" % "h2" % "1.4.199"
 )
 
 scalacOptions += "-deprecation"

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMetaTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMetaTest.scala
@@ -31,7 +31,7 @@ class JdbcMetaTest extends AsyncTest[JdbcTestDB] {
     MTypeInfo.getTypeInfo.named("Type info from DatabaseMetaData"),
 
     ifCap(tcap.jdbcMetaGetFunctions) {
-      /* Not supported by PostgreSQL and H2. */
+      /* Not supported by PostgreSQL, SQLite and H2. */
       MFunction.getFunctions(MQName.local("%")).flatMap { fs =>
         DBIO.sequence(fs.map(_.getFunctionColumns()))
       }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ModelBuilderTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ModelBuilderTest.scala
@@ -168,12 +168,8 @@ class ModelBuilderTest extends AsyncTest[JdbcTestDB] {
         val posts = model.tables.filter(_.name.table.toUpperCase=="POSTS").head
         assertEquals( 5, posts.columns.size )
         assertEquals( posts.indices.toString, 0, posts.indices.size )
-        if(tdb.profile != SQLiteProfile) {
-          // Reporting of multi-column primary keys through JDBC metadata is broken in Xerial SQLite 3.8:
-          // https://bitbucket.org/xerial/sqlite-jdbc/issue/107/databasemetadatagetprimarykeys-does-not
-          assertEquals( Some(2), posts.primaryKey.map(_.columns.size) )
-          assert( !posts.columns.exists(_.options.exists(_ == ColumnOption.PrimaryKey)) )
-        }
+        assertEquals( Some(2), posts.primaryKey.map(_.columns.size) )
+        assert( !posts.columns.exists(_.options.exists(_ == ColumnOption.PrimaryKey)) )
         assertEquals( 1, posts.foreignKeys.size )
         if(tdb.profile != slick.jdbc.SQLiteProfile){
           assertEquals( "CATEGORY_FK", posts.foreignKeys.head.name.get.toUpperCase )

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/StandardTestDBs.scala
@@ -10,6 +10,7 @@ import slick.jdbc._
 import slick.jdbc.GetResult._
 import slick.jdbc.meta.MTable
 import org.junit.Assert
+import slick.basic.Capability
 import slick.util.ConfigExtensionMethods._
 
 import scala.concurrent.duration.Duration
@@ -65,6 +66,7 @@ object StandardTestDBs {
 
   lazy val SQLiteMem = new SQLiteTestDB("jdbc:sqlite:file:slick_test?mode=memory&cache=shared", "sqlitemem") {
     override def isPersistent = false
+    override def capabilities: Set[Capability] = super.capabilities - TestDB.capabilities.jdbcMetaGetFunctions - TestDB.capabilities.jdbcMetaGetClientInfoProperties
   }
 
   lazy val SQLiteDisk = {
@@ -72,6 +74,7 @@ object StandardTestDBs {
     val prefix = "sqlite-"+confName
     new SQLiteTestDB("jdbc:sqlite:"+TestkitConfig.testDBPath+"/"+prefix+".db", confName) {
       override def cleanUpBefore() = TestDB.deleteDBFiles(prefix)
+      override def capabilities: Set[Capability] = super.capabilities - TestDB.capabilities.jdbcMetaGetFunctions - TestDB.capabilities.jdbcMetaGetClientInfoProperties
     }
   }
 
@@ -287,6 +290,8 @@ class SQLiteTestDB(dburl: String, confName: String) extends InternalJdbcTestDB(c
 }
 
 abstract class DerbyDB(confName: String) extends InternalJdbcTestDB(confName) {
+  // sbt enables a security manager which prevents Derby from loading, we must disable it
+  System.setSecurityManager(null)
   import profile.api.actionBasedSQLInterpolation
   val profile = DerbyProfile
   System.setProperty("derby.stream.error.method", classOf[DerbyDB].getName + ".DEV_NULL")

--- a/slick/src/sphinx/gettingstarted.rst
+++ b/slick/src/sphinx/gettingstarted.rst
@@ -33,23 +33,23 @@ following to your build definition - ``build.sbt`` or ``project/Build.scala``:
 .. parsed-literal::
   libraryDependencies ++= Seq(
     "com.typesafe.slick" %% "slick" % "|release|",
-    "org.slf4j" % "slf4j-nop" % "1.6.4",
+    "org.slf4j" % "slf4j-nop" % "1.7.26",
     "com.typesafe.slick" %% "slick-hikaricp" % "|release|"
   )
 
 For Maven projects add the following to your ``<dependencies>`` (make sure to use the correct Scala
-version prefix, ``_2.10`` or ``_2.11``, to match your project's Scala version):
+version prefix, ``_2.11`` or ``_2.12``, to match your project's Scala version):
 
 .. parsed-literal::
   <dependency>
     <groupId>com.typesafe.slick</groupId>
-    <artifactId>slick_2.10</artifactId>
+    <artifactId>slick_2.11</artifactId>
     <version>\ |release|\ </version>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-nop</artifactId>
-    <version>1.6.4</version>
+    <version>1.7.26</version>
   </dependency>
 
 .. index:: logging, SLF4j


### PR DESCRIPTION
Dependency updates, also bumped the in-memory databases to the latest versions

- slf4j 1.7.26
- lightbend config 1.3.4
- hikaricp 3.3.1
- h2 1.4.199
- derby 10.14.2.0
- sqlite 3.27.2.1
- hsqldb 2.4.1

Notes:
For sqlite I had to disable some jdbc4 meta capabilities, however it turns out that these capabilities were never supported, the driver just returned null, see https://github.com/xerial/sqlite-jdbc/pull/256

For derby a specific security manager permission is needed, which causes issues because sbt enables a security manager by default. The derby db tests disable the sbt security manager.