### PR TITLE
[3.3.x]: Scala 2.13.0-RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
 scala:
   - 2.11.12
   - 2.12.8
-  - 2.13.0-RC1
+  - 2.13.0-RC2
 script:
 - admin/build.sh
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ addons:
     - mysql-server-5.6
     - mysql-client-core-5.6
     - mysql-client-5.6
+scala:
+  - 2.11.12
+  - 2.12.8
 script:
 - admin/build.sh
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
 scala:
   - 2.11.12
   - 2.12.8
+  - 2.13.0-RC1
 script:
 - admin/build.sh
 cache:

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -20,7 +20,7 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9-]+)? ]]; then
   openssl aes-256-cbc -K $encrypted_c3c0a1170361_key -iv $encrypted_c3c0a1170361_iv -in secrets.tar.enc -out secrets.tar -d
   myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
   publishVersion='set every version := "'$myVer'"'
-  extraTarget="+publishSigned doc"
+  extraTarget="publishSigned doc"
   publish_docs=1
   cp admin/publish-settings.sbt ./
   echo "Contents of secrets.tar:"
@@ -31,7 +31,7 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9-]+)? ]]; then
   ls -l *.sbt project/*.scala
 fi
 
-sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf "$publishVersion" +testAll $extraTarget
+sbt -jvm-opts jvmopts.travis -Dslick.testkit-config=test-dbs/testkit.travis.conf "$publishVersion" ++$TRAVIS_SCALA_VERSION testAll $extraTarget
 
 if test "$publish_docs" = "1" ; then
   slick_dir=$(pwd)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,13 @@ import BuildUtils._
 
 version in ThisBuild := "3.3.1-SNAPSHOT"
 
-binaryCompatSlickVersion in ThisBuild := Some("3.3.0") // Slick base version for binary compatibility checks
+// Slick base version for binary compatibility checks.
+// The next release to be cut from master will be 3.4.0 during develop of 3.4.0 we check compatibility with 3.3.0.
+// The goal is not to stop any breaking change, but to make us aware. For each breaking change we should add MiMa exclusions.
+// This will also help us decide when a PR can be backported in 3.3.x branch.  
+binaryCompatSlickVersion in ThisBuild := {
+  if (scalaBinaryVersion.value.startsWith("2.13")) None else Some("3.3.0")
+}
 
 docDir in ThisBuild := (baseDirectory in aRootProject).value / "doc"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,6 @@ import BuildUtils._
 
 version in ThisBuild := "3.3.1-SNAPSHOT"
 
-// Slick base version for binary compatibility checks.
-// The next release to be cut from master will be 3.4.0 during develop of 3.4.0 we check compatibility with 3.3.0.
-// The goal is not to stop any breaking change, but to make us aware. For each breaking change we should add MiMa exclusions.
-// This will also help us decide when a PR can be backported in 3.3.x branch.  
 binaryCompatSlickVersion in ThisBuild := {
   if (scalaBinaryVersion.value.startsWith("2.13")) None else Some("3.3.0")
 }

--- a/doc/code/CodeGenerator.scala
+++ b/doc/code/CodeGenerator.scala
@@ -2,6 +2,7 @@ package com.typesafe.slick.docs
 
 //#imports
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
 import slick.jdbc.H2Profile.api._
 import slick.jdbc.H2Profile
 //#imports
@@ -62,10 +63,12 @@ object CodeGenerator extends App {
         }
       }
     })
-    codegenFuture.onSuccess { case codegen =>
-      codegen.writeToFile(
-        "slick.jdbc.H2Profile","some/folder/","some.packag","Tables","Tables.scala"
-      )
+    codegenFuture.onComplete {
+      case Success(codegen) =>
+        codegen.writeToFile(
+          "slick.jdbc.H2Profile","some/folder/","some.packag","Tables","Tables.scala"
+        )
+      case Failure(_) =>
     }
     //#customization
   }

--- a/doc/code/Connection.scala
+++ b/doc/code/Connection.scala
@@ -76,7 +76,10 @@ object Connection extends App {
       val a = q.result
       val f: Future[Seq[String]] = db.run(a)
 
-      f.onSuccess { case s => println(s"Result: $s") }
+      f.onComplete {
+        case Success(s) => println(s"Result: $s")
+        case Failure(t) => t.printStackTrace()
+      }
       //#materialize
       Await.result(f, Duration.Inf)
     };{

--- a/doc/code/SqlToSlick.scala
+++ b/doc/code/SqlToSlick.scala
@@ -55,7 +55,7 @@ object SqlToSlick extends App {
 
       Class.forName("org.h2.Driver")
       val conn = DriverManager.getConnection("jdbc:h2:mem:test1")
-      val people = new scala.collection.mutable.MutableList[(Int,String,Int)]()
+      val people = new scala.collection.mutable.ListBuffer[(Int,String,Int)]()
       try{
         val stmt = conn.createStatement()
         try{

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,14 +6,14 @@ object Dependencies {
   // NOTE: remember to change the version numbers in the sample projects
   // when changing them here
 
-  val scalaVersions = Seq("2.11.12", "2.12.8", "2.13.0-RC1") // When updating these also update .travis.yml
+  val scalaVersions = Seq("2.11.12", "2.12.8", "2.13.0-RC2") // When updating these also update .travis.yml and appveyor.yml
 
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.25"
   val typesafeConfig = "com.typesafe" % "config" % "1.3.2"
   val reactiveStreamsVersion = "1.0.2"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
   val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
-  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "1.0.0"
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.0.0"
 
   def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams, scalaCollectionCompat)
 
@@ -22,7 +22,7 @@ object Dependencies {
     "com.novocode" % "junit-interface" % "0.11"
   )
   def scalaTestFor(scalaVersion: String) = {
-    val v = "3.0.8-RC2"
+    val v = "3.0.8-RC4"
     "org.scalatest" %% "scalatest" % v
   }
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,22 +6,23 @@ object Dependencies {
   // NOTE: remember to change the version numbers in the sample projects
   // when changing them here
 
-  val scalaVersions = Seq("2.11.12", "2.12.8") // When updating these also update .travis.yml
+  val scalaVersions = Seq("2.11.12", "2.12.8", "2.13.0-RC1") // When updating these also update .travis.yml
 
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.25"
   val typesafeConfig = "com.typesafe" % "config" % "1.3.2"
   val reactiveStreamsVersion = "1.0.2"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
   val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "1.0.0"
 
-  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
+  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams, scalaCollectionCompat)
 
   val junit = Seq(
     "junit" % "junit-dep" % "4.11",
     "com.novocode" % "junit-interface" % "0.11"
   )
   def scalaTestFor(scalaVersion: String) = {
-    val v = "3.0.4"
+    val v = "3.0.8-RC2"
     "org.scalatest" %% "scalatest" % v
   }
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   // NOTE: remember to change the version numbers in the sample projects
   // when changing them here
 
-  val scalaVersions = Seq("2.11.12", "2.12.8")
+  val scalaVersions = Seq("2.11.12", "2.12.8") // When updating these also update .travis.yml
 
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.25"
   val typesafeConfig = "com.typesafe" % "config" % "1.3.2"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -39,7 +39,7 @@ object Settings {
           "-doc-root-content", "scaladoc-root.txt"
         ),
         test := (), testOnly :=  (), // suppress test status output
-        mimaPreviousArtifacts := binaryCompatSlickVersion.value.toSet.map { v: String =>
+        mimaPreviousArtifacts := emptyIfScala213(binaryCompatSlickVersion.value, scalaBinaryVersion.value).toSet.map { v: String =>
           "com.typesafe.slick" % ("slick_" + scalaBinaryVersion.value) % v
         },
         mimaBinaryIssueFilters ++= Seq(
@@ -298,6 +298,10 @@ object Settings {
       case null => Seq.empty
       case path => Seq(target := file(path + "/" + extName))
     }
+  }
+
+  def emptyIfScala213(value: Option[String], scalaBinaryVersionString: String): Option[String] = {
+    if (scalaBinaryVersionString.startsWith("2.13")) None else value
   }
 
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -39,7 +39,7 @@ object Settings {
           "-doc-root-content", "scaladoc-root.txt"
         ),
         test := (), testOnly :=  (), // suppress test status output
-        mimaPreviousArtifacts := emptyIfScala213(binaryCompatSlickVersion.value, scalaBinaryVersion.value).toSet.map { v: String =>
+        mimaPreviousArtifacts := binaryCompatSlickVersion.value.toSet.map { v: String =>
           "com.typesafe.slick" % ("slick_" + scalaBinaryVersion.value) % v
         },
         mimaBinaryIssueFilters ++= Seq(
@@ -298,10 +298,6 @@ object Settings {
       case null => Seq.empty
       case path => Seq(target := file(path + "/" + extName))
     }
-  }
-
-  def emptyIfScala213(value: Option[String], scalaBinaryVersionString: String): Option[String] = {
-    if (scalaBinaryVersionString.startsWith("2.13")) None else value
   }
 
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -193,7 +193,7 @@ object Settings {
   )
 
   def slickGeneralSettings =
-    slickPublishSettings ++ slickScalacSettings ++ slickScalaSettings ++ Seq(
+    slickPublishSettings ++ slickScalacSettings ++ slickScalaSettings ++ crossScalaFoldersSettings ++ Seq(
       logBuffered := false
     )
 
@@ -288,6 +288,18 @@ object Settings {
     unmanagedJars in config("compile") := scalaInstance.map( _.jars.classpath).value,
     unmanagedJars in config("test") := scalaInstance.map( _.jars.classpath).value,
     unmanagedJars in config("macro") := scalaInstance.map( _.jars.classpath).value
+  )
+
+  def crossScalaFoldersSettings: Seq[Setting[_]] = Seq(
+    unmanagedSourceDirectories in Compile += {
+      val sourceDir = (sourceDirectory in Compile).value
+      val scalaVer = scalaVersion.value
+      if (scalaVer.startsWith("2.13")) {
+        sourceDir / "scala-2.13+"
+      } else {
+        sourceDir / "scala-2.13-"
+      }
+    }
   )
 
   def sampleProject(s: String): Project = Project(id = "sample-"+s, base = file("samples/"+s))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -254,7 +254,12 @@ object Settings {
   )
 
   def slickScalacSettings = Seq(
-    scalacOptions ++= List("-deprecation", "-feature", "-unchecked", "-Xfuture"),
+    scalacOptions ++= List("-deprecation", "-feature", "-unchecked"),
+    // -Xfuture is deprecated: Not used since 2.13.
+    scalacOptions ++= {
+      if (scalaVersion.value.startsWith("2.13")) List.empty
+      else List("-Xfuture")
+    },
     scalacOptions in (Compile, doc) ++= Seq(
       "-doc-title", name.value,
       "-doc-version", version.value,

--- a/samples/hello-slick/build.sbt
+++ b/samples/hello-slick/build.sbt
@@ -4,7 +4,7 @@ libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.3.0",
   "org.slf4j" % "slf4j-nop" % "1.7.26",
   "com.h2database" % "h2" % "1.4.199",
-  "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test
+  "org.scalatest" %% "scalatest" % "3.0.8-RC4" % Test
 )
 
 scalacOptions += "-deprecation"

--- a/samples/hello-slick/build.sbt
+++ b/samples/hello-slick/build.sbt
@@ -2,9 +2,9 @@ scalaVersion := "2.12.8"
 
 libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "3.3.0",
-  "org.slf4j" % "slf4j-nop" % "1.7.25",
-  "com.h2database" % "h2" % "1.4.191",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  "org.slf4j" % "slf4j-nop" % "1.7.26",
+  "com.h2database" % "h2" % "1.4.199",
+  "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test
 )
 
 scalacOptions += "-deprecation"

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ActionTest.scala
@@ -8,7 +8,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   import tdb.profile.api._
 
   def testSimpleActionAsFuture = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -27,7 +27,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testSessionPinning = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -70,7 +70,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testStreaming = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -114,7 +114,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   } else DBIO.successful(())
 
   def testOptionSequence = {
-    class T(tag: Tag) extends Table[Option[Int]](tag, u"t") {
+    class T(tag: Tag) extends Table[Option[Int]](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a.?
     }
@@ -138,7 +138,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testFlatten = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
       def * = a
     }
@@ -155,7 +155,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testZipWith = {
-      class T(tag: Tag) extends Table[Int](tag, u"t") {
+      class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
         def a = column[Int]("a")
         def * = a
       }
@@ -173,7 +173,7 @@ class ActionTest extends AsyncTest[RelationalTestDB] {
     }
 
   def testCollect = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def a = column[Int]("a")
 
       def * = a

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -183,7 +183,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     DBIO.seq()
   }
 
-  def testInsertOrUpdatePlainWithFuncDefinedPK: DBIOAction[Unit, _, _] = {
+  def testInsertOrUpdatePlainWithFuncDefinedPK: DBIOAction[Unit, NoStream, Effect.All] = {
     //FIXME remove this after fixed checkInsert issue
     if (tdb.profile.isInstanceOf[DerbyProfile]) return DBIO.successful(())
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -2,6 +2,7 @@ package com.typesafe.slick.testkit.tests
 
 import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
 import slick.jdbc.DerbyProfile
+import scala.collection.compat._
 
 class InsertTest extends AsyncTest[JdbcTestDB] {
   import tdb.profile.api._
@@ -37,7 +38,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
       dst2.forceInsertExpr(q3),
       dst2.to[Set].result.map(_ shouldBe Set((1,"A"), (2,"B"), (42,"X"))),
       dst3comp.forceInsertQuery(q4comp),
-      dst3comp.result.map(v => v.to[Set] shouldBe Set((1,"A"), (2,"B")))
+      dst3comp.result.map(v => v.to(Set) shouldBe Set((1,"A"), (2,"B")))
     ))
   }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -38,7 +38,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
       dst2.forceInsertExpr(q3),
       dst2.to[Set].result.map(_ shouldBe Set((1,"A"), (2,"B"), (42,"X"))),
       dst3comp.forceInsertQuery(q4comp),
-      dst3comp.result.map(v => v.to(Set) shouldBe Set((1,"A"), (2,"B")))
+      dst3comp.result.map(v => v.toSet shouldBe Set((1,"A"), (2,"B")))
     ))
   }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -51,7 +51,7 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
   }
 
   def testOverrideStatements = {
-    class T(tag: Tag) extends Table[Int](tag, u"t") {
+    class T(tag: Tag) extends Table[Int](tag, "t".withUniquePostFix) {
       def id = column[Int]("a")
       def * = id
     }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
@@ -28,7 +28,7 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q1a = (for {
       (a, b) <- ts.map(t => (t.a, t.b))
       c <- ts.map(t => t.c)
-    } yield a ~ b ~ c ~ 5).sortBy(t => t._3 ~ t._1)
+    } yield (a, b, c, 5)).sortBy(t => t._3 ~ t._1)
 
     val q1c = (for {
       a ~ b <- ts.map(t => (t.a, t.b))
@@ -43,7 +43,7 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val res2 = Set((1, "1", 8), (2, "2", 10))
 
     val q2a = for {
-      a ~ b ~ c <- ts.filter(_.a === 1).map(t => t.a ~ t.b ~ 4) unionAll ts.filter(_.a === 2).map(t => t.a ~ t.b ~ 5)
+      a ~ b ~ c <- ts.filter(_.a === 1).map(t => (t.a, t.b, 4)) unionAll ts.filter(_.a === 2).map(t => t.a ~ t.b ~ 5)
     } yield a ~ b ~ (c*2)
 
     val q2b = for {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalMapperTest.scala
@@ -146,7 +146,7 @@ class RelationalMapperTest extends AsyncTest[RelationalTestDB] {
 
     case class Row(id: String, escaped: Option[String])
 
-    class T(tag: Tag) extends Table[Row](tag, u"t") {
+    class T(tag: Tag) extends Table[Row](tag, "t".withUniquePostFix) {
       val id = column[String]("id", O.PrimaryKey)
       val name = column[Option[String]]("name")
       val upperName = name.shaped <> (toLower, toUpper)

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
@@ -22,8 +22,8 @@ class RelationalScalarFunctionTest extends AsyncTest[RelationalTestDB] {
       checkLit(-17.5),
       checkLit(17.5f),
       checkLit(-17.5f),
-      checkLit(42l),
-      checkLit(-42l),
+      checkLit(42L),
+      checkLit(-42L),
       checkLit("foo"),
 
       check("42".asColumnOf[Int], 42),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/UnionTest.scala
@@ -206,7 +206,7 @@ class UnionTest extends AsyncTest[RelationalTestDB] {
   }
 
   def testMappedUnion = {
-    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, u"t") {
+    class T(tag: Tag) extends Table[(String, Int, String, Int)](tag, "t".withUniquePostFix) {
       def a = column[String]("a")
       def b = column[Int]("b")
       def c = column[String]("c")

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DBTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DBTest.scala
@@ -2,11 +2,10 @@ package com.typesafe.slick.testkit.util
 
 import slick.dbio.DBIO
 
-import scala.collection.JavaConversions
+import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-
-import org.junit.{Before, After}
+import org.junit.{After, Before}
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
@@ -37,5 +36,5 @@ abstract class DBTestObject(dbs: TestDB*) {
     val s = getClass.getName
     s.substring(0, s.length-1)
   }
-  @Parameters def parameters = JavaConversions.seqAsJavaList(dbs.filter(_.isEnabled).map(to => Array(to)))
+  @Parameters def parameters: java.util.List[Array[TestDB]] = dbs.filter(_.isEnabled).map(to => Array(to)).asJava
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -144,9 +144,11 @@ sealed abstract class GenericTest[TDB >: Null <: TestDB](implicit TdbClass: Clas
     if(keepAliveSession ne null) keepAliveSession.close()
   }
 
-  implicit class StringContextExtensionMethods(s: StringContext) {
+  implicit class StringExtensionMethods(s: String) {
     /** Generate a unique name suitable for a database entity */
-    def u(args: Any*) = s.standardInterpolator(identity, args) + "_" + unique.incrementAndGet()
+    def withUniquePostFix: String = {
+      s"${s}_${unique.incrementAndGet()}"
+    }
   }
 
   final def mark[T](id: String, f: => T): T = {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
@@ -63,7 +63,7 @@ object TestkitConfig {
   def getStrings(config: Config, path: String): Option[Seq[String]] = {
     if(config.hasPath(path)) {
       config.getValue(path).unwrapped() match {
-        case l: java.util.List[_] => Some(l.asScala.map(_.toString))
+        case l: java.util.List[_] => Some(l.asScala.iterator.map(_.toString).toSeq)
         case o => Some(List(o.toString))
       }
     } else None

--- a/slick/src/main/scala-2.13+/slick/lifted/ExtensionMethodsCompat.scala
+++ b/slick/src/main/scala-2.13+/slick/lifted/ExtensionMethodsCompat.scala
@@ -26,10 +26,10 @@ trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
 
   def in[P2, R, C[_]](e: Query[Rep[P2], _, C])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
     om.column(Library.In, n, e.toNode)
-  def inSet[R](seq: scala.collection.immutable.Iterable[B1])(implicit om: o#to[Boolean, R]) =
+  def inSet[R](seq: scala.collection.Iterable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
     else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))
-  def inSetBind[R](seq: scala.collection.immutable.Iterable[B1])(implicit om: o#to[Boolean, R]) =
+  def inSetBind[R](seq: scala.collection.Iterable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
     else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)))))
 

--- a/slick/src/main/scala-2.13+/slick/lifted/ExtensionMethodsCompat.scala
+++ b/slick/src/main/scala-2.13+/slick/lifted/ExtensionMethodsCompat.scala
@@ -1,0 +1,40 @@
+package slick.lifted
+
+import slick.util.ConstArray
+
+import scala.language.{implicitConversions, higherKinds}
+import slick.ast._
+import FunctionSymbolExtensionMethods._
+import ScalaBaseType._
+import slick.SlickException
+
+/** Extension methods for all columns */
+trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
+  def === [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.==, n, e.toNode)
+  def =!= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.Not, Library.==.typed(om.liftedType, n, e.toNode))
+
+  def < [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.<, n, e.toNode)
+  def <= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.<=, n, e.toNode)
+  def > [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.>, n, e.toNode)
+  def >= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.>=, n, e.toNode)
+
+  def in[P2, R, C[_]](e: Query[Rep[P2], _, C])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.In, n, e.toNode)
+  def inSet[R](seq: scala.collection.immutable.Iterable[B1])(implicit om: o#to[Boolean, R]) =
+    if(seq.isEmpty) om(LiteralColumn(false))
+    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))
+  def inSetBind[R](seq: scala.collection.immutable.Iterable[B1])(implicit om: o#to[Boolean, R]) =
+    if(seq.isEmpty) om(LiteralColumn(false))
+    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)))))
+
+  def between[P2, P3, R](start: Rep[P2], end: Rep[P3])(implicit om: o#arg[B1, P2]#arg[B1, P3]#to[Boolean, R]) =
+    om.column(Library.Between, n, start.toNode, end.toNode)
+  def ifNull[B2, P2, R](e: Rep[P2])(implicit om: o#arg[B2, P2]#to[Boolean, R]): Rep[P2] =
+    Library.IfNull.column[P2](n, e.toNode)(tpe(e))
+}

--- a/slick/src/main/scala-2.13+/slick/util/ConstArrayCompat.scala
+++ b/slick/src/main/scala-2.13+/slick/util/ConstArrayCompat.scala
@@ -1,7 +1,7 @@
 package slick.util
 
 trait ConstArrayCompat {
-  def from[T](values: scala.collection.immutable.Iterable[T]): ConstArray[T] = {
+  def from[T](values: scala.collection.Iterable[T]): ConstArray[T] = {
     val a = new Array[Any](values.size)
     var i = 0
     values.foreach { v =>

--- a/slick/src/main/scala-2.13+/slick/util/ConstArrayCompat.scala
+++ b/slick/src/main/scala-2.13+/slick/util/ConstArrayCompat.scala
@@ -1,0 +1,13 @@
+package slick.util
+
+trait ConstArrayCompat {
+  def from[T](values: scala.collection.immutable.Iterable[T]): ConstArray[T] = {
+    val a = new Array[Any](values.size)
+    var i = 0
+    values.foreach { v =>
+      a(i) = v
+      i += 1
+    }
+    new ConstArray[T](a)
+  }
+}

--- a/slick/src/main/scala-2.13+/slick/util/SQLBuilderCompat.scala
+++ b/slick/src/main/scala-2.13+/slick/util/SQLBuilderCompat.scala
@@ -1,0 +1,14 @@
+package slick.util
+
+trait SQLBuilderCompat {
+
+  def +=(s: String): SQLBuilder
+
+  def sep[T](sequence: scala.collection.immutable.Iterable[T], separator: String)(f: T => Unit): Unit = {
+    var first = true
+    for(x <- sequence) {
+      if(first) first = false else this += separator
+      f(x)
+    }
+  }
+}

--- a/slick/src/main/scala-2.13+/slick/util/SQLBuilderCompat.scala
+++ b/slick/src/main/scala-2.13+/slick/util/SQLBuilderCompat.scala
@@ -4,7 +4,7 @@ trait SQLBuilderCompat {
 
   def +=(s: String): SQLBuilder
 
-  def sep[T](sequence: scala.collection.immutable.Iterable[T], separator: String)(f: T => Unit): Unit = {
+  def sep[T](sequence: scala.collection.Iterable[T], separator: String)(f: T => Unit): Unit = {
     var first = true
     for(x <- sequence) {
       if(first) first = false else this += separator

--- a/slick/src/main/scala-2.13-/slick/lifted/ExtensionMethodsCompat.scala
+++ b/slick/src/main/scala-2.13-/slick/lifted/ExtensionMethodsCompat.scala
@@ -1,0 +1,40 @@
+package slick.lifted
+
+import slick.util.ConstArray
+
+import scala.language.{implicitConversions, higherKinds}
+import slick.ast._
+import FunctionSymbolExtensionMethods._
+import ScalaBaseType._
+import slick.SlickException
+
+/** Extension methods for all columns */
+trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
+  def === [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.==, n, e.toNode)
+  def =!= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.Not, Library.==.typed(om.liftedType, n, e.toNode))
+
+  def < [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.<, n, e.toNode)
+  def <= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.<=, n, e.toNode)
+  def > [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.>, n, e.toNode)
+  def >= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.>=, n, e.toNode)
+
+  def in[P2, R, C[_]](e: Query[Rep[P2], _, C])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
+    om.column(Library.In, n, e.toNode)
+  def inSet[R](seq: scala.collection.Traversable[B1])(implicit om: o#to[Boolean, R]) =
+    if(seq.isEmpty) om(LiteralColumn(false))
+    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))
+  def inSetBind[R](seq: scala.collection.Traversable[B1])(implicit om: o#to[Boolean, R]) =
+    if(seq.isEmpty) om(LiteralColumn(false))
+    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)))))
+
+  def between[P2, P3, R](start: Rep[P2], end: Rep[P3])(implicit om: o#arg[B1, P2]#arg[B1, P3]#to[Boolean, R]) =
+    om.column(Library.Between, n, start.toNode, end.toNode)
+  def ifNull[B2, P2, R](e: Rep[P2])(implicit om: o#arg[B2, P2]#to[Boolean, R]): Rep[P2] =
+    Library.IfNull.column[P2](n, e.toNode)(tpe(e))
+}

--- a/slick/src/main/scala-2.13-/slick/util/ConstArrayCompat.scala
+++ b/slick/src/main/scala-2.13-/slick/util/ConstArrayCompat.scala
@@ -1,0 +1,13 @@
+package slick.util
+
+trait ConstArrayCompat {
+  def from[T](values: scala.collection.Traversable[T]): ConstArray[T] = {
+    val a = new Array[Any](values.size)
+    var i = 0
+    values.foreach { v =>
+      a(i) = v
+      i += 1
+    }
+    new ConstArray[T](a)
+  }
+}

--- a/slick/src/main/scala-2.13-/slick/util/SQLBuilderCompat.scala
+++ b/slick/src/main/scala-2.13-/slick/util/SQLBuilderCompat.scala
@@ -1,0 +1,14 @@
+package slick.util
+
+trait SQLBuilderCompat {
+
+  def +=(s: String): SQLBuilder
+
+  def sep[T](sequence: scala.collection.Traversable[T], separator: String)(f: T => Unit): Unit = {
+    var first = true
+    for(x <- sequence) {
+      if(first) first = false else this += separator
+      f(x)
+    }
+  }
+}

--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -667,7 +667,7 @@ final case class IfThenElse(clauses: ConstArray[Node]) extends SimplyTypedNode {
   def mapResultClauses(f: Node => Node, keepType: Boolean = false) =
     mapClauses(f, keepType, (i => i%2 == 1 || i == clauses.length-1))
   def ifThenClauses: Iterator[(Node, Node)] =
-    clauses.iterator.grouped(2).withPartial(false).map { case List(i, t) => (i, t) }
+    clauses.iterator.grouped(2).withPartial(false).map { case Seq(i, t) => (i, t) }
   def elseClause = clauses.last
 }
 

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -2,7 +2,7 @@ package slick.ast
 
 import scala.language.{implicitConversions, higherKinds}
 import slick.SlickException
-import scala.collection.generic.CanBuild
+import scala.collection.compat._
 import scala.collection.mutable.{Builder, ArrayBuilder}
 import scala.reflect.{ClassTag, classTag => mkClassTag}
 import scala.annotation.implicitNotFound
@@ -157,7 +157,7 @@ trait CollectionTypeConstructor {
   def iterableSubstitute: CollectionTypeConstructor =
     if(isUnique && !isSequential) TypedCollectionTypeConstructor.set
     else TypedCollectionTypeConstructor.seq
-    //TODO We should have a better substitute for (isUnique && isSequential)
+  //TODO We should have a better substitute for (isUnique && isSequential)
 }
 
 @implicitNotFound("Cannot use collection in a query\n            collection type: ${C}[_]\n  requires implicit of type: slick.ast.TypedCollectionTypeConstructor[${C}]")
@@ -174,10 +174,10 @@ abstract class TypedCollectionTypeConstructor[C[_]](val classTag: ClassTag[C[_]]
   }
 }
 
-class ErasedCollectionTypeConstructor[C[_]](canBuildFrom: CanBuild[Any, C[Any]], classTag: ClassTag[C[_]]) extends TypedCollectionTypeConstructor[C](classTag) {
+class ErasedCollectionTypeConstructor[C[_]](factory: Factory[Any, C[Any]], classTag: ClassTag[C[_]]) extends TypedCollectionTypeConstructor[C](classTag) {
   val isSequential = classOf[scala.collection.Seq[_]].isAssignableFrom(classTag.runtimeClass)
   val isUnique = classOf[scala.collection.Set[_]].isAssignableFrom(classTag.runtimeClass)
-  def createBuilder[E : ClassTag] = canBuildFrom().asInstanceOf[Builder[E, C[E]]]
+  def createBuilder[E : ClassTag] = factory.newBuilder.asInstanceOf[Builder[E, C[E]]]
 }
 
 object TypedCollectionTypeConstructor {
@@ -187,7 +187,7 @@ object TypedCollectionTypeConstructor {
   /** The standard TypedCollectionTypeConstructor for Set */
   def set = forColl[Set]
   /** Get a TypedCollectionTypeConstructor for an Iterable type */
-  implicit def forColl[C[X] <: Iterable[X]](implicit cbf: CanBuild[Any, C[Any]], tag: ClassTag[C[_]]): TypedCollectionTypeConstructor[C] =
+  implicit def forColl[C[X] <: Iterable[X]](implicit cbf: Factory[Any, C[Any]], tag: ClassTag[C[_]]): TypedCollectionTypeConstructor[C] =
     new ErasedCollectionTypeConstructor[C](cbf, tag)
   /** Get a TypedCollectionTypeConstructor for an Array type */
   implicit val forArray: TypedCollectionTypeConstructor[Array] = new TypedCollectionTypeConstructor[Array](arrayClassTag) {
@@ -224,11 +224,11 @@ case object UnassignedType extends AtomicType {
 }
 
 /** A type with a name, as used by tables.
- *
- * Compiler phases which change types may keep their own representation
- * of the structural view but must update the AST at the end of the phase
- * so that all NominalTypes with the same symbol have the same structural
- * view. */
+  *
+  * Compiler phases which change types may keep their own representation
+  * of the structural view but must update the AST at the end of the phase
+  * so that all NominalTypes with the same symbol have the same structural
+  * view. */
 final case class NominalType(sym: TypeSymbol, structuralView: Type) extends Type {
   override def toString = s"$sym<$structuralView>"
   def withStructuralView(t: Type): NominalType =

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -11,6 +11,7 @@ import com.typesafe.config.Config
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import scala.util.{Success, Failure}
 import scala.util.control.NonFatal
+import scala.collection.compat._
 
 import org.slf4j.LoggerFactory
 import org.reactivestreams._
@@ -186,7 +187,7 @@ trait BasicBackend { self =>
 
           def run(pos: Int): Future[Any] = {
             if (pos == len) Future.successful {
-              val b = sa.cbf()
+              val b = sa.cbf.newBuilder
               var i = 0
               while (i < len) {
                 b += results.get(i)

--- a/slick/src/main/scala/slick/compiler/CreateAggregates.scala
+++ b/slick/src/main/scala/slick/compiler/CreateAggregates.scala
@@ -50,7 +50,7 @@ class CreateAggregates extends Phase {
             logger.debug("Replacement paths: " + repl)
             val scope = Type.Scope(s1 -> from2.nodeType.asCollectionType.elementType)
             val replNodes = repl.mapValues(ss => FwdPath(ss).infer(scope))
-            logger.debug("Replacement path nodes: ", StructNode(ConstArray.from(replNodes)))
+            logger.debug("Replacement path nodes: ", StructNode(ConstArray.from(replNodes.toSeq)))
             val sel3 = sel2.replace({ case n @ Ref(s) => replNodes.getOrElse(s, n) }, keepType = true)
             val n2 = Bind(s1, from2, Pure(sel3, ts1)).infer()
             logger.debug("Lifted aggregates into join in:", n2)

--- a/slick/src/main/scala/slick/compiler/ExpandSums.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandSums.scala
@@ -126,7 +126,7 @@ class ExpandSums extends Phase {
         case _ => Set.empty
       }
       def find(t: Type, path: List[TermSymbol]): Vector[List[TermSymbol]] = t.structural match {
-        case StructType(defs) => defs.toSeq.flatMap { case (s, t) => find(t, s :: path) }(collection.breakOut)
+        case StructType(defs) => defs.toSeq.iterator.flatMap { case (s, t) => find(t, s :: path) }.toVector
         case p: ProductType => p.elements.iterator.zipWithIndex.flatMap { case (t, i) => find(t, ElementSymbol(i+1) :: path) }.toVector
         case _: AtomicType => Vector(path)
         case _ => Vector.empty

--- a/slick/src/main/scala/slick/compiler/ExpandTables.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandTables.scala
@@ -40,7 +40,7 @@ class ExpandTables extends Phase {
       // structural type under a different identity when we are traversing the tree to modify it.
       val structs: Map[TypeSymbol, Type] = tree.collect[(TypeSymbol, (FieldSymbol, Type))] {
         case s @ Select(_ :@ (n: NominalType), sym: FieldSymbol) => baseIdentity(n.sourceNominalType.sym) -> (sym -> s.nodeType)
-      }.toSeq.groupBy(_._1).mapValues(v => StructType(ConstArray.from(v.map(_._2).toMap)))
+      }.toSeq.groupBy(_._1).mapValues(v => StructType(ConstArray.from(v.map(_._2).toMap))).toMap
       logger.debug("Found Selects for NominalTypes: "+structs.keySet.mkString(", "))
 
       val tables = new mutable.HashMap[TableIdentitySymbol, (TermSymbol, Node)]

--- a/slick/src/main/scala/slick/compiler/FlattenProjections.scala
+++ b/slick/src/main/scala/slick/compiler/FlattenProjections.scala
@@ -107,6 +107,6 @@ class FlattenProjections extends Phase {
       }
     }
     flatten(n, Nil)
-    (StructNode(ConstArray.from(defs)), paths.toMap)
+    (StructNode(ConstArray.from(defs.toSeq)), paths.toMap)
   }
 }

--- a/slick/src/main/scala/slick/compiler/MergeToComprehensions.scala
+++ b/slick/src/main/scala/slick/compiler/MergeToComprehensions.scala
@@ -263,7 +263,7 @@ class MergeToComprehensions extends Phase {
 
       case n =>
         val (c, rep) = mergeTakeDrop(n, false)
-        val mappings = ConstArray.from(rep.mapValues(_ :: Nil))
+        val mappings = ConstArray.from(rep.mapValues(_ :: Nil).toSeq)
         logger.debug("Mappings are: "+mappings)
         val c2 = c.select match {
           // Ensure that the select clause is non-empty
@@ -319,7 +319,7 @@ class MergeToComprehensions extends Phase {
   }
 
   def toSubquery(n: Comprehension, r: Replacements): (Comprehension, Replacements) =
-    buildSubquery(n, ConstArray.from(r.mapValues(_ :: Nil)))
+    buildSubquery(n, ConstArray.from(r.mapValues(_ :: Nil).toSeq))
 
   /** Merge the common operations Bind, Filter and CollectionCast into an existing Comprehension.
     * This method is used at different stages of the pipeline. If the Comprehension already contains

--- a/slick/src/main/scala/slick/compiler/RewriteJoins.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteJoins.scala
@@ -210,7 +210,7 @@ class RewriteJoins extends Phase {
       val m2 = m.mapValues(_.replace({
         case Ref(s) :@ tpe if s == j.leftGen => Select(Ref(outsideRef) :@ j2.nodeType.asCollectionType.elementType, ElementSymbol(1)) :@ tpe
         case Ref(s) :@ tpe if s == j.rightGen => Select(Ref(outsideRef) :@ j2.nodeType.asCollectionType.elementType, ElementSymbol(2)) :@ tpe
-      }, keepType = true))
+      }, keepType = true)).toMap
       if(logger.isDebugEnabled) m2.foreach { case (p, n) =>
         logger.debug("Replacement for "+FwdPath.toString(p)+":", n)
       }
@@ -270,7 +270,7 @@ class RewriteJoins extends Phase {
     case b => b
   }
 
-  def splitConjunctions(n: Node): IndexedSeq[Node] = {
+  def splitConjunctions(n: Node): scala.collection.IndexedSeq[Node] = {
     val b = new ArrayBuffer[Node]
     def f(n: Node): Unit = n match {
       case Library.And(l, r) => f(l); f(r)
@@ -281,7 +281,7 @@ class RewriteJoins extends Phase {
     b
   }
 
-  def and(ns: IndexedSeq[Node]): Node =
+  def and(ns: scala.collection.IndexedSeq[Node]): Node =
     if(ns.isEmpty) LiteralNode(true) else ns.reduceLeft { (p1, p2) =>
       val t1 = p1.nodeType.structural
       Library.And.typed(if(t1.isInstanceOf[OptionType]) t1 else p2.nodeType.structural, p1, p2)

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -2,7 +2,7 @@ package slick.dbio
 
 import org.reactivestreams.Subscription
 
-import scala.collection.compat.{Factory, IterableOnce}
+import scala.collection.compat._
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}

--- a/slick/src/main/scala/slick/jdbc/Invoker.scala
+++ b/slick/src/main/scala/slick/jdbc/Invoker.scala
@@ -1,8 +1,8 @@
 package slick.jdbc
 
+import scala.collection.compat._
 import scala.language.higherKinds
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.collection.generic.CanBuildFrom
 import slick.util.CloseableIterator
 
 /** Base trait for all statement invokers of result element type R. */
@@ -35,8 +35,8 @@ trait Invoker[+R] { self =>
   }
 
   /** Execute the statement and return a fully materialized collection. */
-  final def buildColl[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R @uV]]): C[R @uV] = {
-    val b = canBuildFrom()
+  final def buildColl[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: Factory[R, C[R @uV]]): C[R @uV] = {
+    val b = canBuildFrom.newBuilder
     foreach({ x => b += x }, 0)
     b.result()
   }

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -1,11 +1,8 @@
 package slick.jdbc
 
-import slick.sql.{FixedSqlStreamingAction, FixedSqlAction, SqlActionComponent}
-
-import scala.language.{existentials, higherKinds}
-
 import java.sql.{PreparedStatement, Statement}
 
+import scala.language.{existentials, higherKinds}
 import scala.collection.mutable.Builder
 import scala.util.control.NonFatal
 
@@ -17,6 +14,7 @@ import slick.ast.Util._
 import slick.ast.TypeUtil.:@
 import slick.lifted.{CompiledStreamingExecutable, Query, FlatShapeLevel, Shape}
 import slick.relational.{ResultConverter, CompiledMapping}
+import slick.sql.{FixedSqlStreamingAction, FixedSqlAction, SqlActionComponent}
 import slick.util.{DumpInfo, SQLBuilder, ignoreFollowOnError}
 
 trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
@@ -528,13 +526,13 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
       def run(ctx: Backend#Context, sql: Vector[String]) = {
         val sql1 = sql.head
         if(!useBatchUpdates(ctx.session) || (values.isInstanceOf[IndexedSeq[_]] && values.asInstanceOf[IndexedSeq[_]].length < 2))
-          retMany(values, values.map { v =>
+          retMany(values, values.iterator.map { v =>
             preparedInsert(sql1, ctx.session) { st =>
               st.clearParameters()
               a.converter.set(v, st)
               retOne(st, v, st.executeUpdate())
             }
-          }(collection.breakOut): Vector[SingleInsertResult])
+          }.toVector)
         else preparedInsert(a.sql, ctx.session) { st =>
           st.clearParameters()
           for(value <- values) {
@@ -666,7 +664,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
     protected def retMany(values: Iterable[U], individual: Seq[SingleInsertResult]) = individual
 
     protected def retManyBatch(st: Statement, values: Iterable[U], updateCounts: Array[Int]) =
-      (values, buildKeysResult(st).buildColl[Vector](null, implicitly)).zipped.map(mux)(collection.breakOut)
+      (values, buildKeysResult(st).buildColl[Vector](null, implicitly)).zipped.map(mux).toIndexedSeq
 
     protected def retQuery(st: Statement, updateCount: Int) =
       buildKeysResult(st).buildColl[Vector](null, implicitly).asInstanceOf[QueryInsertResult] // Not used with "into"

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -661,10 +661,10 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
 
     protected def retOne(st: Statement, value: U, updateCount: Int) = mux(value, buildKeysResult(st).first(null))
 
-    protected def retMany(values: Iterable[U], individual: Seq[SingleInsertResult]) = individual
+    protected def retMany(values: Iterable[U], individual: Seq[SingleInsertResult]): Seq[SingleInsertResult] = individual
 
-    protected def retManyBatch(st: Statement, values: Iterable[U], updateCounts: Array[Int]) =
-      (values, buildKeysResult(st).buildColl[Vector](null, implicitly)).zipped.map(mux).toIndexedSeq
+    protected def retManyBatch(st: Statement, values: Iterable[U], updateCounts: Array[Int]): Seq[RU] =
+      (values, buildKeysResult(st).buildColl[Vector](null, implicitly)).zipped.map(mux).toSeq
 
     protected def retQuery(st: Statement, updateCount: Int) =
       buildKeysResult(st).buildColl[Vector](null, implicitly).asInstanceOf[QueryInsertResult] // Not used with "into"

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -2,6 +2,7 @@ package slick.jdbc
 
 import slick.util.TableDump
 
+import scala.collection.compat._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.reflectiveCalls
 
@@ -49,7 +50,7 @@ class LoggingStatement(st: Statement) extends Statement {
     if(doStatementAndParameter && (sql ne null)) JdbcBackend.statementAndParameterLogger.debug("Executing "+what+": "+sql)
     if(doParameter && (paramss ne null) && paramss.nonEmpty) {
       // like s.groupBy but only group adjacent elements and keep the ordering
-      def groupBy[T](s: TraversableOnce[T])(f: T => AnyRef): IndexedSeq[IndexedSeq[T]] = {
+      def groupBy[T](s: IterableOnce[T])(f: T => AnyRef): IndexedSeq[IndexedSeq[T]] = {
         var current: AnyRef = null
         val b = new ArrayBuffer[ArrayBuffer[T]]
         s.foreach { v =>

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -59,7 +59,7 @@ class LoggingStatement(st: Statement) extends Statement {
           else b.last += v
           current = id
         }
-        b
+        b.toIndexedSeq.map(_.toIndexedSeq)
       }
       def mkTpStr(tp: Int) = JdbcTypesComponent.typeNames.getOrElse(tp, tp.toString)
       val paramSets = paramss.map { params =>
@@ -80,7 +80,7 @@ class LoggingStatement(st: Statement) extends Statement {
       groupBy(paramSets)(_._1).foreach { matchingSets =>
         val tpes = matchingSets.head._1
         val idxs = 1.to(tpes.length).map(_.toString)
-        dump(Vector(idxs, tpes), matchingSets.map(_._2)).foreach(s => JdbcBackend.parameterLogger.debug(s))
+        dump(Vector(idxs, tpes.toIndexedSeq), matchingSets.map(_._2).toIndexedSeq.map(_.toIndexedSeq)).foreach(s => JdbcBackend.parameterLogger.debug(s))
       }
     }
     val t0 = if(doBenchmark) System.nanoTime() else 0L

--- a/slick/src/main/scala/slick/jdbc/PositionedResult.scala
+++ b/slick/src/main/scala/slick/jdbc/PositionedResult.scala
@@ -1,7 +1,7 @@
 package slick.jdbc
 
+import scala.collection.compat._
 import scala.language.higherKinds
-import scala.collection.generic.CanBuildFrom
 import java.sql.{ResultSet, Blob, Clob, Date, Time, Timestamp}
 import java.io.Closeable
 import slick.util.{ReadAheadIterator, CloseableIterator}
@@ -147,8 +147,8 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable { outer =>
     view(discPos, discPos+1, { r => disc != null && disc == r.nextObject })
   }
 
-  final def build[C[_], R](gr: GetResult[R])(implicit canBuildFrom: CanBuildFrom[Nothing, R, C[R]]): C[R] = {
-    val b = canBuildFrom()
+  final def build[C[_], R](gr: GetResult[R])(implicit canBuildFrom: Factory[R, C[R]]): C[R] = {
+    val b = canBuildFrom.newBuilder
     while(nextRow) b += gr(this)
     b.result()
   }
@@ -156,7 +156,7 @@ abstract class PositionedResult(val rs: ResultSet) extends Closeable { outer =>
   final def to[C[_]] = new To[C]()
 
   final class To[C[_]] private[PositionedResult] () {
-    def apply[R](gr: GetResult[R])(implicit session: JdbcBackend#Session, canBuildFrom: CanBuildFrom[Nothing, R, C[R]]) =
+    def apply[R](gr: GetResult[R])(implicit session: JdbcBackend#Session, canBuildFrom: Factory[R, C[R]]) =
       build[C, R](gr)
   }
 }

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -51,7 +51,7 @@ abstract class StatementInvoker[+R] extends Invoker[R] { self =>
           def close() = {
             st.close()
             if(doLogResult) {
-              StatementInvoker.tableDump(logHeader, logBuffer).foreach(s => StatementInvoker.resultLogger.debug(s))
+              StatementInvoker.tableDump(logHeader.toIndexedSeq.map(_.toIndexedSeq), logBuffer.toIndexedSeq.map(_.toIndexedSeq)).foreach(s => StatementInvoker.resultLogger.debug(s))
               val rest = rowCount - logBuffer.length
               if(rest > 0) StatementInvoker.resultLogger.debug(s"$rest more rows read ($rowCount total)")
             }

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -3,6 +3,7 @@ package slick.jdbc
 import java.sql.PreparedStatement
 import slick.util.{TableDump, SlickLogger, CloseableIterator}
 import org.slf4j.LoggerFactory
+import scala.collection.compat._
 import scala.collection.mutable.ArrayBuffer
 
 private[jdbc] object StatementInvoker {
@@ -41,7 +42,7 @@ abstract class StatementInvoker[+R] extends Invoker[R] { self =>
           val meta = rs.getMetaData
           Vector(
             1.to(meta.getColumnCount).map(_.toString),
-            1.to(meta.getColumnCount).map(idx => meta.getColumnLabel(idx)).to[ArrayBuffer]
+            1.to(meta.getColumnCount).map(idx => meta.getColumnLabel(idx)).to(ArrayBuffer)
           )
         } else null
         val logBuffer = if(doLogResult) new ArrayBuffer[ArrayBuffer[Any]] else null
@@ -60,7 +61,7 @@ abstract class StatementInvoker[+R] extends Invoker[R] { self =>
           def extractValue(pr: PositionedResult) = {
             if(doLogResult) {
               if(logBuffer.length < StatementInvoker.maxLogResults)
-                logBuffer += 1.to(logHeader(0).length).map(idx => rs.getObject(idx) : Any).to[ArrayBuffer]
+                logBuffer += 1.to(logHeader(0).length).map(idx => rs.getObject(idx) : Any).to(ArrayBuffer)
               rowCount += 1
             }
             self.extractValue(pr)

--- a/slick/src/main/scala/slick/lifted/AbstractTable.scala
+++ b/slick/src/main/scala/slick/lifted/AbstractTable.scala
@@ -64,9 +64,9 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     * @param onDelete A `ForeignKeyAction`, default being `NoAction`.
     */
   def foreignKey[P, PU, TT <: AbstractTable[_], U]
-      (name: String, sourceColumns: P, targetTableQuery: TableQuery[TT])
-      (targetColumns: TT => P, onUpdate: ForeignKeyAction = ForeignKeyAction.NoAction,
-       onDelete: ForeignKeyAction = ForeignKeyAction.NoAction)(implicit unpack: Shape[_ <: FlatShapeLevel, TT, U, _], unpackp: Shape[_ <: FlatShapeLevel, P, PU, _]): ForeignKeyQuery[TT, U] = {
+  (name: String, sourceColumns: P, targetTableQuery: TableQuery[TT])
+  (targetColumns: TT => P, onUpdate: ForeignKeyAction = ForeignKeyAction.NoAction,
+   onDelete: ForeignKeyAction = ForeignKeyAction.NoAction)(implicit unpack: Shape[_ <: FlatShapeLevel, TT, U, _], unpackp: Shape[_ <: FlatShapeLevel, P, PU, _]): ForeignKeyQuery[TT, U] = {
     val targetTable: TT = targetTableQuery.shaped.value
     val q = targetTableQuery.asInstanceOf[Query[TT, U, Seq]]
     val generator = new AnonSymbol
@@ -85,10 +85,10 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
   def primaryKey[T](name: String, sourceColumns: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]): PrimaryKey = PrimaryKey(name, ForeignKey.linearizeFieldRefs(shape.toNode(sourceColumns)))
 
   def tableConstraints: Iterator[Constraint] = for {
-      m <- getClass().getMethods.iterator
-      if m.getParameterTypes.length == 0 && classOf[Constraint].isAssignableFrom(m.getReturnType)
-      q = m.invoke(this).asInstanceOf[Constraint]
-    } yield q
+    m <- getClass().getMethods.iterator
+    if m.getParameterTypes.length == 0 && classOf[Constraint].isAssignableFrom(m.getReturnType)
+    q = m.invoke(this).asInstanceOf[Constraint]
+  } yield q
 
   final def foreignKeys: Iterable[ForeignKey] =
     tableConstraints.collect{ case q: ForeignKeyQuery[_, _] => q.fks }.flatten.toIndexedSeq.sortBy(_.name)
@@ -100,7 +100,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
   def index[T](name: String, on: T, unique: Boolean = false)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]) = new Index(name, this, ForeignKey.linearizeFieldRefs(shape.toNode(on)), unique)
 
   def indexes: Iterable[Index] = (for {
-      m <- getClass().getMethods.view
-      if m.getReturnType == classOf[Index] && m.getParameterTypes.length == 0
-    } yield m.invoke(this).asInstanceOf[Index]).sortBy(_.name)
+    m <- getClass().getMethods.iterator
+    if m.getReturnType == classOf[Index] && m.getParameterTypes.length == 0
+  } yield m.invoke(this).asInstanceOf[Index]).toIndexedSeq.sortBy(_.name)
 }

--- a/slick/src/main/scala/slick/lifted/Constraint.scala
+++ b/slick/src/main/scala/slick/lifted/Constraint.scala
@@ -59,7 +59,7 @@ object ForeignKey {
         n.childrenForeach(f)
     }
     f(n)
-    sels
+    sels.toIndexedSeq
   }
 }
 

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -43,10 +43,10 @@ trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
 
   def in[P2, R, C[_]](e: Query[Rep[P2], _, C])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
     om.column(Library.In, n, e.toNode)
-  def inSet[R](seq: Traversable[B1])(implicit om: o#to[Boolean, R]) =
+  def inSet[R](seq: Iterable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
     else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))
-  def inSetBind[R](seq: Traversable[B1])(implicit om: o#to[Boolean, R]) =
+  def inSetBind[R](seq: Iterable[B1])(implicit om: o#to[Boolean, R]) =
     if(seq.isEmpty) om(LiteralColumn(false))
     else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)))))
 

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -25,37 +25,6 @@ trait OptionExtensionMethods[B1] extends Any with ExtensionMethods[B1, Option[B1
   protected[this] implicit def b1Type = p1Type.asInstanceOf[OptionType].elementType.asInstanceOf[TypedType[B1]]
 }
 
-/** Extension methods for all columns */
-trait ColumnExtensionMethods[B1, P1] extends Any with ExtensionMethods[B1, P1] {
-  def === [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.==, n, e.toNode)
-  def =!= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.Not, Library.==.typed(om.liftedType, n, e.toNode))
-
-  def < [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.<, n, e.toNode)
-  def <= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.<=, n, e.toNode)
-  def > [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.>, n, e.toNode)
-  def >= [P2, R](e: Rep[P2])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.>=, n, e.toNode)
-
-  def in[P2, R, C[_]](e: Query[Rep[P2], _, C])(implicit om: o#arg[B1, P2]#to[Boolean, R]) =
-    om.column(Library.In, n, e.toNode)
-  def inSet[R](seq: Iterable[B1])(implicit om: o#to[Boolean, R]) =
-    if(seq.isEmpty) om(LiteralColumn(false))
-    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map{ v => LiteralNode(implicitly[TypedType[B1]], v) })))
-  def inSetBind[R](seq: Iterable[B1])(implicit om: o#to[Boolean, R]) =
-    if(seq.isEmpty) om(LiteralColumn(false))
-    else om.column(Library.In, n, ProductNode(ConstArray.from(seq.map(v => LiteralNode(implicitly[TypedType[B1]], v, vol = true)))))
-
-  def between[P2, P3, R](start: Rep[P2], end: Rep[P3])(implicit om: o#arg[B1, P2]#arg[B1, P3]#to[Boolean, R]) =
-    om.column(Library.Between, n, start.toNode, end.toNode)
-  def ifNull[B2, P2, R](e: Rep[P2])(implicit om: o#arg[B2, P2]#to[Boolean, R]): Rep[P2] =
-    Library.IfNull.column[P2](n, e.toNode)(tpe(e))
-}
-
 final class BaseColumnExtensionMethods[P1](val c: Rep[P1]) extends AnyVal with ColumnExtensionMethods[P1, P1] with BaseExtensionMethods[P1] {
   /** Lift a column to an Option column. This is the same as calling [[slick.lifted.Rep.Some]]. */
   def ? : Rep[Option[P1]] = Rep.forNode(OptionApply(c.toNode))(p1Type.optionType)

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -162,7 +162,7 @@ abstract class ProductNodeShape[Level <: ShapeLevel, C, M <: C, U <: C, P <: C] 
   }
   def toNode(value: Mixed): Node = ProductNode(ConstArray.from(shapes.iterator.zip(getIterator(value)).map {
     case (p, f) => p.toNode(f.asInstanceOf[p.Mixed])
-  }.toIterable))
+  }.toSeq))
 }
 
 /** Base class for ProductNodeShapes with a type mapping */

--- a/slick/src/main/scala/slick/lifted/SimpleFunction.scala
+++ b/slick/src/main/scala/slick/lifted/SimpleFunction.scala
@@ -25,7 +25,7 @@ object SimpleFunction {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]): Self = build(ch.toSeq)
     }
-    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.map(_.toNode)(collection.breakOut))) }
+    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
   def nullary[R : TypedType](fname: String, fn: Boolean = false): Rep[R] =
     apply(fname, fn).apply(Seq())
@@ -82,7 +82,7 @@ object SimpleExpression {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]) = build(ch.toSeq)
     }
-    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.map(_.toNode)(collection.breakOut))) }
+    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
 
   def nullary[R : TypedType](f: JdbcStatementBuilderComponent#QueryBuilder => Unit): Rep[R] = {

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -3,13 +3,14 @@ package slick.memory
 import com.typesafe.config.Config
 import org.reactivestreams.Subscriber
 
+import scala.collection.compat._
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.util.{Failure, Try}
 import slick.SlickException
 import slick.relational.RelationalBackend
 import slick.basic.BasicBackend
 import slick.util.Logging
-import scala.collection.mutable.ArrayBuffer
-import scala.util.{Failure, Try}
 
 /** The backend for DistributedProfile. */
 trait DistributedBackend extends RelationalBackend with Logging {
@@ -57,7 +58,7 @@ trait DistributedBackend extends RelationalBackend with Logging {
   class DatabaseFactoryDef {
     /** Create a new distributed database instance that uses the supplied ExecutionContext for
       * asynchronous execution of database actions. */
-    def apply(dbs: TraversableOnce[BasicBackend#DatabaseDef], executionContext: ExecutionContext): Database =
+    def apply(dbs: IterableOnce[BasicBackend#DatabaseDef], executionContext: ExecutionContext): Database =
       new DatabaseDef(dbs.toVector, executionContext)
   }
 

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 
 import org.reactivestreams.Subscriber
 
+import scala.collection.compat._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.concurrent.{Future, ExecutionContext}
 
@@ -116,7 +117,7 @@ trait HeapBackend extends RelationalBackend with Logging {
       logger.debug("Inserted ("+row.mkString(", ")+") into "+this)
     }
 
-    def createInsertRow: ArrayBuffer[Any] = columns.map(_.createDefault)(collection.breakOut)
+    def createInsertRow: ArrayBuffer[Any] = columns.map(_.createDefault).to(ArrayBuffer)
 
     override def toString = name + "(" + columns.map(_.sym.name).mkString(", ") + ")"
 

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -94,7 +94,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
       val htable = session.database.getTable(table.tableName)
       val buf = htable.createInsertRow
       converter.asInstanceOf[ResultConverter[MemoryResultConverterDomain, Any]].set(value, buf)
-      htable.append(buf)
+      htable.append(buf.toIndexedSeq)
     }
 
     def ++= (values: Iterable[T])(implicit session: Backend#Session): Unit =

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -448,7 +448,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
     case t: ScalaType[_] => if(t.nullable) None else null
     case StructType(el) =>
       new StructValue(el.toSeq.map{ case (_, tpe) => createNullRow(tpe) },
-        el.toSeq.zipWithIndex.map{ case ((sym, _), idx) => (sym, idx) }(collection.breakOut): Map[TermSymbol, Int])
+        el.toSeq.zipWithIndex.iterator.map{ case ((sym, _), idx) => (sym, idx) }.toMap)
     case ProductType(el) =>
       new ProductValue(el.toSeq.map(tpe => createNullRow(tpe)))
   }

--- a/slick/src/main/scala/slick/relational/ResultConverter.scala
+++ b/slick/src/main/scala/slick/relational/ResultConverter.scala
@@ -42,7 +42,7 @@ trait ResultConverterDomain {
 
 /** An efficient (albeit boxed) ResultConverter for Product/Tuple values. */
 final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product](elementConverters: ResultConverter[M, _]*) extends ResultConverter[M, T] {
-  private[this] val cha = elementConverters.to(Array)
+  private[this] val cha = elementConverters.toArray
   private[this] val len = cha.length
 
   val width = cha.foldLeft(0)(_ + _.width)
@@ -76,7 +76,7 @@ final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product
 
 /** Result converter that can write to multiple sub-converters and read from the first one */
 final case class CompoundResultConverter[M <: ResultConverterDomain, @specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean) T](width: Int, childConverters: ResultConverter[M, T]*) extends ResultConverter[M, T] {
-  private[this] val cha = childConverters.to(Array)
+  private[this] val cha = childConverters.toArray
   private[this] val len = cha.length
 
   def read(pr: Reader) = {

--- a/slick/src/main/scala/slick/relational/ResultConverter.scala
+++ b/slick/src/main/scala/slick/relational/ResultConverter.scala
@@ -2,6 +2,7 @@ package slick.relational
 
 import slick.SlickException
 import slick.util.{Dumpable, DumpInfo, TupleSupport}
+import scala.collection.compat._
 
 /** A `ResultConverter` is used to read data from a result, update a result,
   * and set parameters of a query. */
@@ -41,7 +42,7 @@ trait ResultConverterDomain {
 
 /** An efficient (albeit boxed) ResultConverter for Product/Tuple values. */
 final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product](elementConverters: ResultConverter[M, _]*) extends ResultConverter[M, T] {
-  private[this] val cha = elementConverters.to[Array]
+  private[this] val cha = elementConverters.to(Array)
   private[this] val len = cha.length
 
   val width = cha.foldLeft(0)(_ + _.width)
@@ -75,7 +76,7 @@ final case class ProductResultConverter[M <: ResultConverterDomain, T <: Product
 
 /** Result converter that can write to multiple sub-converters and read from the first one */
 final case class CompoundResultConverter[M <: ResultConverterDomain, @specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean) T](width: Int, childConverters: ResultConverter[M, T]*) extends ResultConverter[M, T] {
-  private[this] val cha = childConverters.to[Array]
+  private[this] val cha = childConverters.to(Array)
   private[this] val len = cha.length
 
   def read(pr: Reader) = {

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -12,7 +12,7 @@ import scala.util.hashing.MurmurHash3
   * the same as for Scala collections but for performance reasons it does not implement any
   * standard collection traits. */
 final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extends Product { self =>
-  private def this(a: Array[Any]) = this(a, a.length)
+  private[util] def this(a: Array[Any]) = this(a, a.length)
 
   def apply(i: Int): T =
     if(i > length) throw new IndexOutOfBoundsException
@@ -397,7 +397,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
   override def productPrefix = "ConstArray"
 }
 
-object ConstArray {
+object ConstArray extends ConstArrayCompat {
   val empty: ConstArray[Nothing] = new ConstArray[Nothing](new Array[Any](0))
 
   def apply[T](v0: T): ConstArray[T] = {
@@ -419,16 +419,6 @@ object ConstArray {
     a(1) = v1
     a(2) = v2
     new ConstArray(a)
-  }
-
-  def from[T](values: Iterable[T]): ConstArray[T] = {
-    val a = new Array[Any](values.size)
-    var i = 0
-    values.foreach { v =>
-      a(i) = v
-      i += 1
-    }
-    new ConstArray[T](a)
   }
 
   def from[T](o: Option[T]): ConstArray[T] =

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -3,6 +3,7 @@ package slick.util
 import java.util.Arrays
 
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.compat._
 import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
@@ -420,7 +421,7 @@ object ConstArray {
     new ConstArray(a)
   }
 
-  def from[T](values: Traversable[T]): ConstArray[T] = {
+  def from[T](values: Iterable[T]): ConstArray[T] = {
     val a = new Array[Any](values.size)
     var i = 0
     values.foreach { v =>
@@ -500,7 +501,7 @@ final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double =
     len += vslen
   }
 
-  def ++= (vs: TraversableOnce[T]): Unit = {
+  def ++= (vs: IterableOnce[T]): Unit = {
     if(vs.isInstanceOf[IndexedSeq[_]]) ensure(vs.size)
     vs.foreach(self += _)
   }
@@ -516,6 +517,6 @@ final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double =
 
   def + (v: T): this.type = { this += v; this }
   def ++ (vs: ConstArray[T]): this.type = { this ++= vs; this }
-  def ++ (vs: TraversableOnce[T]): this.type = { this ++= vs; this }
+  def ++ (vs: IterableOnce[T]): this.type = { this ++= vs; this }
   def ++ (vs: Option[T]): this.type = { this ++= vs; this }
 }

--- a/slick/src/main/scala/slick/util/SQLBuilder.scala
+++ b/slick/src/main/scala/slick/util/SQLBuilder.scala
@@ -3,7 +3,7 @@ package slick.util
 import java.sql.PreparedStatement
 import scala.collection.mutable.ArrayBuffer
 
-final class SQLBuilder { self =>
+final class SQLBuilder extends SQLBuilderCompat { self =>
   import SQLBuilder._
 
   private val sb = new StringBuilder(128)
@@ -15,14 +15,6 @@ final class SQLBuilder { self =>
   def +=(c: Char) = { sb append c; this }
 
   def +?=(f: Setter) = { setters append f; sb append '?'; this }
-
-  def sep[T](sequence: Iterable[T], separator: String)(f: T => Unit): Unit = {
-    var first = true
-    for(x <- sequence) {
-      if(first) first = false else self += separator
-      f(x)
-    }
-  }
 
   def sep[T](sequence: ConstArray[T], separator: String)(f: T => Unit): Unit = {
     var i = 0

--- a/slick/src/main/scala/slick/util/SQLBuilder.scala
+++ b/slick/src/main/scala/slick/util/SQLBuilder.scala
@@ -16,7 +16,7 @@ final class SQLBuilder { self =>
 
   def +?=(f: Setter) = { setters append f; sb append '?'; this }
 
-  def sep[T](sequence: Traversable[T], separator: String)(f: T => Unit): Unit = {
+  def sep[T](sequence: Iterable[T], separator: String)(f: T => Unit): Unit = {
     var first = true
     for(x <- sequence) {
       if(first) first = false else self += separator

--- a/slick/src/main/scala/slick/util/TableDump.scala
+++ b/slick/src/main/scala/slick/util/TableDump.scala
@@ -40,7 +40,7 @@ class TableDump(maxColumnWidth: Int = 20) {
       }
     }
     buf += cBlue + widths.map(l => dashes.substring(0, l+2)).mkString(box(7), box(8), box(9)) + cNormal
-    buf
+    buf.toIndexedSeq
   }
 
   /** Return the first `len` codepoints from a String */


### PR DESCRIPTION
Backports #2023, #2018 and #2012 to branch 3.3.x.

So that we avoid breaking binary compatibility and ensures that other projects using Slick can also cross-build using Scala 2.13.0 doing a patch upgrade.

## Status

WIP since this is still using scala-collections-compat 1.0.0, but stable libraries should instead use 2.0.0. See note here: https://github.com/scala/scala-collection-compat#compatibility-library