### PR TITLE
Fix travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ addons:
   apt:
     packages:
     - graphviz
-    - mysql-server-5.7
-    - mysql-client-core-5.7
-    - mysql-client-5.7
 scala:
   - 2.11.12
   - 2.12.8


### PR DESCRIPTION
The travis build on master seems to be broken.

After this change we no longer to upgrade the mysql packages as these are already provided by travis.

The mysql version is still 5.7. Since we use Xenial on travis
see https://docs.travis-ci.com/user/database-setup/#mysql