### PR TITLE
Issue #2076: fix MySql upsert

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/MySQLDMLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/MySQLDMLTest.scala
@@ -20,6 +20,6 @@ class MySQLDMLTest {
     assertTrue("generates query with update action if insert primary key only",
       TableQuery[T].insertOrUpdate(1).statements.mkString.endsWith("on duplicate key update `id`=VALUES(`id`)"))
     assertTrue("generates query with update action if insert with value",
-      TableQuery[T2].insertOrUpdate(V("test", "test-value")).statements.mkString.endsWith("on duplicate key update `value`=VALUES(`value`)"))
+      TableQuery[T2].insertOrUpdate(V("test", "test-value")).statements.mkString.endsWith("on duplicate key update `id`=VALUES(`id`), `value`=VALUES(`value`)"))
   }
 }

--- a/slick-testkit/src/test/scala/slick/test/lifted/MySQLDMLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/MySQLDMLTest.scala
@@ -17,10 +17,8 @@ class MySQLDMLTest {
       def value = column[String]("value")
       def * = (id, value) <> ((V.apply _).tupled, V.unapply)
     }
-    assertTrue("generates insert ignore statements",
-      TableQuery[T].insertOrUpdate(1).statements.mkString.startsWith("insert ignore"))
-    assertTrue("there are no update action if insert primary key only",
-      TableQuery[T].insertOrUpdate(1).statements.mkString.endsWith(")"))
+    assertTrue("generates query with update action if insert primary key only",
+      TableQuery[T].insertOrUpdate(1).statements.mkString.endsWith("on duplicate key update `id`=VALUES(`id`)"))
     assertTrue("generates query with update action if insert with value",
       TableQuery[T2].insertOrUpdate(V("test", "test-value")).statements.mkString.endsWith("on duplicate key update `value`=VALUES(`value`)"))
   }

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -252,6 +252,8 @@ trait MySQLProfile extends JdbcProfile { profile =>
   }
 
   class UpsertBuilder(ins: Insert) extends super.UpsertBuilder(ins) {
+    // Method kept for binary compatibility. Otherwise unused
+    def buildInsertIgnoreStart: String = allNames.iterator.mkString(s"insert ignore into $tableName (", ",", ") ")
     override def buildInsert: InsertBuilderResult = {
       val start = buildInsertStart
       val columnNamesForUpdate = if (softNames.nonEmpty) softNames else pkNames

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -252,14 +252,11 @@ trait MySQLProfile extends JdbcProfile { profile =>
   }
 
   class UpsertBuilder(ins: Insert) extends super.UpsertBuilder(ins) {
-    def buildInsertIgnoreStart: String = allNames.iterator.mkString(s"insert ignore into $tableName (", ",", ") ")
     override def buildInsert: InsertBuilderResult = {
-      val start = buildInsertIgnoreStart
-      if (softNames.isEmpty) new InsertBuilderResult(table, s"$start values $allVars", syms)
-      else {
-        val update = softNames.map(n => s"$n=VALUES($n)").mkString(", ")
-        new InsertBuilderResult(table, s"$start values $allVars on duplicate key update $update", syms)
-      }
+      val start = buildInsertStart
+      val columnNamesForUpdate = if (softNames.nonEmpty) softNames else pkNames
+      val update = columnNamesForUpdate.map(n => s"$n=VALUES($n)").mkString(", ")
+      new InsertBuilderResult(table, s"$start values $allVars on duplicate key update $update", syms)
     }
   }
 

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -256,8 +256,7 @@ trait MySQLProfile extends JdbcProfile { profile =>
     def buildInsertIgnoreStart: String = allNames.iterator.mkString(s"insert ignore into $tableName (", ",", ") ")
     override def buildInsert: InsertBuilderResult = {
       val start = buildInsertStart
-      val columnNamesForUpdate = if (softNames.nonEmpty) softNames else pkNames
-      val update = columnNamesForUpdate.map(n => s"$n=VALUES($n)").mkString(", ")
+      val update = allNames.map(n => s"$n=VALUES($n)").mkString(", ")
       new InsertBuilderResult(table, s"$start values $allVars on duplicate key update $update", syms)
     }
   }


### PR DESCRIPTION
This should fix #2076 and #2045. `insert into table ... on duplicate key update` syntax seems to work fine even when table contains only primary key columns.

I'm not able to sign the Lightbend license agreement for legal reasons, but those interested in fixing this bug may use this PR as an example and create their own fix.

There're 2 ways to implement upsert in MySql:
1. `insert ignore into tableName (col1, col2, ...) values (value1, value2, ...)`
2. `insert into $tableName (col1, col2, ...) values (value1, value2, ...) on duplicate key update col1=values(col1), col2=values(col2), ...`

The problem with the first implementation is that it effectively ignores _all_ exceptions, even those that you may not want to ignore (e.g., attempt to insert null into a non-null column).
The second method doesn't have this problem, but there was another problem with it, which is described in issue #1627. TL;DR it didn't work with tables, which had only primary key columns, which was caused by using `softNames` variable to generate part of the statement which follows `on duplicate key update` (when all columns are primary keys, `softNames` is empty).

This PR implements the second approach to generate upsert statement and lacks the problems described above.