### PR TITLE
Fix overrideStatements for insert actions. Fixes #1850

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -57,8 +57,8 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
     }
     val t = TableQuery[T]
 
-    class U(tag: Tag) extends Table[Int](tag, "u".withUniquePostFix) {
-      def id = column[Int]("a")
+    class U(tag: Tag) extends Table[Int](tag, "u") {
+      def id = column[Int]("id")
       def * = id
     }
     val u = TableQuery[U]
@@ -74,13 +74,13 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
       a1.result.head.map(_ shouldBe 1),
       a1.result.head.overrideStatements(a2.result.head.statements).map(_ shouldBe 2),
       /* Build an action that inserts a single value into table "t".
-         Then, override its statements with an "insert into u" statement. */
-      (t += 4).overrideStatements(Seq(u.insertStatement)),
+         Then, override its insert statement". */
+      (t += 4).overrideStatements(Seq(s"""insert into "u" ("id") values (?)""")),
       /* Check that the statement passed to "overrideStatements" has been executed,
          i.e. that the value has been inserted into table "u". */
       u.result.map(_ shouldBe Seq(4)),
       /* Now do the same for a multi-insert action. */
-      (t ++= Seq(5, 6)).overrideStatements(Seq(u.insertStatement)),
+      (t ++= Seq(5, 6)).overrideStatements(Seq(s"""insert into "u" ("id") values (?)""")),
       /* Check that the values have been appended to the "u" table. */
       u.result.map(_ shouldBe Seq(4, 5, 6))
     )

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -74,7 +74,7 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
       a1.result.head.map(_ shouldBe 1),
       a1.result.head.overrideStatements(a2.result.head.statements).map(_ shouldBe 2),
       /* Build an action that inserts a single value into table "t".
-         Then, override its insert statement". */
+         Then, override its insert statement. */
       (t += 4).overrideStatements(Seq(s"""insert into "u" ("id") values (?)""")),
       /* Check that the statement passed to "overrideStatements" has been executed,
          i.e. that the value has been inserted into table "u". */

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -74,13 +74,13 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
       a1.result.head.map(_ shouldBe 1),
       a1.result.head.overrideStatements(a2.result.head.statements).map(_ shouldBe 2),
       /* Build an action that inserts a single value into table "t".
-         Then, override its insert statement. */
-      (t += 4).overrideStatements(Seq(s"""insert into "u" ("id") values (?)""")),
+         Then, override its statement with: "insert into u (id) values (?)". */
+      (t += 4).overrideStatements(Seq(u.insertStatement)),
       /* Check that the statement passed to "overrideStatements" has been executed,
          i.e. that the value has been inserted into table "u". */
       u.result.map(_ shouldBe Seq(4)),
       /* Now do the same for a multi-insert action. */
-      (t ++= Seq(5, 6)).overrideStatements(Seq(s"""insert into "u" ("id") values (?)""")),
+      (t ++= Seq(5, 6)).overrideStatements(Seq(u.insertStatement)),
       /* Check that the values have been appended to the "u" table. */
       u.result.map(_ shouldBe Seq(4, 5, 6))
     )

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMiscTest.scala
@@ -73,9 +73,15 @@ class JdbcMiscTest extends AsyncTest[JdbcTestDB] {
       a1.result.overrideStatements(a2.result.statements).map(_ shouldBe Seq(2)),
       a1.result.head.map(_ shouldBe 1),
       a1.result.head.overrideStatements(a2.result.head.statements).map(_ shouldBe 2),
+      /* Build an action that inserts a single value into table "t".
+         Then, override its statements with an "insert into u" statement. */
       (t += 4).overrideStatements(Seq(u.insertStatement)),
+      /* Check that the statement passed to "overrideStatements" has been executed,
+         i.e. that the value has been inserted into table "u". */
       u.result.map(_ shouldBe Seq(4)),
+      /* Now do the same for a multi-insert action. */
       (t ++= Seq(5, 6)).overrideStatements(Seq(u.insertStatement)),
+      /* Check that the values have been appended to the "u" table. */
       u.result.map(_ shouldBe Seq(4, 5, 6))
     )
   }

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -514,7 +514,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
       session.withPreparedStatement(sql)(f)
 
     class SingleInsertAction(a: compiled.Artifacts, value: U) extends SimpleJdbcProfileAction[SingleInsertResult]("SingleInsertAction", Vector(a.sql)) {
-      def run(ctx: Backend#Context, sql: Vector[String]) = preparedInsert(a.sql, ctx.session) { st =>
+      def run(ctx: Backend#Context, sql: Vector[String]) = preparedInsert(sql.head, ctx.session) { st =>
         st.clearParameters()
         a.converter.set(value, st)
         val count = st.executeUpdate()
@@ -533,7 +533,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
               retOne(st, v, st.executeUpdate())
             }
           }.toVector)
-        else preparedInsert(a.sql, ctx.session) { st =>
+        else preparedInsert(sql1, ctx.session) { st =>
           st.clearParameters()
           for(value <- values) {
             a.converter.set(value, st)


### PR DESCRIPTION
Fixes `overrideStatements` method for `MultiInsertAction` and `SingleInsertAction`. Fixes https://github.com/slick/slick/issues/1850.