### PR TITLE
Minimize circular dependencies between auto-generated files to improve compilation speed

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -88,6 +88,9 @@ abstract class AbstractSourceCodeGenerator(model: m.Model)
     }).toMap
   }
 
+  def foreignKeysPerTable: Map[String, List[String]] = tables.map(t =>
+    t.TableValue.name -> t.model.foreignKeys.map(k => tableName(k.referencedTable.table)).toList
+  ).toMap
 
   protected def tuple(i: Int) = termName(s"_${i+1}")
 

--- a/slick-codegen/src/main/scala/slick/codegen/OutputHelpers.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/OutputHelpers.scala
@@ -16,6 +16,11 @@ trait OutputHelpers{
   def codePerTable: Map[String, String]
 
   /**
+    * Foreign keys used for mapping a minimal set of dependencies between tables.
+  */
+  def foreignKeysPerTable: Map[String, List[String]]
+
+  /**
     * The generated code used to generate the container class.
     */
   def codeForContainer: String
@@ -70,6 +75,7 @@ trait OutputHelpers{
    */
   def writeToMultipleFiles(profile: String, folder: String, pkg: String, container: String = "Tables"): Unit = {
     // Write the container file (the file that contains the stand-alone object).
+    writeStringToFile(rootTraitCode(profile, pkg, container), folder, pkg, container + "Root.scala")
     writeStringToFile(packageContainerCode(profile, pkg, container), folder, pkg, container + ".scala")
     // Write one file for each table.
     codePerTable.foreach {
@@ -79,6 +85,17 @@ trait OutputHelpers{
 
   private def handleQuotedNamed(tableName: String) = {
     if (tableName.endsWith("`")) s"${tableName.init}Table`" else s"${tableName}Table"
+  }
+
+  def rootTraitCode(profile: String, pkg: String, container: String = "Tables"): String = {
+  s"""
+package ${pkg}
+// AUTO-GENERATED Slick data model
+
+trait ${container}Root {
+  val profile: slick.jdbc.JdbcProfile
+}
+"""
   }
 
   /**
@@ -114,7 +131,9 @@ trait ${container}${parentType.map(t => s" extends $t").getOrElse("")} {
    * @param container The name of a trait and an object the generated code will be placed in within the specified package.
    */
   def packageContainerCode(profile: String, pkg: String, container: String = "Tables"): String = {
-    val mixinCode = codePerTable.keys.map(tableName => s"${handleQuotedNamed(tableName) }").mkString("extends ", " with ", "")
+    val tableTraits = codePerTable.keys.map(tableName => s"${handleQuotedNamed(tableName) }")
+    val allTraits = s"${container}Root" :: tableTraits.toList
+    val mixinCode = allTraits.mkString("extends ", " with ", "")
     s"""
 package ${pkg}
 // AUTO-GENERATED Slick data model
@@ -144,12 +163,16 @@ trait ${container}${parentType.map(t => s" extends $t").getOrElse("")} ${mixinCo
    * @param container The name of the container
    */
   def packageTableCode(tableName: String, tableCode: String, pkg: String, container: String): String = {
+
+    val foreignKeys = foreignKeysPerTable.getOrElse(tableName, Nil).map(handleQuotedNamed)
+    val selfTraits = s"${container}Root" :: foreignKeys
+
     s"""
 package ${pkg}
 // AUTO-GENERATED Slick data model for table ${tableName}
 trait ${handleQuotedNamed(tableName) } {
 
-  self:${container}  =>
+  self:${selfTraits.mkString(" with ")}  =>
 
   import profile.api._
   ${indent(tableCode)}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestCodeGenerator.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestCodeGenerator.scala
@@ -25,6 +25,7 @@ trait TestCodeGenerator {
       def indent(code: String): String = code
       def code: String = ""
       def codePerTable:Map[String,String] = Map()
+      def foreignKeysPerTable: Map[String, List[String]] = Map()
       def codeForContainer:String = ""
     }.writeStringToFile(
       s"""


### PR DESCRIPTION
Currently, when generating multiple table files, there are cyclic dependencies between `Tables`, which mixes in every table trait, and each table trait, has the self-type `self: Tables =>`.

This PR adds a `TablesRoot` trait, which `Tables` mixes in and is a self-type for each table trait. The table traits also mix in the other table traits they have foreign keys to, meaning that there will be cyclic dependencies iff there are cyclic foreign keys between tables.

This change sped up compilation of our autogenerated schema (~420 tables) codebase about 30%, from ~295s to ~225s