### PR TITLE
Fix CI: sdkman grep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - export TZ=Asia/Kamchatka
   - docker version
 install:
-  - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
+  - sdk install java $(sdk list java | grep -oP "(?<=\s)$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
   - unset JAVA_HOME
   - java -Xmx32m -version
   - javac -J-Xmx32m -version


### PR DESCRIPTION
The old command was matching the tail end of `11.0.8.hs-adpt` so it tried to pull `8.hs-adpt`, this one uses a perl-style look-behind to check for a word boundary, so it shouldn't match partial jdk versions.