### PR TITLE
Fix typos in comment and deprecation message in Slick BasicProfile

### DIFF
--- a/slick/src/main/scala/slick/basic/BasicProfile.scala
+++ b/slick/src/main/scala/slick/basic/BasicProfile.scala
@@ -46,7 +46,7 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
     type SlickException = slick.SlickException
 
     implicit val slickProfile: self.type = self
-    @deprecated("User `slickProfile` instead of `slickDriver`", "3.2")
+    @deprecated("Use `slickProfile` instead of `slickDriver`", "3.2")
     val slickDriver: self.type = slickProfile
 
     implicit final def anyToShapedValue[T, U](value: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, U, _]): ShapedValue[T, U] =
@@ -87,7 +87,7 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
     * which should be computed lazily. */
   type CompiledInsert
 
-  /** (Partially) ompile an AST for insert operations */
+  /** (Partially) compile an AST for insert operations */
   def compileInsert(n: Node): CompiledInsert
 
   /* internal: */


### PR DESCRIPTION
Fixing a couple of typos in Slick BasicProfile