### PR TITLE
Cleaned unused public method in UpsertBuilder

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -68,7 +68,9 @@ object Settings {
           // #2025 default parameters for AsyncExecutor.apply have been removed and replaced by overloads
           ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$5"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$6"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$7")
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.util.AsyncExecutor.apply$default$7"),
+          // #2221 Removing unused method for 3.3.x -> 3.4.x or 4.0.0 release
+          ProblemFilters.exclude[DirectMissingMethodProblem]("slick.jdbc.MySQLProfile#UpsertBuilder.buildInsertIgnoreStart")
         ),
         ivyConfigurations += MacroConfig.hide.extend(Compile),
         Compile / unmanagedClasspath  ++= (MacroConfig / products).value,

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -1,7 +1,8 @@
 package com.typesafe.slick.testkit.tests
 
 import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
-import slick.jdbc.DerbyProfile
+import slick.jdbc.{DerbyProfile, PostgresProfile}
+
 import scala.collection.compat._
 
 class InsertTest extends AsyncTest[JdbcTestDB] {
@@ -232,8 +233,8 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
   }
 
   // Regression test for https://github.com/slick/slick/issues/1627
-  def testInsertOrUpdateWithPrimaryKeyOnly: DBIOAction[Unit, NoStream, Effect.All] = tdb.confName match {
-    case "postgres" | "derbymem" | "derbydisk" =>
+  def testInsertOrUpdateWithPrimaryKeyOnly: DBIOAction[Unit, NoStream, Effect.All] = tdb.profile match {
+    case _: PostgresProfile | _: DerbyProfile =>
       // TODO DerbyProfile and PostgresProfile seems to have a problem in this case, so we skip testing them.
       // See https://github.com/slick/slick/issues/2206 and https://github.com/slick/slick/issues/2207
       DBIO.seq()

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -264,8 +264,6 @@ trait MySQLProfile extends JdbcProfile { profile =>
   }
 
   class UpsertBuilder(ins: Insert) extends super.UpsertBuilder(ins) {
-    @deprecated("No longer used", "3.4.0")
-    def buildInsertIgnoreStart: String = allNames.iterator.mkString(s"insert ignore into $tableName (", ",", ") ")
     override def buildInsert: InsertBuilderResult = {
       val start = buildInsertStart
       val update = allNames.map(n => s"$n=VALUES($n)").mkString(", ")


### PR DESCRIPTION
As far as #2198 is concerned, binary compatibility is not expected in the next release, so we cleaned up Upsert in MySQLProfile.