### PR TITLE
Codegen: handle non-empty parentType in OutputHelpers correctly

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/OutputHelpers.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/OutputHelpers.scala
@@ -133,7 +133,7 @@ trait ${container}${parentType.map(t => s" extends $t").getOrElse("")} {
    * @param container The name of a trait and an object the generated code will be placed in within the specified package.
    */
   def packageContainerCode(profile: String, pkg: String, container: String = "Tables"): String = {
-    val tableTraits = codePerTable.keys.map(tableName => s"${handleQuotedNamed(tableName) }")
+    val tableTraits = parentType.toSeq ++ codePerTable.keys.map(tableName => s"${handleQuotedNamed(tableName) }")
     val allTraits = s"${container}Root" :: tableTraits.toList
     val mixinCode = allTraits.mkString("extends ", " with ", "")
     s"""
@@ -147,7 +147,7 @@ object ${container} extends ${container} {
 /** Slick data model trait for extension, choice of backend or usage in the cake pattern. (Make sure to initialize this late.)
     Each generated XXXXTable trait is mixed in this trait hence allowing access to all the TableQuery lazy vals.
   */
-trait ${container}${parentType.map(t => s" extends $t").getOrElse("")} ${mixinCode} {
+trait ${container} ${mixinCode} {
   val profile: slick.jdbc.JdbcProfile
   import profile.api._
   ${indent(codeForContainer)}

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
@@ -22,6 +22,7 @@ object GenerateRoundtripSources {
     import Tables.profile.api._
     val ddl = posts.schema ++ categories.schema ++ typeTest.schema ++ large.schema ++ `null`.schema ++ X.schema ++ SingleNonOptionColumn.schema ++ SelfRef.schema
     val a1 = profile.createModel(ignoreInvalidDefaults=false).map(m => new SourceCodeGenerator(m) {
+      override def parentType = Some("slick.test.codegen.EmptyTestTrait")
       override def Table = new Table(_)
       {
         override def hugeClassEnabled = false // HList type instead of case classes (like with Slick before 3.3)

--- a/slick-testkit/src/test/scala/slick/test/codegen/EmptyTestTrait.scala
+++ b/slick-testkit/src/test/scala/slick/test/codegen/EmptyTestTrait.scala
@@ -1,0 +1,2 @@
+package slick.test.codegen
+trait EmptyTestTrait


### PR DESCRIPTION
When `parentType` is overriden to return a `Some` in `SourceCodeGenerator`,
the `packageContainerCode` method will generate a trait with two `extends`
clauses, which is invalid Scala.

An example would be 
`Tables extends CustomParent extends FooTable with BarTable {`
It should be
`Tables extends CustomParent with FooTable with BarTable {`