### PR TITLE
Fix overridden paradox sbt task slowness

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -114,16 +114,17 @@ object Docs extends AutoPlugin {
     Compile / paradox := {
       val outDir = (Compile / paradox).value
       val files = IO.listFiles(outDir, globFilter("*.html"))
+      val ref = Versioning.currentRef(baseDirectory.value)
       for (f <- files)
         modifyFileLines(f) { line =>
           line
             .replaceAllLiterally(
               "https://github.com/slick/slick/tree/master/doc/target/preprocessed/",
-              s"https://github.com/slick/slick/tree/${Versioning.currentRef(baseDirectory.value)}/doc/paradox/"
+              s"https://github.com/slick/slick/tree/$ref/doc/paradox/"
             )
             .replaceAllLiterally(
               "https://github.com/slick/slick/tree/master/doc/target/code/",
-              s"https://github.com/slick/slick/tree/${Versioning.currentRef(baseDirectory.value)}/doc/code/"
+              s"https://github.com/slick/slick/tree/$ref/doc/code/"
             )
         }
       outDir


### PR DESCRIPTION
Look up the ref once, not twice per each line!!
