### PR TITLE
Support batch updates if its supported by db

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -652,7 +652,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
       ResultSetInvoker[QR](_ => st.getGeneratedKeys)(pr => keyConverter.read(pr.rs).asInstanceOf[QR])
 
     // Returning keys from batch inserts is generally not supported
-    override protected def useBatchUpdates(implicit session: Backend#Session) = session.capabilities.supportsBatchUpdates
+    override protected def useBatchUpdates(implicit session: Backend#Session) = false
 
     protected lazy val (keyColumns, keyConverter, keyReturnOther) = compiled.buildReturnColumns(keys)
 

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -652,7 +652,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
       ResultSetInvoker[QR](_ => st.getGeneratedKeys)(pr => keyConverter.read(pr.rs).asInstanceOf[QR])
 
     // Returning keys from batch inserts is generally not supported
-    override protected def useBatchUpdates(implicit session: Backend#Session) = false
+    override protected def useBatchUpdates(implicit session: Backend#Session) = session.capabilities.supportsBatchUpdates
 
     protected lazy val (keyColumns, keyConverter, keyReturnOther) = compiled.buildReturnColumns(keys)
 

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -412,6 +412,12 @@ trait MySQLProfile extends JdbcProfile { profile =>
       }
     }
   }
+
+  override def createReturningInsertActionComposer[U, QR, RU](compiled: JdbcCompiledInsert, keys: Node, mux: (U, QR) => RU): ReturningInsertActionComposer[U, RU] = {
+    new ReturningInsertActionComposerImpl[U, QR, RU](compiled, keys, mux) {
+      override protected def useBatchUpdates(implicit session: JdbcBackend#SessionDef): Boolean = true
+    }
+  }
 }
 
 object MySQLProfile extends MySQLProfile {


### PR DESCRIPTION
Looks like `useBatchUpdates` on the `ReturningInsertActionComposerImpl` was hardcoded to false which did not allow batch updates to work if the database supported it.

This would fix the issue and let us do batch inserts with returning ids on a database that supports it(MariaDB in our case)