### PR TITLE
Issue #1684: Invalid query generated using OracleDriver for filter with Option column.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     } else "8"
     "com.microsoft.sqlserver" % "mssql-jdbc" % s"7.2.2.jre$jreVersionToUse"
   }
-  
+
   val testDBs = Seq(
     h2,
     sqlServer,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -7,7 +7,7 @@ import com.typesafe.sbt.osgi.SbtOsgi.{OsgiKeys, osgiSettings}
 import com.typesafe.sbt.pgp.PgpKeys
 
 object Settings {
-//  val slickVersion = 
+//  val slickVersion =
 
   val testSamples = TaskKey[Unit]("testSamples", "Run tests in the sample apps")
 

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -145,6 +145,7 @@ oracle {
   ]
   testClasses = ${testkit.testClasses} [
     ${testkit.testPackage}.OracleExtraTests
+    ${testkit.testPackage}.OptionBooleanTest
   ]
 }
 

--- a/slick-testkit/src/main/resources/testkit-reference.conf
+++ b/slick-testkit/src/main/resources/testkit-reference.conf
@@ -49,6 +49,7 @@ testkit {
     ${testPackage}.ForUpdateTest
     ${testPackage}.ForceInsertQueryTest
     ${testPackage}.RewriteBooleanTest
+    ${testPackage}.OptionBooleanTest
   ]
 }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OptionBooleanTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OptionBooleanTest.scala
@@ -1,0 +1,29 @@
+package com.typesafe.slick.testkit.tests
+
+import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
+import slick.jdbc.OracleProfile
+
+class OptionBooleanTest extends AsyncTest[JdbcTestDB] {
+  lazy val oracleProfile = tdb.profile.asInstanceOf[OracleProfile]
+  import oracleProfile.api._
+
+  def testFilterWithOption = {
+    class A(tag: Tag) extends Table[(Int, Option[Boolean], Option[Int])](tag, "a") {
+      def id = column[Int]("id")
+      def b = column[Option[Boolean]]("a")
+      def oi = column[Option[Int]]("oi")
+      def * = (id, b, oi)
+    }
+    val as = TableQuery[A]
+
+    DBIO.seq(
+      as.schema.create,
+      as += (1, Some(true), None),
+      as += (2, Some(false), Some(1)),
+      as += (3, None, Some(2)),
+      as.filter(_.b.getOrElse(false) === false).result.map(_ shouldBe Seq(2, 3)),
+      as.filter(_.oi.map(_ === 2).getOrElse(false)).result.map(_ shouldBe Seq(3)),
+      as.schema.drop
+    )
+  }
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OptionBooleanTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/OptionBooleanTest.scala
@@ -1,16 +1,14 @@
 package com.typesafe.slick.testkit.tests
 
 import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
-import slick.jdbc.OracleProfile
 
 class OptionBooleanTest extends AsyncTest[JdbcTestDB] {
-  lazy val oracleProfile = tdb.profile.asInstanceOf[OracleProfile]
-  import oracleProfile.api._
+  import tdb.profile.api._
 
   def testFilterWithOption = {
     class A(tag: Tag) extends Table[(Int, Option[Boolean], Option[Int])](tag, "a") {
       def id = column[Int]("id")
-      def b = column[Option[Boolean]]("a")
+      def b = column[Option[Boolean]]("b")
       def oi = column[Option[Int]]("oi")
       def * = (id, b, oi)
     }
@@ -21,8 +19,8 @@ class OptionBooleanTest extends AsyncTest[JdbcTestDB] {
       as += (1, Some(true), None),
       as += (2, Some(false), Some(1)),
       as += (3, None, Some(2)),
-      as.filter(_.b.getOrElse(false) === false).result.map(_ shouldBe Seq(2, 3)),
-      as.filter(_.oi.map(_ === 2).getOrElse(false)).result.map(_ shouldBe Seq(3)),
+      as.filter(_.b.getOrElse(false) === false).map(_.id).result.map(_ shouldBe Seq(2, 3)),
+      as.filter(_.oi.map(_ === 2).getOrElse(false)).map(_.id).result.map(_ shouldBe Seq(3)),
       as.schema.drop
     )
   }

--- a/slick/src/main/scala/slick/compiler/RewriteBooleans.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteBooleans.scala
@@ -76,4 +76,8 @@ object RewriteBooleans {
     IfThenElse(ConstArray(n, LiteralNode(1).infer(), LiteralNode(0).infer()))
   def rewriteFakeBooleanWithEquals(n: Node): Node =
     IfThenElse(ConstArray(Library.==.typed[Boolean](n, LiteralNode(1).infer()), LiteralNode(1).infer(), LiteralNode(0).infer()))
+
+  def rewriteFakeBooleanEqOne(n: Node): Node =
+    Library.==.typed[Boolean](rewriteFakeBooleanWithEquals(n), LiteralNode(1).infer())
+
 }

--- a/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
@@ -211,6 +211,10 @@ trait DerbyProfile extends JdbcProfile {
         b"\}"
       case RewriteBooleans.ToFakeBoolean(a @ Apply(Library.SilentCast, _)) =>
         expr(RewriteBooleans.rewriteFakeBooleanWithEquals(a), skipParens)
+      case RewriteBooleans.ToFakeBoolean(a @ Apply(Library.IfNull, _)) =>
+        expr(RewriteBooleans.rewriteFakeBooleanWithEquals(a), skipParens)
+      case c@Comprehension(_, _, _, Some(n @ Apply(Library.IfNull, _)), _, _, _, _, _, _, _) =>
+        super.expr(c.copy(where = Some(RewriteBooleans.rewriteFakeBooleanEqOne(n))), skipParens)
       case _ => super.expr(c, skipParens)
     }
   }

--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -152,6 +152,10 @@ trait OracleProfile extends JdbcProfile {
         b"\(dbms_lob.compare($l, $r) = 0\)"
       case RewriteBooleans.ToFakeBoolean(a @ Apply(Library.SilentCast, _)) =>
         expr(RewriteBooleans.rewriteFakeBooleanWithEquals(a), skipParens)
+      case RewriteBooleans.ToFakeBoolean(a @ Apply(Library.IfNull, _)) =>
+        expr(RewriteBooleans.rewriteFakeBooleanWithEquals(a), skipParens)
+      case c@Comprehension(_, _, _, Some(n @ Apply(Library.IfNull, _)), _, _, _, _, _, _, _) =>
+        super.expr(c.copy(where = Some(RewriteBooleans.rewriteFakeBooleanEqOne(n))), skipParens)
       case _ => super.expr(c, skipParens)
     }
   }

--- a/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLServerProfile.scala
@@ -194,6 +194,10 @@ trait SQLServerProfile extends JdbcProfile {
         b"replicate($str, $count)"
       case RewriteBooleans.ToFakeBoolean(a @ Apply(Library.SilentCast, _)) =>
         expr(RewriteBooleans.rewriteFakeBooleanWithEquals(a), skipParens)
+      case RewriteBooleans.ToFakeBoolean(a @ Apply(Library.IfNull, _)) =>
+        expr(RewriteBooleans.rewriteFakeBooleanWithEquals(a), skipParens)
+      case c@Comprehension(_, _, _, Some(n @ Apply(Library.IfNull, _)), _, _, _, _, _, _, _) =>
+        super.expr(c.copy(where = Some(RewriteBooleans.rewriteFakeBooleanEqOne(n))), skipParens)
       case n => super.expr(n, skipParens)
     }
   }


### PR DESCRIPTION
Adds test and fixes #1684 
Giving value by default and comparing with boolean like [here](https://github.com/alexFrankfurt/slick/commit/80e3224390ec11a1ad4b491d88d8e3ddb5847208#diff-4f6a4460f0646720349ec80039ba7e1eR24) wasn't working either. This PR implements fix for that case as well.