### PR TITLE
Travis-CI: simplify config, drop broken JDK 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+version: ~> 1.0 # needed for imports
+import: scala/scala-dev:travis/default.yml
+
 language: scala
 scala:
   - 2.12.13
@@ -6,7 +9,6 @@ env:
   matrix:
     - ADOPTOPENJDK=8
     - ADOPTOPENJDK=11
-    - ADOPTOPENJDK=15
 services:
   - mysql
   - postgresql
@@ -16,39 +18,16 @@ addons:
   apt:
     packages:
     - graphviz
+
 before_install:
-  # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
-  - "[[ -d $HOME/.sdkman/bin/ ]] || rm -rf $HOME/.sdkman/"
-  - curl -sL https://get.sdkman.io | bash
-  - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
   # TZ needed for Oracle driver!
   - export TZ=Asia/Kamchatka
   - docker version
+
 install:
-  - sdk install java $(sdk list java | grep -oP "(?<=\s)$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
-  - unset JAVA_HOME
-  - java -Xmx32m -version
-  - javac -J-Xmx32m -version
   - sh -v travis/runcontainer.sh oracle db2
   - docker ps
   - sh -v ./travis/extractNonPublicDeps
-  # as per sbt release notes (https://github.com/sbt/sbt/releases/tag/v1.4.9)
-  - |
-    # update this only when sbt-the-bash-script needs to be updated
-    export SBT_LAUNCHER=1.4.9
-    export SBT_OPTS="-Dfile.encoding=UTF-8"
-    curl -L --silent "https://github.com/sbt/sbt/releases/download/v$SBT_LAUNCHER/sbt-$SBT_LAUNCHER.tgz" > $HOME/sbt.tgz
-    tar zxf $HOME/sbt.tgz -C $HOME
-    sudo rm /usr/local/bin/sbt
-    sudo ln -s $HOME/sbt/bin/sbt /usr/local/bin/sbt
+
 script:
   - admin/build.sh
-before_cache:
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
-cache:
-  directories:
-    - "$HOME/.sbt"
-    - "$HOME/.ivy2"
-    - "$HOME/.sdkman/archives"


### PR DESCRIPTION
by borrowing from scala-dev

we use this in many scala/* repos and are happy with it