### PR TITLE
Issue #2121: modify AbstractSourceCodeGenerator.TableClassDef to output infix operators with dot syntax

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -175,7 +175,7 @@ implicit def ${name}(implicit $dependencies): GR[${TableClass.elementType}] = GR
     trait TableClassDef extends super.TableClassDef{
       def star = {
         val struct = compoundValue(columns.map(c=>if(c.asOption)s"Rep.Some(${c.name})" else s"${c.name}"))
-        val rhs = if (isMappedToHugeClass) s"($struct).mapTo[${typeName(entityName(model.name.table))}]" else if(mappingEnabled) s"$struct <> ($factory, $extractor)" else struct
+        val rhs = if (isMappedToHugeClass) s"($struct).mapTo[${typeName(entityName(model.name.table))}]" else if(mappingEnabled) s"$struct.<>($factory, $extractor)" else struct
         s"def * = $rhs"
       }
       def option = {


### PR DESCRIPTION
Scala 2.13.3+ throws a warning (`-Xlint:multiarg infix`): 
```
multiarg infix syntax looks like a tuple and will be deprecated
```
on Slick-generated data models that use the `AbstractTable.*` projection. e.g.

```scala
(customer, client) <> (Table.tupled, Table.unapply)
```

There was an earlier issue (#2121) that mentioned this, but nothing seemed to come of it. This PR just modifies the code generator to use method dot syntax, such that the generator will output 

```scala
(customer, client).<>(Table.tupled, Table.unapply) 
```
instead.

All tests pass on my machine, and scalac doesn't nag me anymore :)