### PR TITLE
Add inSet support for Tuple2

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -41,6 +41,8 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
       u2 <- users
     } yield u2
 
+    implicit def tuple2BaseTypedType[A: scala.math.Ordering, B: scala.math.Ordering] = new slick.ast.ScalaBaseType[(A, B)]
+
     seq(
       users.schema.create,
       users.map(_.baseProjection) += ("Homer", "Simpson"),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -50,6 +50,11 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
       ),
       users.map(_.asFoo) += Foo(User(None, "Lenny", "Leonard")),
       users.filter(_.last inSet Set("Bouvier", "Ferdinand")).size.result.map(_ shouldBe 1),
+      users.filter(user => (user.first, user.last) inSet Set("Marge" -> "Bouvier")).size.result.map(_ shouldBe 1),
+      users.filter(user => (user.first, user.last) inSet Set("Marg" -> "Bouvier")).size.result.map(_ shouldBe 0),
+      users.filter(user => (user.first, user.last) inSet Set("Marg" -> "Bouvier", "Carl" -> "Carlson")).size.result.map(_ shouldBe 1),
+      users.filter(user => (user.first, user.last) inSet Set("Marge" -> "Bouvier", "Carl" -> "Carlson")).size.result.map(_ shouldBe 2),
+      users.filter(user => (user.first, user.last) inSet Set("Marge" -> "Bouvier", "Marge" -> "Bouvier")).size.result.map(_ shouldBe 1),
       updateQ.update(User(None, "Marge", "Simpson")),
       Query(users.filter(_.id === 1).exists).result.head.map(_ shouldBe true),
       users

--- a/slick-testkit/src/test/scala/slick/test/lifted/TupleInSetExtensionMethodsTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/TupleInSetExtensionMethodsTest.scala
@@ -1,0 +1,38 @@
+package slick.test.lifted
+
+import org.junit.Assert._
+import org.junit.Test
+import slick.lifted.Tuple2OfColumnExtensionMethods
+
+/** Test cases for Tuple inSet extension methods */
+class TupleInSetExtensionMethodsTest {
+
+  @Test def testTupleInSetExtensionMethodsTest = {
+    import slick.jdbc.H2Profile.api._
+
+    class T(tag: Tag) extends Table[(Int, String, Option[String])](tag, Some("myschema"), "mytable") {
+      def id = column[Int]("id")
+      def myString = column[String]("myString")
+      def optString = column[Option[String]]("optString")
+      def * = (id, myString, optString)
+    }
+
+    val ts = TableQuery[T]
+
+    implicit def tuple2BaseTypedType[A: scala.math.Ordering, B: scala.math.Ordering] = new slick.ast.ScalaBaseType[(A, B)]
+
+    val s1 = ts.filter(row => (row.id, row.myString) inSet Seq(1 -> "one", 2 -> "two")).result.statements.head
+    println(s1)
+    assertTrue("inSet looks correct", s1 contains """where ("id", "myString") in ((1, 'one'), (2, 'two'))""")
+
+    // TODO - doesn't work for Option without explicit conversion
+    val s2 = ts.filter(row => new Tuple2OfColumnExtensionMethods(row.id, row.optString) inSet Seq(1 -> Some("one"), 2 -> Some("two"))).result.statements.head
+    println(s2)
+    assertTrue("inSet looks correct for options", s2 contains """where ("id", "optString") in ((1, 'one'), (2, 'two'))""")
+
+    // TODO - not sure if `where (foo) in (null)` is valid...
+    val s3 = ts.filter(row => new Tuple2OfColumnExtensionMethods(row.id, row.optString) inSet Seq(1 -> Some("one"), 2 -> None)).result.statements.head
+    println(s3)
+    assertTrue("inSet looks correct for an empty option", s3 contains """where ("id", "optString") in ((1, 'one'), (2, null))""")
+  }
+}

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -67,7 +67,7 @@ final class Tuple2ColumnExtensionMethods[A: TypedType, B: TypedType](val c: Rep[
     }
 }
 
-final class Tuple2OfColumnExtensionMethods[A: BaseTypedType, B: BaseTypedType](val t: (Rep[A], Rep[B]))
+final class Tuple2OfColumnExtensionMethods[A: TypedType, B: TypedType](val t: (Rep[A], Rep[B]))(implicit shapeA: Shape[_ <: FlatShapeLevel, Rep[A], A, Rep[A]], shapeB: Shape[_ <: FlatShapeLevel, Rep[B], B, Rep[B]])
   extends BaseExtensionMethods[(A, B)] {
   override protected[this] def c: Rep[(A, B)] = new ShapedValue[(Rep[A], Rep[B]), (A, B)](t, implicitly)
 

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -255,9 +255,7 @@ trait ExtensionMethodConversions {
   implicit def stringOptionColumnExtensionMethods(c: Rep[Option[String]]): StringColumnExtensionMethods[Option[String]] = new StringColumnExtensionMethods[Option[String]](c)
   implicit def booleanColumnExtensionMethods(c: Rep[Boolean]): BooleanColumnExtensionMethods[Boolean] = new BooleanColumnExtensionMethods[Boolean](c)
   implicit def booleanOptionColumnExtensionMethods(c: Rep[Option[Boolean]]): BooleanColumnExtensionMethods[Option[Boolean]] = new BooleanColumnExtensionMethods[Option[Boolean]](c)
-  implicit def tuple2ColumnExtensionMethods[A : TypedType, B : TypedType](c: Rep[(A, B)]): Tuple2ColumnExtensionMethods[A, B] = new Tuple2ColumnExtensionMethods[A, B](c)
   implicit def tuple2OfColumnExtensionMethods[A : BaseTypedType, B : BaseTypedType](c: (Rep[A], Rep[B])): Tuple2OfColumnExtensionMethods[A, B] = new Tuple2OfColumnExtensionMethods[A, B](c)
-  implicit def tup2type[A: scala.math.Ordering, B: scala.math.Ordering]: ScalaBaseType[(A, B)] = new ScalaBaseType
 
   implicit def anyColumnExtensionMethods[B1 : BaseTypedType](c: Rep[B1]): AnyExtensionMethods = new AnyExtensionMethods(c.toNode)
   implicit def anyOptionColumnExtensionMethods[B1 : BaseTypedType](c: Rep[Option[B1]]): AnyExtensionMethods = new AnyExtensionMethods(c.toNode)


### PR DESCRIPTION
resolves https://github.com/slick/slick/issues/517

Creates an `inSet` variant for a tuple of columns. Unfortunately, it doesn't actually seem to work for databases... also I'm not terribly familiar with Slick's internal `Type`/`Node`/`Shape` etc stuff so this might be an incorrect approach...