### PR TITLE
Use sensible default parameters for the AsyncExecutor

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -59,7 +59,12 @@ object Settings {
           ProblemFilters.exclude[DirectMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.inSetBind"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.inSet"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.inSetBind"),
-          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.inSet")
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.inSet"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.lifted.ColumnExtensionMethods.in"),
+          // #2025 default parameters for AsyncExecutor.apply have been removed and replaced by overloads
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$5"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$6"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$7")
         ),
         ivyConfigurations += config("macro").hide.extend(Compile),
         unmanagedClasspath in Compile ++= (products in config("macro")).value,


### PR DESCRIPTION
When AsyncExecutor is called using a method where maxConnections is not provided, the default `Integer.MAX_VALUE` was used. However this caused a warning to be logged in the tests on travis:

> *** (slick.util.AsyncExecutor) Having maxConnection > maxThreads can result in deadlocks if transactions or database locks are used.

Instead of using `Integer.MAX_VALUE` for the max number of connections,  the (max) number of connections should equal the number of threads.

In order to fix this properly I chose to remove the default parameters from this method, and use overloads instead, this introduces a binary compatibility. Since slick 3.4.0 is not binary compatible anyways it should not be a problem.

This issue fixes #1938