### PR TITLE
#2303 Make `filterIf` filter function argument generic over CanBeQueryCondition

### DIFF
--- a/slick/src/main/scala/slick/lifted/Query.scala
+++ b/slick/src/main/scala/slick/lifted/Query.scala
@@ -49,19 +49,19 @@ sealed abstract class Query[+E, U, C[_]] extends QueryBase[C[U]] { self =>
   /** Select all elements of this query which satisfy a predicate. Unlike
     * `withFilter, this method only allows `Rep`-valued predicates, so it
     * guards against the accidental use plain Booleans. */
-  def filter[T <: Rep[_]](f: E => T)(implicit wt: CanBeQueryCondition[T]): Query[E, U, C] =
+  def filter[T](f: E => T)(implicit wt: CanBeQueryCondition[T]): Query[E, U, C] =
     withFilter(f)
-  def filterNot[T <: Rep[_]](f: E => T)(implicit wt: CanBeQueryCondition[T]): Query[E, U, C] =
+  def filterNot[T](f: E => T)(implicit wt: CanBeQueryCondition[T]): Query[E, U, C] =
     filterHelper(f, node => Library.Not.typed(node.nodeType, node) )
 
   /** Applies the given filter, if the Option value is defined.
     * If the value is None, the filter will not be part of the query. */
-  def filterOpt[V, T <: Rep[_] : CanBeQueryCondition](optValue: Option[V])(f: (E, V) => T): Query[E, U, C] =
+  def filterOpt[V, T : CanBeQueryCondition](optValue: Option[V])(f: (E, V) => T): Query[E, U, C] =
     optValue.map(v => withFilter(a => f(a, v))).getOrElse(this)
 
   /** Applies the given filter function, if the boolean parameter `p` evaluates to true. 
     * If not, the filter will not be part of the query. */
-  def filterIf(p: Boolean)(f: E => Rep[Boolean]): Query[E, U, C] =
+  def filterIf[T : CanBeQueryCondition](p: Boolean)(f: E => T): Query[E, U, C] =
     if (p) withFilter(f) else this
 
   /** Select all elements of this query which satisfy a predicate. This method


### PR DESCRIPTION
This PR makes the return type of filter function parameter provided to `filterIf` combinator generic over `CanBeQueryCondition` context bound so that we can not only return `Boolean` or `Rep[Boolean]`, but also `Rep[Option[Boolean]]` similar to `.withFilter` or `.filterOpt`. This PR should solve #2303.