### PR TITLE
Fix link to code generator api documentation

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -10,7 +10,7 @@ Reactive Functional Relational Mapping for Scala
 ## API Documentation (scaladoc)
 
 - [Slick Core](unchecked:/api/index.html) (slick)
-- [Code Generator](unchecked:/api/index.html) (slick-codegen)
+- [Code Generator](unchecked:/codegen-api/index.html) (slick-codegen)
 - [HikariCP integration](unchecked:hikaricp-api/index.html) (slick-hikaricp)
 - [TestKit](unchecked:testkit-api/index.html) (slick-testkit)
 


### PR DESCRIPTION
The link to the api-documentation of the code generator on the documentation index page points to the api documentation of slick (and not to codegen-api).