### PR TITLE
Use the latest version of the open source mssql-jdbc driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are the databases and driver versions that have explicit automated tests.
 
 |Database|JDBC Driver|Build status|
 |--------|-----------|-----------:|
-|SQLServer 2008, 2012, 2014, 2017|[jtds:1.3.1](http://sourceforge.net/projects/jtds/files/jtds/) and [msjdbc:4.2](https://www.microsoft.com/en-gb/download/details.aspx?id=11774)|[![Build status](https://ci.appveyor.com/api/projects/status/hcy6w0cp2qgw6ltt/branch/master?svg=true)](https://ci.appveyor.com/project/slick/slick)|
+|SQLServer 2008, 2012, 2014, 2017|[jtds:1.3.1](http://sourceforge.net/projects/jtds/files/jtds/) and [msjdbc:7.2.2](https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server?view=sql-server-2017)|[![Build status](https://ci.appveyor.com/api/projects/status/hcy6w0cp2qgw6ltt/branch/master?svg=true)](https://ci.appveyor.com/project/slick/slick)|
 |Oracle 11g|[ojdbc7:12.1.0.2](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |DB2 10.5|[db2jcc4:4.19.20](http://www-01.ibm.com/support/docview.wss?uid=swg21363866)|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|
 |MySQL|mysql-connector-java:5.1.38|[![Build Status](https://travis-ci.org/slick/slick.svg?branch=master)](https://travis-ci.org/slick/slick)|

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - cmd: SET JDK_HOME=C:\Program Files\Java\jdk11
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk11
   - cmd: SET PATH=C:\sbt\sbt\bin;%JDK_HOME%\bin;%PATH%
-  - cmd: SET SBT_OPTS=-Xmx4g -Xss2m -Dslick.testkit-config=test-dbs/testkit-appveyor.conf
+  - cmd: SET SBT_OPTS=-Xmx4g -Xss2m -Dslick.testkit-config=test-dbs/testkit.appveyor.conf
 # Start up sqlservers: 2008 on port 1433, 2012 on 1533, 2014 on 1633, 2017 on 1733. Enable tcp connections
   - ps: |
       [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,17 @@ object Dependencies {
   val hikariCP = "com.zaxxer" % "HikariCP" % "3.3.1"
 
   val h2 = "com.h2database" % "h2" % "1.4.199"
+  val sqlServer = {
+    val javaVersion = System.getProperty("java.version")
+    val jreVersionToUse = if (javaVersion.startsWith("11") || javaVersion.startsWith("12")) {
+      "11"
+    } else "8"
+    "com.microsoft.sqlserver" % "mssql-jdbc" % s"7.2.2.jre$jreVersionToUse"
+  }
+  
   val testDBs = Seq(
     h2,
+    sqlServer,
     "org.apache.derby" % "derby" % "10.14.2.0",
     "org.xerial" % "sqlite-jdbc" % "3.27.2.1",
     "org.hsqldb" % "hsqldb" % "2.4.1",

--- a/test-dbs/README.md
+++ b/test-dbs/README.md
@@ -77,8 +77,6 @@ SQL Server via JTDS quick setup:
 
 SQL Server via sqljdbc quick setup:
 - Install [SQL Server Express 2008 R2](http://www.microsoft.com/express/Database/InstallOptions.aspx)
-- Install [sqljdbc](http://www.microsoft.com/en-us/download/details.aspx?id=11774)
-- Copy the sqljdbc driver jar into the `slick-testkit/lib` directory
 - Enter the password for the `sa` user in `sqlserver-sqljdbc.password`
   (use SQL Server Management Studio to set a password if necessary)
 - Ensure that the TCP transport on port 1433 is enabled (-> SQL Server Configuration Manager)

--- a/test-dbs/testkit.appveyor.conf
+++ b/test-dbs/testkit.appveyor.conf
@@ -117,7 +117,6 @@ sqlserver-sqljdbc {
   drop = [
     use ${adminDB}
   ]
-  driverJar = "file:./sqljdbc42.jar"
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }
 
@@ -142,7 +141,6 @@ sqlserver2012-sqljdbc {
   drop = [
     use ${testDB}
   ]
-  driverJar = "file:./sqljdbc42.jar"
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }
 
@@ -167,7 +165,6 @@ sqlserver2014-sqljdbc {
   drop = [
     use ${testDB}
   ]
-  driverJar = "file:./sqljdbc42.jar"
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }
 
@@ -193,6 +190,5 @@ sqlserver2017-sqljdbc {
   drop = [
     use ${testDB}
   ]
-  driverJar = "file:./sqljdbc42.jar"
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }

--- a/travis/extractNonPublicDeps
+++ b/travis/extractNonPublicDeps
@@ -1,7 +1,6 @@
 #!/bin/bash
 # This script extracts jars that aren't in public repositories. This is used for slick CI.
 # Don't use this script to get the jars for your environment. Download them from the relevant source.
-# https://www.microsoft.com/en-gb/download/details.aspx?id=11774
 # http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html
 # http://www-01.ibm.com/support/docview.wss?uid=swg21363866
 
@@ -10,7 +9,6 @@ SCRIPTPATH=$DIR/ZNonPublicDeps
 OJDBCDIR=ojdbc7
 OUTPUTDIR=${DIR}/../slick-testkit/lib
 export CxD=$(echo wraan | tr '[A-Za-z]' '[N-ZA-Mn-za-m]')
-openssl enc -in ${SCRIPTPATH}/mssql.enc -out ./sqljdbc42.jar -d -aes256  -pass env:CxD
 openssl enc -in ${SCRIPTPATH}/npj.enc -out ${SCRIPTPATH}/npj.tjz -d -aes256  -pass env:CxD
 tar xvjf ${SCRIPTPATH}/npj.tjz -C ${SCRIPTPATH}
 cp ${SCRIPTPATH}/nonpublicjars/${OJDBCDIR}/jars/ojdbc7-12.1.0.2.jar .


### PR DESCRIPTION
Instead if an old version of the mssql-jdbc driver, we can now use the publicly available open-source driver.

Unfortunately I was not able to setup AppVeyor on my local github repo, so I will have to see if the build works fine here.