### PR TITLE
remove redundant `final` modifiers

### DIFF
--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -345,13 +345,13 @@ final case class Ordering(direction: Ordering.Direction = Ordering.Asc, nulls: O
 
 object Ordering {
   sealed abstract class NullOrdering(val first: Boolean, val last: Boolean)
-  final case object NullsDefault extends NullOrdering(false, false)
-  final case object NullsFirst extends NullOrdering(true, false)
-  final case object NullsLast extends NullOrdering(false, true)
+  case object NullsDefault extends NullOrdering(false, false)
+  case object NullsFirst extends NullOrdering(true, false)
+  case object NullsLast extends NullOrdering(false, true)
 
   sealed abstract class Direction(val desc: Boolean) { def reverse: Direction }
-  final case object Asc extends Direction(false) { def reverse = Desc }
-  final case object Desc extends Direction(true) { def reverse = Asc }
+  case object Asc extends Direction(false) { def reverse = Desc }
+  case object Desc extends Direction(true) { def reverse = Asc }
 }
 
 /** A .groupBy call. */

--- a/slick/src/main/scala/slick/collection/heterogeneous/HList.scala
+++ b/slick/src/main/scala/slick/collection/heterogeneous/HList.scala
@@ -124,7 +124,7 @@ sealed abstract class HList extends Product {
   final def canEqual(that: Any) = that.isInstanceOf[HList]
 }
 
-final object HList {
+object HList {
   import syntax._
 
   final class HListShape[Level <: ShapeLevel, M <: HList, U <: HList : ClassTag, P <: HList](val shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) extends MappedScalaProductShape[Level, HList, M, U, P] {
@@ -136,7 +136,7 @@ final object HList {
     new HListShape[Level, M1 :: M2, U1 :: U2, P1 :: P2](s1 +: s2.shapes)
 }
 // Separate object for macro impl to avoid dependency of companion class on scala.reflect, see https://github.com/xeno-by/sbt-example-paradise210/issues/1#issuecomment-21021396
-final object HListMacros{
+object HListMacros{
   def applyImpl(ctx: Context { type PrefixType = HList })(n: ctx.Expr[Int]): ctx.Expr[Any] = {
     import ctx.universe._
     val _Succ = typeOf[Succ[_]].typeSymbol
@@ -179,7 +179,7 @@ object HCons {
 }
 
 /** The empty `HList` */
-final object HNil extends HList {
+object HNil extends HList {
   type Self = HNil.type
   type Head = Nothing
   type Tail = Nothing

--- a/slick/src/main/scala/slick/collection/heterogeneous/Nat.scala
+++ b/slick/src/main/scala/slick/collection/heterogeneous/Nat.scala
@@ -161,7 +161,7 @@ object Nat {
 }
 
 /** The zero value and type for `Nat` */
-final object Zero extends Nat {
+object Zero extends Nat {
   type Self = Zero.type
   type Fold[U, F[_ <: U] <: U, Z <: U] = Z
   type + [X <: Nat] = X

--- a/slick/src/main/scala/slick/jdbc/meta/MBestRowIdentifierColumn.scala
+++ b/slick/src/main/scala/slick/jdbc/meta/MBestRowIdentifierColumn.scala
@@ -25,9 +25,9 @@ object MBestRowIdentifierColumn {
   sealed abstract class Scope(val value: Int)
 
   object Scope {
-    final case object Temporary extends Scope(DatabaseMetaData.bestRowTemporary)
-    final case object Transaction extends Scope(DatabaseMetaData.bestRowTransaction)
-    final case object Session extends Scope(DatabaseMetaData.bestRowSession)
+    case object Temporary extends Scope(DatabaseMetaData.bestRowTemporary)
+    case object Transaction extends Scope(DatabaseMetaData.bestRowTransaction)
+    case object Session extends Scope(DatabaseMetaData.bestRowSession)
     private[MBestRowIdentifierColumn] def apply(value: Short) = value match {
       case DatabaseMetaData.bestRowTemporary => Temporary
       case DatabaseMetaData.bestRowTransaction => Transaction


### PR DESCRIPTION
prepare Scala 3

```
scala> final object A
1 |final object A
  |^^^^^
  |final modifier is redundant for objects
// defined object A

scala> final case object B
1 |final case object B
  |^^^^^
  |final modifier is redundant for objects
// defined case object B
```