### PR TITLE
#2193 [WIP] Sample codes broken links referenced in docs/gettingstarted resolving to 404

### DIFF
--- a/doc/ornate.conf
+++ b/doc/ornate.conf
@@ -91,8 +91,12 @@ extension.externalLinks {
     uri = "https://issues.scala-lang.org/browse/SI-[all]"
     text = "SI-[all]"
   }
-  samplezip.uri = "https://example.lightbend.com/v1/download/[all]-"${shortVersion}
-  samplerepo.uri = "https://github.com/slick/slick/tree/"${shortVersion}"/samples/[all]"
+  sampleCodeZip{
+    uri = "https://example.lightbend.com/v1/download/[all]-"${tag}
+  }
+  sampleCodeRepo{
+    uri = "https://github.com/slick/slick/tree/"${tag}"/samples/[all]"
+  }
 }
 
 extension.highlightjs {

--- a/doc/src/gettingstarted.md
+++ b/doc/src/gettingstarted.md
@@ -4,17 +4,17 @@ The easiest way to get started is with a working sample application. The followi
 Slick distribution. You can either clone Slick from github or download pre-packaged zip files with an individual
 sample plus an [sbt] launcher.
 
-* To learn the basics of Slick, start with the **Hello Slick** sample ([github](https://github.com/slick/slick/blob/v3.3.2/samples/hello-slick),
-  [zip](samplezip:hello-slick)). This is the one we are using in this chapter.
+* To learn the basics of Slick, start with the **Hello Slick** sample ([github](sampleCodeRepo:hello-slick),
+  [zip](sampleCodeZip:hello-slick)). This is the one we are using in this chapter.
 
-* The **Plain SQL Queries** sample ([github](https://github.com/slick/slick/blob/v3.3.2/samples/slick-plainsql), [zip](samplezip:slick-plainsql)) shows you how
+* The **Plain SQL Queries** sample ([github](sampleCodeRepo:slick-plainsql), [zip](sampleCodeZip:slick-plainsql)) shows you how
   to do SQL queries with Slick. See [](sql.md) for details.
 
-* The **Multi-DB Patterns** sample ([github](https://github.com/slick/slick/blob/v3.3.2/samples/slick-multidb), [zip](samplezip:slick-multidb)) shows you how
+* The **Multi-DB Patterns** sample ([github](sampleCodeRepo:slick-multidb), [zip](sampleCodeZip:slick-multidb)) shows you how
   to write Slick applications that can use different database systems and how to use custom database functions in
   Slick queries.
 
-* The **TestKit** sample ([github](https://github.com/slick/slick/blob/v3.3.2/samples/slick-testkit-example), [zip](samplezip:slick-testkit-example)) shows you
+* The **TestKit** sample ([github](sampleCodeRepo:slick-testkit-example), [zip](sampleCodeZip:slick-testkit-example)) shows you
   how to use Slick TestKit to test your own database profiles.
 
 ## Hello Slick


### PR DESCRIPTION
Issue reference: https://github.com/slick/slick/issues/2193

- Fix the issue with ``externalLinks`` configuration in ``ornate.conf``
- Use the git release tags for the repo and zip file links
- lightbend specific zip file URL not reachable (fix)