### PR TITLE
Don't add Resolver.sbtPluginRepo("releases") to reactive-streams-tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,7 +219,6 @@ lazy val `reactive-streams-tests` =
     .settings(
       slickGeneralSettings,
       name := "Slick-ReactiveStreamsTests",
-      resolvers += Resolver.sbtPluginRepo("releases"),
       libraryDependencies += "org.scalatestplus" %% "testng-6-7" % "3.2.9.0",
       libraryDependencies ++=
         (Dependencies.logback +: Dependencies.testDBs).map(_ % Test),


### PR DESCRIPTION
It's causing problems lately and is unnecessary. sbt-testng needed it before https://github.com/sbt/sbt-testng/pull/8 (March 2016). Cf. https://github.com/sbt/sbt-testng/issues/9#issuecomment-174561029