### PR TITLE
GitHub Actions config: don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         java: [1.8.0, 1.11.0, 1.16.0]
         scala: [2.12.14, 2.13.6]


### PR DESCRIPTION
in this context, "fail fast" means that as soon as one of the CI jobs fails, the others are canceled.  I think it's better to get the full results