### PR TITLE
Add more informative message to Invoker.first() errors

### DIFF
--- a/slick/src/main/scala/slick/jdbc/Invoker.scala
+++ b/slick/src/main/scala/slick/jdbc/Invoker.scala
@@ -24,13 +24,15 @@ trait Invoker[+R] { self =>
     res
   }
 
+  protected def debuggingId: Option[String] = None
+
   /** Execute the statement and return the first row of the result set.
     * If the result set is empty, a NoSuchElementException is thrown. */
   final def first(implicit session: JdbcBackend#Session): R = {
     val it = iteratorTo(0)
     try {
       if(it.hasNext) it.next()
-      else throw new NoSuchElementException("Invoker.first")
+      else throw new NoSuchElementException("empty result set" + debuggingId.map(" when invoking " + _))
     } finally it.close
   }
 

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -17,6 +17,7 @@ abstract class StatementInvoker[+R] extends Invoker[R] { self =>
 
   protected def getStatement: String
   protected def setParam(st: PreparedStatement): Unit
+  override protected def debuggingId = Some(s"statement $getStatement")
 
   def iteratorTo(maxRows: Int)(implicit session: JdbcBackend#Session): CloseableIterator[R] =
     results(maxRows).fold(r => new CloseableIterator.Single[R](r.asInstanceOf[R]), identity)


### PR DESCRIPTION
This somewhat reduces the problem of #1277; knowing the statement being
run can help narrow down the location of a failing .result.head call.

Only works for StatementInvoker, but the method attached to Invoker
could be used to annotate error messages for e.g. ResultSetInvoker.