### PR TITLE
reduce sdkman cache, fixes #2087

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ cache:
   directories:
     - "$HOME/.sbt"
     - "$HOME/.ivy2"
-    - "$HOME/.sdkman"
+    - "$HOME/.sdkman/archives"


### PR DESCRIPTION
This looks like it ought to get the build back to building again --- at least due to a problem of caching of sdkman. Let's see...