### PR TITLE
add parentheses for lambda param

### DIFF
--- a/samples/hello-slick/src/main/scala/QueryActions.scala
+++ b/samples/hello-slick/src/main/scala/QueryActions.scala
@@ -21,7 +21,7 @@ object QueryActions extends App {
     //#upTo
     // Define a pre-compiled parameterized query for reading all key/value
     // pairs up to a given key.
-    val upTo = Compiled { k: Rep[Int] =>
+    val upTo = Compiled { (k: Rep[Int]) =>
       dict.filter(_.key <= k).sortBy(_.key)
     }
     //#upTo

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateRoundtripSources.scala
@@ -235,7 +235,7 @@ class Tables(val profile: JdbcProfile){
       ).shaped <> ({ case (id, p1, p2, p3, p4, p5, p6) =>
       // We could do this without .shaped but then we'd have to write a type annotation for the parameters
       Whole(id, Part.tupled.apply(p1), Part.tupled.apply(p2), Part.tupled.apply(p3), Part.tupled.apply(p4), Part.tupled.apply(p5), Part.tupled.apply(p6))
-    }, { w: Whole =>
+    }, { (w: Whole) =>
       def f(p: Part) = Part.unapply(p).get
       Some((w.id, f(w.p1), f(w.p2), f(w.p3), f(w.p4), f(w.p5), f(w.p6)))
     })

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -46,15 +46,15 @@ class AggregateTest extends AsyncTest[RelationalTestDB] {
     }.flatMap { _ =>
       val q0 = ts.groupBy(_.a)
       val q1 = q0.map(_._2.length).sortBy(identity)
-      db.run(mark("q1", q1.result)).map { r0t: Seq[Int] => r0t shouldBe Vector(2, 3, 3) }
+      db.run(mark("q1", q1.result)).map { (r0t: Seq[Int]) => r0t shouldBe Vector(2, 3, 3) }
     }.flatMap { _ =>
       val q0 = ts.groupBy(_.a).map(_._1).length
-      db.run(mark("q0", q0.result)).map { r0t: Int => r0t shouldBe 3 }
+      db.run(mark("q0", q0.result)).map { (r0t: Int) => r0t shouldBe 3 }
     }.flatMap { _ =>
       val q = (for {
         (k, v) <- ts.groupBy(t => t.a)
       } yield (k, v.length, v.map(_.a).sum, v.map(_.b).sum)).sortBy(_._1)
-      db.run(mark("q", q.result)).map { rt: Seq[(Int, Int, Option[Int], Option[Int])] =>
+      db.run(mark("q", q.result)).map { (rt: Seq[(Int, Int, Option[Int], Option[Int])]) =>
         rt shouldBe Vector((1, 3, Some(3), Some(6)), (2, 3, Some(6), Some(8)), (3, 2, Some(6), Some(10)))
       }
     }.flatMap { _ =>
@@ -66,21 +66,21 @@ class AggregateTest extends AsyncTest[RelationalTestDB] {
       } yield (u, t)).groupBy(_._1.id).map {
         case (id, q) => (id, q.length, q.map(_._2.a).sum, q.map(_._2.b).sum)
       }
-      db.run(mark("q2", q2.result)).map { r2t: Seq[(Int, Int, Option[Int], Option[Int])] =>
+      db.run(mark("q2", q2.result)).map { (r2t: Seq[(Int, Int, Option[Int], Option[Int])]) =>
         r2t.toSet shouldBe Set((1, 3, Some(3), Some(6)), (2, 3, Some(6), Some(8)), (3, 2, Some(6), Some(10)))
       }
     }.flatMap { _ =>
       val q3 = (for {
         (x, q) <- ts.map(t => (t.a + 10, t.b)).groupBy(_._1)
       } yield (x, q.map(_._2).sum)).sortBy(_._1)
-      db.run(mark("q3", q3.result)).map { r3t: Seq[(Int, Option[Int])] =>
+      db.run(mark("q3", q3.result)).map { (r3t: Seq[(Int, Option[Int])]) =>
         r3t shouldBe Vector((11, Some(6)), (12, Some(8)), (13, Some(10)))
       }
     }.flatMap { _ =>
       val q4 = (for {
         (x, q) <- ts.groupBy(t => (t.a, t.b))
       } yield (x, q.length)).sortBy(_._1)
-      db.run(mark("q4", q4.result)).map { r4t: Seq[((Int, Option[Int]), Int)] =>
+      db.run(mark("q4", q4.result)).map { (r4t: Seq[((Int, Option[Int]), Int)]) =>
         r4t shouldBe Vector(
           ((1,Some(1)),1), ((1,Some(2)),1), ((1,Some(3)),1),
           ((2,Some(1)),1), ((2,Some(2)),1), ((2,Some(5)),1),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -96,17 +96,17 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
 
     (for {
       _ <- as.schema.create
-      _ <- (ins1 += ("a", "b")) map { id1: Int => id1 shouldBe 1 }
+      _ <- (ins1 += ("a", "b")) map { (id1: Int) => id1 shouldBe 1 }
       _ <- ifCap(jcap.returnInsertOther) {
-        (ins2 += ("c", "d")) map { id2: (Int, String) => id2 shouldBe (2, "c") }
+        (ins2 += ("c", "d")) map { (id2: (Int, String)) => id2 shouldBe (2, "c") }
       }
       _ <- ifNotCap(jcap.returnInsertOther) {
-        (ins1 += ("c", "d")) map { id2: Int => id2 shouldBe 2 }
+        (ins1 += ("c", "d")) map { (id2: Int) => id2 shouldBe 2 }
       }
       _ <- (ins1 ++= Seq(("e", "f"), ("g", "h"))) map (_ shouldBe Seq(3, 4))
       _ <- (ins3 += ("i", "j")) map (_ shouldBe (5, "i", "j"))
       _ <- ifCap(jcap.returnInsertOther) {
-        (ins4 += ("k", "l")) map { id5: (Int, String, String) => id5 shouldBe (6, "k", "l") }
+        (ins4 += ("k", "l")) map { (id5: (Int, String, String)) => id5 shouldBe (6, "k", "l") }
       }
     } yield ()).withPinnedSession // Some database servers (e.g. DB2) preallocate ID blocks per session
   }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -20,7 +20,7 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
       def * = id.? ~: baseProjection <> (User.tupled, User.unapply _)
       def baseProjection = first ~ last
       def forUpdate = baseProjection.shaped <>
-        ({ case (f, l) => User(None, f, l) }, { u:User => Some((u.first, u.last)) })
+        ({ case (f, l) => User(None, f, l) }, { (u:User) => Some((u.first, u.last)) })
       def asFoo = forUpdate <> ((u: User) => Foo(u), (f: Foo[User]) => Some(f.value))
     }
     object users extends TableQuery(new Users(_)) {
@@ -130,7 +130,7 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
         ).shaped <> ({ case (id, p1, p2, p3, p4) =>
         // We could do this without .shaped but then we'd have to write a type annotation for the parameters
         Whole(id, Part.tupled.apply(p1), Part.tupled.apply(p2), Part.tupled.apply(p3), Part.tupled.apply(p4))
-      }, { w: Whole =>
+      }, { (w: Whole) =>
         def f(p: Part) = Part.unapply(p).get
         Some((w.id, f(w.p1), f(w.p2), f(w.p3), f(w.p4)))
       })

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
@@ -149,8 +149,8 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     // Use Option.map
     val q1d = q1.map(_.map(_.a))
     val q1d2 = q1.map(_.map(x => (x.a, x.b, x.c)))
-    val q2d = q2.map { io: Rep[Option[Int]] =>
-      io.map { i: Rep[Int] =>
+    val q2d = q2.map { (io: Rep[Option[Int]]) =>
+      io.map { (i: Rep[Int]) =>
         i + 1
       }
     }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
@@ -73,13 +73,13 @@ class TemplateTest extends AsyncTest[RelationalTestDB] {
     val byIdAndS = { (id: Rep[Int], s: ConstColumn[String]) => ts.filter(t => t.id === id && t.s === s) }
     val byIdAndSC = Compiled(byIdAndS)
     val byIdAndFixedSC = byIdAndSC.map(f => f((_: Rep[Int]), "b"))
-    val byIdC = Compiled { id: Rep[Int] => ts.filter(_.id === id) }
+    val byIdC = Compiled { (id: Rep[Int]) => ts.filter(_.id === id) }
     val byId = byIdC.extract
     val byIdC3 = byIdC(3)
     val byId3 = byIdC3.extract
     val countBelow = { (id: Rep[Int]) => ts.filter(_.id < id).length }
     val countBelowC = Compiled(countBelow)
-    val joinC = Compiled { id: Rep[Int] => ts.filter(_.id === id).join(ts.filter(_.id === id)) }
+    val joinC = Compiled { (id: Rep[Int]) => ts.filter(_.id === id).join(ts.filter(_.id === id)) }
 
     implicitly[slick.lifted.Executable[(Rep[Int], Rep[Int]), _]]
     implicitly[slick.lifted.Compilable[(Rep[Int], Rep[Int]), _]]

--- a/slick/src/main/scala/slick/lifted/SimpleFunction.scala
+++ b/slick/src/main/scala/slick/lifted/SimpleFunction.scala
@@ -25,13 +25,13 @@ object SimpleFunction {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]): Self = build(ch.toSeq)
     }
-    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
+    { (paramsC: Seq[Rep[_] ]) => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
   def nullary[R : TypedType](fname: String, fn: Boolean = false): Rep[R] =
     apply(fname, fn).apply(Seq())
   def unary[T1, R : TypedType](fname: String, fn: Boolean = false): (Rep[T1] => Rep[R]) = {
     val f = apply(fname, fn);
-    { t1: Rep[T1] => f(Seq(t1)) }
+    { (t1: Rep[T1]) => f(Seq(t1)) }
   }
   def binary[T1, T2, R : TypedType](fname: String, fn: Boolean = false): ((Rep[T1], Rep[T2]) => Rep[R]) = {
     val f = apply(fname, fn);
@@ -82,7 +82,7 @@ object SimpleExpression {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]) = build(ch.toSeq)
     }
-    { paramsC: Seq[Rep[_] ] => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
+    { (paramsC: Seq[Rep[_] ]) => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
 
   def nullary[R : TypedType](f: JdbcStatementBuilderComponent#QueryBuilder => Unit): Rep[R] = {
@@ -92,7 +92,7 @@ object SimpleExpression {
   
   def unary[T1, R : TypedType](f: (Node, JdbcStatementBuilderComponent#QueryBuilder) => Unit): (Rep[T1] => Rep[R]) = {
     val g = apply({ (ch: Seq[Node], qb: JdbcStatementBuilderComponent#QueryBuilder) => f(ch(0), qb) });
-    { t1: Rep[T1] => g(Seq(t1)) }
+    { (t1: Rep[T1]) => g(Seq(t1)) }
   }
 
   def binary[T1, T2, R : TypedType](f: (Node, Node, JdbcStatementBuilderComponent#QueryBuilder) => Unit): ((Rep[T1], Rep[T2]) => Rep[R]) = {


### PR DESCRIPTION
prepare Scala 3

```
scala> Option(1).map{ a => a }
val res0: Option[Int] = Some(1)

scala> Option(1).map{ a: Int => a }
1 |Option(1).map{ a: Int => a }
  |                      ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```