### PR TITLE
avoid mutating autoIncrement after rendering first time

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -592,7 +592,10 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
   /** Builder for various DDL statements. */
   class TableDDLBuilder(val table: Table[_]) { self =>
     protected val tableNode = table.toNode.asInstanceOf[TableExpansion].table.asInstanceOf[TableNode]
-    protected val columns: Iterable[ColumnDDLBuilder] = table.create_*.map(fs => createColumnDDLBuilder(fs, table))
+
+    /** new instance on access to avoid sharing mutable state during createPhase1 or createIfNotExistsPhase */
+    protected def columns: Iterable[ColumnDDLBuilder] = table.create_*.map(fs => createColumnDDLBuilder(fs, table))
+
     protected val indexes: Iterable[Index] = table.indexes
     protected val foreignKeys: Iterable[ForeignKey] = table.foreignKeys
     protected val primaryKeys: Iterable[PrimaryKey] = table.primaryKeys


### PR DESCRIPTION
Fixes https://github.com/slick/slick/issues/2052

---

When calling `create` and / or `createIfNotExists` more than once on the same instance a mutable variable is changed with breaks idempotent evaluation of both methods. The problem is caused by the initial render of all phases [here](https://github.com/slick/slick/blob/master/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala#L604). 

Before this PR, both phases(`create` and `createIfNotExists`) would share the same underlying instance of  `val columns` which wraps the mutable state of [autoIncrement](https://github.com/slick/slick/blob/master/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala#L706). The render of `createPhase1` would set [autoIncrement=false](https://github.com/slick/slick/blob/master/slick/src/main/scala/slick/jdbc/PostgresProfile.scala#L246) which would change the way how `createIfNotExistsPhase` to render the auto increment columns [different](https://github.com/slick/slick/blob/master/slick/src/main/scala/slick/jdbc/PostgresProfile.scala#L243-L245). 

This PR is tries to mitigate the issue but the does not attempt to improve the code by refactoring the mutable member(s) of ColumnDDLBuilder (like [autoIncrement](https://github.com/slick/slick/blob/master/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala#L706) which is relevant to this PR)