### PR TITLE
correct the parsing logic between positive infinite and Instant.MAX (issue #2237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Slick
+Slick 
 =====
 
 [![Build Status](https://travis-ci.org/slick/slick.png?branch=master)](https://travis-ci.org/slick/slick) [![Maven](https://img.shields.io/maven-central/v/com.typesafe.slick/slick_2.12.svg)](http://mvnrepository.com/artifact/com.typesafe.slick/slick_2.12) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/slick/slick?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Slick 
+Slick
 =====
 
 [![Build Status](https://travis-ci.org/slick/slick.png?branch=master)](https://travis-ci.org/slick/slick) [![Maven](https://img.shields.io/maven-central/v/com.typesafe.slick/slick_2.12.svg)](http://mvnrepository.com/artifact/com.typesafe.slick/slick_2.12) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/slick/slick?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -312,7 +312,9 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
       List(LocalDateTime.parse("2018-03-25T01:37:40", formatter).toInstant(ZoneOffset.UTC),
         Instant.parse("2015-06-05T09:43:00Z"), // time has zero seconds and milliseconds
         generateTestLocalDateTime().withHour(15).toInstant(ZoneOffset.UTC),
-        generateTestLocalDateTime().withHour(5).toInstant(ZoneOffset.UTC)),
+        generateTestLocalDateTime().withHour(5).toInstant(ZoneOffset.UTC),
+        Instant.MIN,
+        Instant.MAX),
       () => randomLocalDateTime().toInstant(ZoneOffset.UTC)
     )
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -333,6 +333,15 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
     )(withTimeZone)
   } else Future.successful(())
 
+  def testPostgresInstantWithInfiniteValues: Future[Unit] = if (tdb.confName == "postgres") {
+    roundTrip[Instant](
+      List(
+        Instant.MIN,
+        Instant.MAX),
+      () => randomLocalDateTime().toInstant(ZoneOffset.UTC),
+    )
+  } else Future.successful(())
+
   private def randomZoneOffset = {
     // offset could be +-18 in java.time context, but postgres and oracle are stricter
     val hours = random.nextInt(25)-12

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -339,6 +339,7 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
         Instant.MIN,
         Instant.MAX),
       () => randomLocalDateTime().toInstant(ZoneOffset.UTC),
+      tableNameSuffix = "_with_infinite_values"
     )
   } else Future.successful(())
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -312,9 +312,7 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
       List(LocalDateTime.parse("2018-03-25T01:37:40", formatter).toInstant(ZoneOffset.UTC),
         Instant.parse("2015-06-05T09:43:00Z"), // time has zero seconds and milliseconds
         generateTestLocalDateTime().withHour(15).toInstant(ZoneOffset.UTC),
-        generateTestLocalDateTime().withHour(5).toInstant(ZoneOffset.UTC),
-        Instant.MIN,
-        Instant.MAX),
+        generateTestLocalDateTime().withHour(5).toInstant(ZoneOffset.UTC)),
       () => randomLocalDateTime().toInstant(ZoneOffset.UTC)
     )
 

--- a/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
@@ -300,8 +300,8 @@ trait PostgresProfile extends JdbcProfile {
       protected def parseTime(time : String): T = {
         time match {
           case null => null.asInstanceOf[T]
-          case `negativeInfinite` => max
-          case `positiveInfinite` => min
+          case `negativeInfinite` => min
+          case `positiveInfinite` => max
           case _ => parseFiniteTime(time)
         }
       }


### PR DESCRIPTION
Fix for this issue: https://github.com/slick/slick/issues/2237