### PR TITLE
allow jdbc types to be overridden by importing an implicit JdbcType[T] in scope

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.nio.Keys.fileTreeView
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, IncompatibleMethTypeProblem, MissingClassProblem, ProblemFilters, ReversedMissingMethodProblem}
+import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, IncompatibleMethTypeProblem, IncompatibleResultTypeProblem, MissingClassProblem, ProblemFilters, ReversedMissingMethodProblem}
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPreviousArtifacts}
 import com.jsuereth.sbtpgp.PgpKeys
 
@@ -72,7 +72,58 @@ object Settings {
           // #2025 default parameters for AsyncExecutor.apply have been removed and replaced by overloads
           ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$5"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$6"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$7")
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$7"),
+          // #2058 allow jdbc types to be overridden by importing an implicit JdbcType[T] in scope
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.charColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.longColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.clobColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.byteColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.blobColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.timeColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.instantColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.intColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.booleanColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.shortColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.localDateColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.doubleColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.timestampColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.offsetTimeColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.floatColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.bigDecimalColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.zonedDateTimeColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.uuidColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.localTimeColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.dateColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.localDateTimeColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.offsetDateTimeColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.byteArrayColumnType"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.stringColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.charColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.byteColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.longColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.intColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.booleanColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.shortColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.doubleColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.floatColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.bigDecimalColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.dateColumnType"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.stringColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcProfile.columnTypes"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcProfile.slick$jdbc$JdbcProfile$_setter_$columnTypes_="),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcProfile.columnTypes"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("slick.jdbc.JdbcProfile#API.apiTypes"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.charColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.longColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.byteColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.intColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.booleanColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.shortColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.doubleColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.bigDecimalColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.floatColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.dateColumnType"),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("slick.jdbc.JdbcTypesComponent#ImplicitColumnTypes.stringColumnType")
         ),
         ivyConfigurations += MacroConfig.hide.extend(Compile),
         Compile / unmanagedClasspath  ++= (MacroConfig / products).value,

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -2,6 +2,8 @@ package slick.ast
 
 import scala.language.{implicitConversions, higherKinds}
 import slick.SlickException
+import slick.jdbc.JdbcType
+
 import scala.collection.compat._
 import scala.collection.mutable.{Builder, ArrayBuilder}
 import scala.reflect.{ClassTag, classTag => mkClassTag}
@@ -265,6 +267,10 @@ trait TypedType[T] extends Type { self =>
 
 trait BaseTypedType[T] extends TypedType[T] with AtomicType
 
+object BaseTypedType {
+  implicit def fromJdbcType[T](implicit jtt: JdbcType[T]): BaseTypedType[T] = jtt
+}
+
 trait OptionTypedType[T] extends TypedType[Option[T]] with OptionType {
   val elementType: TypedType[T]
 }
@@ -274,6 +280,7 @@ trait NumericTypedType
 
 object TypedType {
   @inline implicit def typedTypeToOptionTypedType[T](implicit t: TypedType[T]): OptionTypedType[T] = t.optionType
+  implicit def fromBaseTypedType[T](implicit btt: BaseTypedType[T]): TypedType[T] = btt
 }
 
 class TypeUtil(val tpe: Type) extends AnyVal {
@@ -372,18 +379,18 @@ class ErasedScalaBaseType[T, E](implicit val erasure: ScalaBaseType[E], val ct: 
 }
 
 object ScalaBaseType {
-  implicit val booleanType = new ScalaBaseType[Boolean]
-  implicit val bigDecimalType = new ScalaNumericType[BigDecimal](BigDecimal.apply _)
-  implicit val byteType = new ScalaNumericType[Byte](_.toByte)
-  implicit val charType = new ScalaBaseType[Char]
-  implicit val doubleType = new ScalaNumericType[Double](identity)
-  implicit val floatType = new ScalaNumericType[Float](_.toFloat)
-  implicit val intType = new ScalaNumericType[Int](_.toInt)
-  implicit val longType = new ScalaNumericType[Long](_.toLong)
-  implicit val nullType = new ScalaBaseType[Null]
-  implicit val shortType = new ScalaNumericType[Short](_.toShort)
-  implicit val stringType = new ScalaBaseType[String]
-  implicit val optionDiscType = new ErasedScalaBaseType[OptionDisc, Int]
+  implicit val booleanType: ScalaBaseType[Boolean] = new ScalaBaseType[Boolean]
+  implicit val bigDecimalType: ScalaNumericType[BigDecimal] = new ScalaNumericType[BigDecimal](BigDecimal.apply _)
+  implicit val byteType: ScalaNumericType[Byte] = new ScalaNumericType[Byte](_.toByte)
+  implicit val charType: ScalaBaseType[Char] = new ScalaBaseType[Char]
+  implicit val doubleType: ScalaNumericType[Double] = new ScalaNumericType[Double](identity)
+  implicit val floatType: ScalaNumericType[Float] = new ScalaNumericType[Float](_.toFloat)
+  implicit val intType: ScalaNumericType[Int] = new ScalaNumericType[Int](_.toInt)
+  implicit val longType: ScalaNumericType[Long] = new ScalaNumericType[Long](_.toLong)
+  implicit val nullType: ScalaBaseType[Null] = new ScalaBaseType[Null]
+  implicit val shortType: ScalaNumericType[Short] = new ScalaNumericType[Short](_.toShort)
+  implicit val stringType: ScalaBaseType[String] = new ScalaBaseType[String]
+  implicit val optionDiscType: ErasedScalaBaseType[OptionDisc, Int] = new ErasedScalaBaseType[OptionDisc, Int]
 
   private[this] val all: Map[ClassTag[_], ScalaBaseType[_]] =
     Seq(booleanType, bigDecimalType, byteType, charType, doubleType,

--- a/slick/src/main/scala/slick/jdbc/ApiJdbcTypes.scala
+++ b/slick/src/main/scala/slick/jdbc/ApiJdbcTypes.scala
@@ -1,0 +1,37 @@
+package slick.jdbc
+
+import java.sql.{Blob, Clob, Date, Time, Timestamp}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZonedDateTime}
+import java.util.UUID
+
+import slick.ast.{BaseTypedType, NumericTypedType, ScalaBaseType, ScalaNumericType, TypedType}
+
+import scala.language.higherKinds
+
+trait ApiJdbcTypes {
+  def booleanJdbcType: JdbcType[Boolean]
+  def bigDecimalJdbcType: JdbcType[BigDecimal] with NumericTypedType
+  def byteJdbcType: JdbcType[Byte] with NumericTypedType
+  def charJdbcType: JdbcType[Char]
+  def doubleJdbcType: JdbcType[Double] with NumericTypedType
+  def floatJdbcType: JdbcType[Float] with NumericTypedType
+  def intJdbcType: JdbcType[Int] with NumericTypedType
+  def longJdbcType: JdbcType[Long] with NumericTypedType
+  def shortJdbcType: JdbcType[Short] with NumericTypedType
+  def stringJdbcType: JdbcType[String]
+  def blobJdbcType: JdbcType[Blob]
+  def byteArrayJdbcType: JdbcType[Array[Byte]]
+  def clobJdbcType: JdbcType[Clob]
+  def dateJdbcType: JdbcType[Date]
+  def offsetDateTimeType: JdbcType[OffsetDateTime]
+  def zonedDateType: JdbcType[ZonedDateTime]
+  def localTimeType: JdbcType[LocalTime]
+  def localDateType: JdbcType[LocalDate]
+  def localDateTimeType: JdbcType[LocalDateTime]
+  def offsetTimeType: JdbcType[OffsetTime]
+  def instantType: JdbcType[Instant]
+  def timeJdbcType: JdbcType[Time]
+  def timestampJdbcType: JdbcType[Timestamp]
+  def uuidJdbcType: JdbcType[UUID]
+  def nullJdbcType: JdbcType[Null]
+}

--- a/slick/src/main/scala/slick/jdbc/JdbcProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcProfile.scala
@@ -21,8 +21,8 @@ trait JdbcProfile extends SqlProfile with JdbcActionComponent
   type Backend = JdbcBackend
   val backend: Backend = JdbcBackend
   type ColumnType[T] = JdbcType[T]
-  type BaseColumnType[T] = JdbcType[T] with BaseTypedType[T]
-  val columnTypes = new JdbcTypes
+  type BaseColumnType[T] = JdbcType[T]
+  val columnTypes: ApiJdbcTypes = new JdbcTypes
   lazy val MappedColumnType = MappedJdbcType
 
   override protected def computeCapabilities = super.computeCapabilities ++ JdbcCapabilities.all
@@ -49,6 +49,8 @@ trait JdbcProfile extends SqlProfile with JdbcActionComponent
   trait API extends LowPriorityAPI with super.API with ImplicitColumnTypes {
     type SimpleDBIO[+R] = SimpleJdbcAction[R]
     val SimpleDBIO = SimpleJdbcAction
+
+    implicit def apiTypes: ApiJdbcTypes = columnTypes
 
     implicit def queryDeleteActionExtensionMethods[C[_]](q: Query[_ <: RelationalProfile#Table[_], _, C]): DeleteActionExtensionMethods =
       createDeleteActionExtensionMethods(deleteCompiler.run(q.toNode).tree, ())

--- a/slick/src/main/scala/slick/jdbc/JdbcType.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcType.scala
@@ -1,7 +1,11 @@
 package slick.jdbc
 
 import java.sql.{PreparedStatement, ResultSet}
-import slick.ast.{FieldSymbol, BaseTypedType}
+
+import slick.ast.{BaseTypedType, FieldSymbol, NumericTypedType}
+import java.sql.{Blob, Clob, Date, Time, Timestamp}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZonedDateTime}
+import java.util.UUID
 
 /** A JdbcType object represents a Scala type that can be used as a column type in the database.
   * Implicit JdbcTypes for the standard types are provided by the profile. */
@@ -44,4 +48,36 @@ trait JdbcType[@specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean
   def hasLiteralForm: Boolean
 
   override def toString = scalaType.toString + "'"
+}
+object JdbcType {
+  object Primitives {
+    // Note implicits for String, BigDecimal and all primitives are already imported when profile.api._ is imported
+    // TODO decide on whether to remove this or not...
+    implicit def booleanJdbcType(implicit types: ApiJdbcTypes): JdbcType[Boolean] = types.booleanJdbcType
+    implicit def bigDecimalJdbcType(implicit types: ApiJdbcTypes): JdbcType[BigDecimal] with NumericTypedType = types.bigDecimalJdbcType
+    implicit def byteJdbcType(implicit types: ApiJdbcTypes): JdbcType[Byte] with NumericTypedType = types.byteJdbcType
+    implicit def charJdbcType(implicit types: ApiJdbcTypes): JdbcType[Char] = types.charJdbcType
+    implicit def doubleJdbcType(implicit types: ApiJdbcTypes): JdbcType[Double] with NumericTypedType = types.doubleJdbcType
+    implicit def floatJdbcType(implicit types: ApiJdbcTypes): JdbcType[Float] with NumericTypedType = types.floatJdbcType
+    implicit def intJdbcType(implicit types: ApiJdbcTypes): JdbcType[Int] with NumericTypedType = types.intJdbcType
+    implicit def longJdbcType(implicit types: ApiJdbcTypes): JdbcType[Long] with NumericTypedType = types.longJdbcType
+    implicit def shortJdbcType(implicit types: ApiJdbcTypes): JdbcType[Short] with NumericTypedType = types.shortJdbcType
+    implicit def stringJdbcType(implicit types: ApiJdbcTypes): JdbcType[String] = types.stringJdbcType
+  }
+
+  implicit def blobColumnType(implicit types: ApiJdbcTypes): JdbcType[Blob] = types.blobJdbcType
+  implicit def byteArrayColumnType(implicit types: ApiJdbcTypes): JdbcType[Array[Byte]] = types.byteArrayJdbcType
+  implicit def clobColumnType(implicit types: ApiJdbcTypes): JdbcType[Clob] = types.clobJdbcType
+  implicit def dateColumnType(implicit types: ApiJdbcTypes): JdbcType[Date] = types.dateJdbcType
+  implicit def offsetDateTimeColumnType(implicit types: ApiJdbcTypes): JdbcType[OffsetDateTime] = types.offsetDateTimeType
+  implicit def zonedDateColumnType(implicit types: ApiJdbcTypes): JdbcType[ZonedDateTime] = types.zonedDateType
+  implicit def localTimeColumnType(implicit types: ApiJdbcTypes): JdbcType[LocalTime] = types.localTimeType
+  implicit def localDateColumnType(implicit types: ApiJdbcTypes): JdbcType[LocalDate] = types.localDateType
+  implicit def localDateTimeColumnType(implicit types: ApiJdbcTypes): JdbcType[LocalDateTime] = types.localDateTimeType
+  implicit def offsetTimeColumnType(implicit types: ApiJdbcTypes): JdbcType[OffsetTime] = types.offsetTimeType
+  implicit def instantColumnType(implicit types: ApiJdbcTypes): JdbcType[Instant] = types.instantType
+  implicit def timeColumnType(implicit types: ApiJdbcTypes): JdbcType[Time] = types.timeJdbcType
+  implicit def timestampColumnType(implicit types: ApiJdbcTypes): JdbcType[Timestamp] = types.timestampJdbcType
+  implicit def uuidColumnType(implicit types: ApiJdbcTypes): JdbcType[UUID] = types.uuidJdbcType
+  implicit def nullColumnType(implicit types: ApiJdbcTypes): JdbcType[Null] = types.nullJdbcType
 }

--- a/slick/src/main/scala/slick/jdbc/JdbcType.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcType.scala
@@ -2,7 +2,7 @@ package slick.jdbc
 
 import java.sql.{PreparedStatement, ResultSet}
 
-import slick.ast.{BaseTypedType, FieldSymbol, NumericTypedType}
+import slick.ast.{BaseTypedType, FieldSymbol}
 import java.sql.{Blob, Clob, Date, Time, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZonedDateTime}
 import java.util.UUID
@@ -50,20 +50,7 @@ trait JdbcType[@specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean
   override def toString = scalaType.toString + "'"
 }
 object JdbcType {
-  object Primitives {
-    // Note implicits for String, BigDecimal and all primitives are already imported when profile.api._ is imported
-    // TODO decide on whether to remove this or not...
-    implicit def booleanJdbcType(implicit types: ApiJdbcTypes): JdbcType[Boolean] = types.booleanJdbcType
-    implicit def bigDecimalJdbcType(implicit types: ApiJdbcTypes): JdbcType[BigDecimal] with NumericTypedType = types.bigDecimalJdbcType
-    implicit def byteJdbcType(implicit types: ApiJdbcTypes): JdbcType[Byte] with NumericTypedType = types.byteJdbcType
-    implicit def charJdbcType(implicit types: ApiJdbcTypes): JdbcType[Char] = types.charJdbcType
-    implicit def doubleJdbcType(implicit types: ApiJdbcTypes): JdbcType[Double] with NumericTypedType = types.doubleJdbcType
-    implicit def floatJdbcType(implicit types: ApiJdbcTypes): JdbcType[Float] with NumericTypedType = types.floatJdbcType
-    implicit def intJdbcType(implicit types: ApiJdbcTypes): JdbcType[Int] with NumericTypedType = types.intJdbcType
-    implicit def longJdbcType(implicit types: ApiJdbcTypes): JdbcType[Long] with NumericTypedType = types.longJdbcType
-    implicit def shortJdbcType(implicit types: ApiJdbcTypes): JdbcType[Short] with NumericTypedType = types.shortJdbcType
-    implicit def stringJdbcType(implicit types: ApiJdbcTypes): JdbcType[String] = types.stringJdbcType
-  }
+  // Note implicits for all primitives and String, BigDecimal are already imported when profile.api._ is imported
 
   implicit def blobColumnType(implicit types: ApiJdbcTypes): JdbcType[Blob] = types.blobJdbcType
   implicit def byteArrayColumnType(implicit types: ApiJdbcTypes): JdbcType[Array[Byte]] = types.byteArrayJdbcType

--- a/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala
@@ -95,7 +95,7 @@ trait JdbcTypesComponent extends RelationalTypesComponent { self: JdbcProfile =>
     def setNull(p: PreparedStatement, idx: Int): Unit = p.setNull(idx, sqlType)
   }
 
-  class JdbcTypes {
+  class JdbcTypes extends ApiJdbcTypes {
     val booleanJdbcType = new BooleanJdbcType
     val blobJdbcType = new BlobJdbcType
     val byteJdbcType = new ByteJdbcType
@@ -482,30 +482,17 @@ trait JdbcTypesComponent extends RelationalTypesComponent { self: JdbcProfile =>
   }
 
   trait ImplicitColumnTypes extends super.ImplicitColumnTypes {
-    implicit def booleanColumnType = columnTypes.booleanJdbcType
-    implicit def blobColumnType = columnTypes.blobJdbcType
-    implicit def byteColumnType = columnTypes.byteJdbcType
-    implicit def byteArrayColumnType = columnTypes.byteArrayJdbcType
-    implicit def charColumnType = columnTypes.charJdbcType
-    implicit def clobColumnType = columnTypes.clobJdbcType
-    implicit def dateColumnType = columnTypes.dateJdbcType
-    implicit def doubleColumnType = columnTypes.doubleJdbcType
-    implicit def floatColumnType = columnTypes.floatJdbcType
-    implicit def intColumnType = columnTypes.intJdbcType
-    implicit def longColumnType = columnTypes.longJdbcType
-    implicit def shortColumnType = columnTypes.shortJdbcType
-    implicit def stringColumnType = columnTypes.stringJdbcType
-    implicit def timeColumnType = columnTypes.timeJdbcType
-    implicit def timestampColumnType = columnTypes.timestampJdbcType
-    implicit def uuidColumnType = columnTypes.uuidJdbcType
-    implicit def bigDecimalColumnType = columnTypes.bigDecimalJdbcType
-    implicit def offsetDateTimeColumnType = columnTypes.offsetDateTimeType
-    implicit def zonedDateTimeColumnType = columnTypes.zonedDateType
-    implicit def localTimeColumnType = columnTypes.localTimeType
-    implicit def localDateColumnType = columnTypes.localDateType
-    implicit def localDateTimeColumnType = columnTypes.localDateTimeType
-    implicit def offsetTimeColumnType = columnTypes.offsetTimeType
-    implicit def instantColumnType = columnTypes.instantType
+    implicit def booleanColumnType: JdbcType[Boolean] = columnTypes.booleanJdbcType
+    implicit def byteColumnType: JdbcType[Byte] with NumericTypedType = columnTypes.byteJdbcType
+    implicit def charColumnType: JdbcType[Char] = columnTypes.charJdbcType
+    implicit def dateColumnType: JdbcType[Date] = columnTypes.dateJdbcType
+    implicit def doubleColumnType: JdbcType[Double] with NumericTypedType = columnTypes.doubleJdbcType
+    implicit def floatColumnType: JdbcType[Float] with NumericTypedType = columnTypes.floatJdbcType
+    implicit def intColumnType: JdbcType[Int] with NumericTypedType = columnTypes.intJdbcType
+    implicit def longColumnType: JdbcType[Long] with NumericTypedType = columnTypes.longJdbcType
+    implicit def shortColumnType: JdbcType[Short] with NumericTypedType = columnTypes.shortJdbcType
+    implicit def stringColumnType: JdbcType[String] = columnTypes.stringJdbcType
+    implicit def bigDecimalColumnType: JdbcType[BigDecimal] with NumericTypedType = columnTypes.bigDecimalJdbcType
   }
 }
 

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -3,7 +3,6 @@ package slick.memory
 import scala.language.existentials
 import scala.collection.mutable.Builder
 import scala.reflect.ClassTag
-
 import slick.ast._
 import slick.ast.TypeUtil._
 import slick.basic.{FixedBasicAction, FixedBasicStreamingAction}

--- a/slick/src/main/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryQueryingProfile.scala
@@ -22,16 +22,16 @@ trait MemoryQueryingProfile extends BasicProfile { self: MemoryQueryingProfile =
   val api: API
 
   trait ImplicitColumnTypes {
-    implicit def booleanColumnType = ScalaBaseType.booleanType
-    implicit def bigDecimalColumnType = ScalaBaseType.bigDecimalType
-    implicit def byteColumnType = ScalaBaseType.byteType
-    implicit def charColumnType = ScalaBaseType.charType
-    implicit def doubleColumnType = ScalaBaseType.doubleType
-    implicit def floatColumnType = ScalaBaseType.floatType
-    implicit def intColumnType = ScalaBaseType.intType
-    implicit def longColumnType = ScalaBaseType.longType
-    implicit def shortColumnType = ScalaBaseType.shortType
-    implicit def stringColumnType = ScalaBaseType.stringType
+    implicit def booleanColumnType: ScalaBaseType[Boolean] = ScalaBaseType.booleanType
+    implicit def bigDecimalColumnType: ScalaNumericType[BigDecimal] = ScalaBaseType.bigDecimalType
+    implicit def byteColumnType: ScalaNumericType[Byte] = ScalaBaseType.byteType
+    implicit def charColumnType: ScalaBaseType[Char] = ScalaBaseType.charType
+    implicit def doubleColumnType: ScalaNumericType[Double] = ScalaBaseType.doubleType
+    implicit def floatColumnType: ScalaNumericType[Float] = ScalaBaseType.floatType
+    implicit def intColumnType: ScalaNumericType[Int] = ScalaBaseType.intType
+    implicit def longColumnType: ScalaNumericType[Long] = ScalaBaseType.longType
+    implicit def shortColumnType: ScalaNumericType[Short] = ScalaBaseType.shortType
+    implicit def stringColumnType: ScalaBaseType[String] = ScalaBaseType.stringType
   }
 
   /* internal: */


### PR DESCRIPTION
The general idea is that the default implementations of `JdbcType` are found though the companion object of `JdbcType`.  These are always in the implicit scope therefore no explicit import is required. The only thing that is needed is the delegate `ApiJdbcTypes` which is in scope when `profile.api._` is imported.

The advantage of this method it is now possible to override the default `JdbcType[X]` for any pre-defined type X (actually not all, see below), which is especially useful if you want to store the java.time types in a non-default way.

Unfortunately, the fact that slick also has non-jdbc `RelationalProfiles`, such as `DistributedProfile` and `MemoryProfile` made things a lot more complex. I ran into the problem of that `RelationalTypesComponent` defines a  `type ColumnType[T] <: TypedType[T]` and `type BaseColumnType[T] <: ColumnType[T] with BaseTypedType[T]` however I did not find a way to bring the implicits for `BaseColumnType` into some default scope as these types are abstract.

As a result it is not possible to override any primitive type, or `String` or `BigDecimal`.

This PR resolves a part of the issues described in #1987 as the java.time types are now overridable.