### PR TITLE
Insert multiple rows using a single SQL statement

### DIFF
--- a/doc/paradox/upgrade.md
+++ b/doc/paradox/upgrade.md
@@ -58,10 +58,23 @@ carefully after upgrading. See issue [#1938](https://github.com/slick/slick/issu
 The following bug fixes are highlighted here because they change the default mapping behaviour for some `java.time`
 columns in PostgreSQL:
 
-- `java.time.Instant.MIN` and `java.time.Instant.MAX` are now correctly mapped to `-infinity` and `infinity` 
+- `java.time.Instant.MIN` and `java.time.Instant.MAX` are now correctly mapped to `-infinity` and `infinity`
   respectively in PostgreSQL profile ([#2237](https://github.com/slick/slick/issues/2237))
 - changes to handling of timezone part of `java.time.Instant` in PostgreSQL profile
   ([#2005](https://github.com/slick/slick/issues/2005))
+
+Upgrade from 3.4 to 3.5
+-----------------------
+
+### ResultConverter
+
+``ResultConverter`` is an internal interface for converting between values handled in JDBC and values handled in
+application code (case classes, etc.). While you most likely aren't using it directly, you may need to call methods
+of this interface if you are override behavior of a profile or writing a new one.
+
+In order to support a single insert statement with multiple rows, the `set` method now takes an `offset` parameter.
+If you have extended a profile and used the `set` method of this interface, you may need to specify 0 for the offset
+(unless the number of variable placeholders in the SQL dynamically changes).
 
 Upgrade from 3.2 to 3.3
 -----------------------

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -1,13 +1,13 @@
 package com.typesafe.slick.testkit.tests
 
-import slick.jdbc.{DerbyProfile, JdbcCapabilities}
+import slick.jdbc.{DerbyProfile, JdbcCapabilities, RowsPerStatement}
+
 import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
 
 
 class InsertTest extends AsyncTest[JdbcTestDB] {
 
   import tdb.profile.api._
-  import tdb.profile.StatementOption
 
 
   def testSimple = {
@@ -69,7 +69,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     val records = Seq((1, 10), (2, 20), (3, 30))
     DBIO.seq(
       as.schema.create,
-      as.insertAll(records, StatementOption.SingleStatement).map(_ shouldBe Some(3)),
+      as.insertAll(records, RowsPerStatement.All).map(_ shouldBe Some(3)),
       as.sortBy(_.id).result.map(_ shouldBe records)
     )
   }
@@ -84,7 +84,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     val records = Seq(E(1, 10), E(2, 20), E(3, 30))
     DBIO.seq(
       as.schema.create,
-      as.insertAll(records, StatementOption.SingleStatement).map(_ shouldBe Some(3)),
+      as.insertAll(records, RowsPerStatement.All).map(_ shouldBe Some(3)),
       as.sortBy(_.id).result.map(_ shouldBe records)
     )
   }
@@ -98,7 +98,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     val records = Seq((10, 10), (20, 20), (30, 30))
     for {
       _ <- as.schema.create
-      result <- as.returning(as.map(_.id)).insertAll(records, StatementOption.SingleStatement)
+      result <- as.returning(as.map(_.id)).insertAll(records, RowsPerStatement.All)
       _ <- ifCap(jcap.returnMultipleInsertKey)(DBIO.successful(result shouldBe Seq(1, 2, 3)))
       _ <- ifNotCap(jcap.returnMultipleInsertKey)(DBIO.successful(result shouldBe Nil))
       _ <- as.sortBy(_.id).result.map(_ shouldBe Seq((1, 10), (2, 20), (3, 30)))
@@ -113,7 +113,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     val as = TableQuery[A]
     DBIO.seq(
       as.schema.create,
-      as.insertAll(Seq(1, 2, 3), StatementOption.SingleStatement),
+      as.insertAll(Seq(1, 2, 3), RowsPerStatement.All),
       as.result.map(_ shouldBe Seq(1, 2, 3))
     )
   }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -1,13 +1,13 @@
 package com.typesafe.slick.testkit.tests
 
 import slick.jdbc.{DerbyProfile, JdbcCapabilities}
-
 import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
 
 
 class InsertTest extends AsyncTest[JdbcTestDB] {
 
   import tdb.profile.api._
+  import tdb.profile.StatementOption
 
 
   def testSimple = {
@@ -56,6 +56,65 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
       as.schema.create,
       as += 42,
       as.result.map(_ shouldBe Seq(1))
+    )
+  }
+
+  def testInsertAllTupleWithSingleInsert = ifCap(jcap.insertMultipleRowsWithSingleStatement) {
+    class A(tag: Tag) extends Table[(Int, Int)](tag, "insert_all") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def v1 = column[Int]("v1")
+      def * = (id, v1)
+    }
+    val as = TableQuery[A]
+    val records = Seq((1, 10), (2, 20), (3, 30))
+    DBIO.seq(
+      as.schema.create,
+      as.insertAll(records, StatementOption.SingleStatement).map(_ shouldBe Some(3)),
+      as.sortBy(_.id).result.map(_ shouldBe records)
+    )
+  }
+  def testInsertAllProduct = ifCap(jcap.insertMultipleRowsWithSingleStatement) {
+    case class E(id: Int, v1: Int)
+    class A(tag: Tag) extends Table[E](tag, "insert_all_product") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def v1 = column[Int]("v1")
+      def * = (id, v1).mapTo[E]
+    }
+    val as = TableQuery[A]
+    val records = Seq(E(1, 10), E(2, 20), E(3, 30))
+    DBIO.seq(
+      as.schema.create,
+      as.insertAll(records, StatementOption.SingleStatement).map(_ shouldBe Some(3)),
+      as.sortBy(_.id).result.map(_ shouldBe records)
+    )
+  }
+  def testInsertAllAutoInc = ifCap (jcap.returnInsertKey, jcap.insertMultipleRowsWithSingleStatement) {
+    class A(tag: Tag) extends Table[(Int, Int)](tag, "insert_all_auto_inc") {
+      def id = column[Int]("ID", O.PrimaryKey, O.AutoInc)
+      def v1 = column[Int]("V1")
+      def * = (id, v1)
+    }
+    val as = TableQuery[A]
+    val records = Seq((10, 10), (20, 20), (30, 30))
+    for {
+      _ <- as.schema.create
+      result <- as.returning(as.map(_.id)).insertAll(records, StatementOption.SingleStatement)
+      _ <- ifCap(jcap.returnMultipleInsertKey)(DBIO.successful(result shouldBe Seq(1, 2, 3)))
+      _ <- ifNotCap(jcap.returnMultipleInsertKey)(DBIO.successful(result shouldBe Nil))
+      _ <- as.sortBy(_.id).result.map(_ shouldBe Seq((1, 10), (2, 20), (3, 30)))
+    } yield ()
+  }
+
+  def testInsertAllDefaultValue = ifCap(jcap.insertMultipleRowsWithSingleStatement) {
+    class A(tag: Tag) extends Table[Int](tag, "insert_all_default") {
+      def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+      def * = id
+    }
+    val as = TableQuery[A]
+    DBIO.seq(
+      as.schema.create,
+      as.insertAll(Seq(1, 2, 3), StatementOption.SingleStatement),
+      as.result.map(_ shouldBe Seq(1, 2, 3))
     )
   }
 

--- a/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
@@ -72,6 +72,9 @@ import slick.util.MacroSupport.macroSupportInterpolation
   *     There's not builtin string function repeat in Derby.
   *     <a href="https://db.apache.org/derby/docs/10.10/ref/rrefsqlj29026.html" target="_parent"
   *     >https://db.apache.org/derby/docs/10.10/ref/rrefsqlj29026.html</a></li>
+  *   <li>[[slick.jdbc.JdbcCapabilities.returnMultipleInsertKey]]:
+  *     Derby's driver is unable to properly return the generated key for insert statements with multiple values.
+  *     (<a href="https://issues.apache.org/jira/browse/DERBY-3609" target="_parent"></a>DERBY-3609</li>)
   * </ul>
   */
 trait DerbyProfile extends JdbcProfile {
@@ -92,6 +95,7 @@ trait DerbyProfile extends JdbcProfile {
     - JdbcCapabilities.booleanMetaData
     - JdbcCapabilities.supportsByte
     - RelationalCapabilities.repeat
+    - JdbcCapabilities.returnMultipleInsertKey
   )
 
   class ModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit ec: ExecutionContext) extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -575,7 +575,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
     class InsertAllAction(a: compiled.Artifacts, values: Iterable[U]) extends SimpleJdbcProfileAction[MultiInsertResult]("InsertAllAction", Vector(a.ibr.buildInsertMultipleRowsSql(values.size))) {
       override def run(ctx: Backend#Context, sql: Vector[String]): MultiInsertResult = {
         val size = a.ibr.fields.length
-        preparedInsert(statements.head, ctx.session) { st =>
+        preparedInsert(sql.head, ctx.session) { st =>
           st.clearParameters()
           values.zipWithIndex.foreach {
             case (value, idx) => a.converter.set(value, st, idx * size)

--- a/slick/src/main/scala/slick/jdbc/JdbcCapabilities.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcCapabilities.scala
@@ -15,10 +15,14 @@ object JdbcCapabilities {
   val insertOrUpdate = Capability("jdbc.insertOrUpdate")
   /** Supports `insertOrUpdate` with only primary keys (equivalent to "insert if not exists") */
   val insertOrUpdateWithPrimaryKeyOnly = Capability("jdbc.insertOrUpdateWithPrimaryKeyOnly")
+  /** Supports `insertAll` with `SingleStatement` option.*/
+  val insertMultipleRowsWithSingleStatement = Capability("jdbc.insertMultipleRowsWithSingleStatement")
   /** Supports mutable result sets */
   val mutable = Capability("jdbc.mutable")
   /** Can return primary key of inserted rows */
   val returnInsertKey = Capability("jdbc.returnInsertKey")
+  /** Can return multiple primary key of inserted rows in a single statement */
+  val returnMultipleInsertKey = Capability("jdbc.returnMultipleInsertKey")
   /** Can also return non-primary-key columns of inserted rows */
   val returnInsertOther = Capability("jdbc.returnInsertOther")
   /** Returns column default values in meta data */
@@ -47,11 +51,13 @@ object JdbcCapabilities {
     forceInsert,
     insertOrUpdate,
     insertOrUpdateWithPrimaryKeyOnly,
+    insertMultipleRowsWithSingleStatement,
     mutable,
     nullableNoDefault,
     other,
     returnInsertKey,
     returnInsertOther,
+    returnMultipleInsertKey,
     supportsByte,
   )
 }

--- a/slick/src/main/scala/slick/jdbc/JdbcResultConverter.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcResultConverter.scala
@@ -12,8 +12,8 @@ class BaseResultConverter[@specialized(Byte, Short, Int, Long, Char, Float, Doub
     v
   }
   def update(value: T, pr: ResultSet) = ti.updateValue(value, pr, idx)
-  def set(value: T, pp: PreparedStatement) =
-    ti.setValue(value, pp, idx)
+  def set(value: T, pp: PreparedStatement, offset: Int) =
+    ti.setValue(value, pp, idx + offset)
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = s"idx=$idx, name=$name", attrInfo = ": " + ti)
   def width = 1
 }
@@ -29,9 +29,9 @@ class OptionResultConverter[@specialized(Byte, Short, Int, Long, Char, Float, Do
     case Some(v) => ti.updateValue(v, pr, idx)
     case _ => ti.updateNull(pr, idx)
   }
-  def set(value: Option[T], pp: PreparedStatement) = value match {
-    case Some(v) => ti.setValue(v, pp, idx)
-    case _ => ti.setNull(pp, idx)
+  def set(value: Option[T], pp: PreparedStatement, offset: Int) = value match {
+    case Some(v) => ti.setValue(v, pp, idx + offset)
+    case _ => ti.setNull(pp, idx + offset)
   }
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = s"idx=$idx", attrInfo = ": " + ti)
   def width = 1
@@ -54,7 +54,7 @@ class DefaultingResultConverter[@specialized(Byte, Short, Int, Long, Char, Float
     if(ti.wasNull(pr, idx)) default() else v
   }
   def update(value: T, pr: ResultSet) = ti.updateValue(value, pr, idx)
-  def set(value: T, pp: PreparedStatement) = ti.setValue(value, pp, idx)
+  def set(value: T, pp: PreparedStatement, offset: Int) = ti.setValue(value, pp, idx + offset)
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = s"idx=$idx, default=" +
     { try default() catch { case e: Throwable => "["+e.getClass.getName+"]" } },
     attrInfo = ": " + ti)
@@ -69,7 +69,7 @@ class IsDefinedResultConverter[@specialized(Byte, Short, Int, Long, Char, Float,
   }
   def update(value: Boolean, pr: ResultSet) =
     throw new SlickException("Cannot insert/update IsDefined check")
-  def set(value: Boolean, pp: PreparedStatement) =
+  def set(value: Boolean, pp: PreparedStatement, offset: Int) =
     throw new SlickException("Cannot insert/update IsDefined check")
   def width = 1
   override def getDumpInfo = super.getDumpInfo.copy(mainInfo = s"idx=$idx", attrInfo = ": " + ti)

--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -4,7 +4,6 @@ import java.time.format.DateTimeFormatter
 import java.time._
 import java.util.UUID
 import java.sql.{Array => _, _}
-
 import scala.concurrent.ExecutionContext
 import slick.SlickException
 import slick.ast._
@@ -15,6 +14,7 @@ import slick.lifted._
 import slick.model.ForeignKeyAction
 import slick.relational.{RelationalCapabilities, RelationalProfile, ResultConverter}
 import slick.basic.Capability
+import slick.sql.FixedSqlAction
 import slick.util.ConstArray
 import slick.util.MacroSupport.macroSupportInterpolation
 
@@ -44,6 +44,11 @@ import slick.util.MacroSupport.macroSupportInterpolation
   *     which is always mapped back to BigDecimal in model and generated code.</li>
   *   <li>[[slick.jdbc.JdbcCapabilities.supportsByte]]:
   *     Oracle does not have a BYTE type.</li>
+ *   <li>[[slick.jdbc.JdbcCapabilities.returnMultipleInsertKey]]:
+ *      Oracle returns the last generated key only.</li>
+ *   <li>[[slick.jdbc.JdbcCapabilities.insertMultipleRowsWithSingleStatement]]:
+ *      Oracle doesn't support this feature directly.
+ *      There are several alternative ways, but the library doesn't support them, so far.</li>
   * </ul>
   *
   * Note: The Oracle JDBC driver has problems with quoted identifiers. Columns
@@ -63,6 +68,8 @@ trait OracleProfile extends JdbcProfile {
     - JdbcCapabilities.booleanMetaData
     - JdbcCapabilities.distinguishesIntTypes
     - JdbcCapabilities.supportsByte
+    - JdbcCapabilities.returnMultipleInsertKey
+    - JdbcCapabilities.insertMultipleRowsWithSingleStatement
   )
 
   override protected lazy val useServerSideUpsert = true
@@ -532,6 +539,24 @@ END;
         }
       }).asInstanceOf[ResultConverter[JdbcResultConverterDomain, Option[T]]]
     else super.createOptionResultConverter(ti, idx)
+
+
+  private trait OverrideInsertAll[U] { self : InsertActionComposerImpl[U] =>
+    override def insertAll(values: Iterable[U], option: StatementOption = StatementOption.Batch): FixedSqlAction[MultiInsertResult, NoStream, Effect.Write] = {
+      option match {
+        case StatementOption.Batch =>
+          new self.MultiInsertAction(compiled.standardInsert, values)
+        case StatementOption.SingleStatement =>
+          throw new SlickException("OracleProfile doesn't support multiple insert with single statement.")
+      }
+    }
+  }
+
+  override def createInsertActionExtensionMethods[T](compiled: CompiledInsert): InsertActionExtensionMethods[T] =
+    new CountingInsertActionComposerImpl[T](compiled) with OverrideInsertAll[T]
+
+  override def createReturningInsertActionComposer[U, QR, RU](compiled: JdbcCompiledInsert, keys: Node, mux: (U, QR) => RU): ReturningInsertActionComposer[U, RU] =
+    new ReturningInsertActionComposerImpl[U, QR, RU](compiled, keys, mux) with OverrideInsertAll[U]
 
   // Does not work to get around the ORA-00904 issue when returning columns
   // with lower-case names

--- a/slick/src/main/scala/slick/jdbc/OracleProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/OracleProfile.scala
@@ -542,17 +542,12 @@ END;
 
 
   private trait OracleInsertAll[U] extends InsertActionComposerImpl[U] {
-    override def insertAll(values: Iterable[U],
-                           rowsPerStatement: RowsPerStatement = RowsPerStatement.One): FixedSqlAction[
-      MultiInsertResult,
-      NoStream,
-      Effect.Write
-    ] =
+    override def insertAll(values: Iterable[U], rowsPerStatement: RowsPerStatement = RowsPerStatement.One) =
       rowsPerStatement match {
         case RowsPerStatement.One =>
-          new MultiInsertAction(compiled.standardInsert, values)
+          super.insertAll(values, rowsPerStatement)
         case RowsPerStatement.All =>
-          throw new SlickException("OracleProfile doesn't support multiple insert with single statement.")
+          throw new SlickException("OracleProfile doesn't support inserting multiple rows with a single statement.")
       }
   }
 

--- a/slick/src/main/scala/slick/jdbc/RowsPerStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/RowsPerStatement.scala
@@ -1,0 +1,11 @@
+package slick.jdbc
+
+sealed trait RowsPerStatement
+
+object RowsPerStatement {
+  /** A single statement with all rows should be used */
+  case object All extends RowsPerStatement
+
+  /** A separate statement is used for each row */
+  case object One extends RowsPerStatement
+}

--- a/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/SQLiteProfile.scala
@@ -178,17 +178,16 @@ trait SQLiteProfile extends JdbcProfile {
   override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder = new ColumnDDLBuilder(column)
 
   private trait SQLiteInsertAll[U] extends InsertActionComposerImpl[U] {
-    override def insertAll(values: Iterable[U],
-                           rowsPerStatement: RowsPerStatement = RowsPerStatement.All): FixedSqlAction[
-      MultiInsertResult,
-      NoStream,
-      Effect.Write
-    ] =
-      if (compiled.standardInsert.ibr.fields.isEmpty) {
-        // Use batch insert because sqlite doesn't support multi default values
-        new MultiInsertAction(compiled.standardInsert, values)
-      } else
-        super.insertAll(values, rowsPerStatement)
+    override def insertAll(values: Iterable[U], rowsPerStatement: RowsPerStatement = RowsPerStatement.All) =
+      super.insertAll(
+        values = values,
+        rowsPerStatement =
+          if (compiled.standardInsert.ibr.fields.isEmpty) {
+            // Use batch insert because sqlite doesn't support multi default values
+            RowsPerStatement.One
+          } else
+            rowsPerStatement
+      )
   }
 
   override def createInsertActionExtensionMethods[T](compiled: CompiledInsert): InsertActionExtensionMethods[T] =

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -325,7 +325,7 @@ object ShapedValue {
     val fpName = Constant("Fast Path of ("+fields.map(_._2).mkString(", ")+").mapTo["+rTag.tpe+"]")
     val fpChildren = fields.map { case (_, t, n) => q"val $n = next[$t]" }
     val fpReadChildren = fields.map { case (_, _, n) => q"$n.read(r)" }
-    val fpSetChildren = fields.map { case (fn, _, n) => q"$n.set(value.$fn, pp)" }
+    val fpSetChildren = fields.map { case (fn, _, n) => q"$n.set(value.$fn, pp, offset)" }
     val fpUpdateChildren = fields.map { case (fn, _, n) => q"$n.update(value.$fn, pr)" }
 
     q"""
@@ -336,7 +336,7 @@ object ShapedValue {
           new _root_.slick.relational.SimpleFastPathResultConverter[_root_.slick.relational.ResultConverterDomain, $rTag](tm.asInstanceOf[_root_.slick.relational.TypeMappingResultConverter[_root_.slick.relational.ResultConverterDomain, $rTag, _]]) {
             ..$fpChildren
             override def read(r: Reader): $rTag = new $rTag(..$fpReadChildren)
-            override def set(value: $rTag, pp: Writer): _root_.scala.Unit = {..$fpSetChildren}
+            override def set(value: $rTag, pp: Writer, offset: Int): _root_.scala.Unit = {..$fpSetChildren}
             override def update(value: $rTag, pr: Updater): _root_.scala.Unit = {..$fpUpdateChildren}
             override def getDumpInfo = super.getDumpInfo.copy(name = $fpName)
           }

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -93,7 +93,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
     def += (value: T)(implicit session: Backend#Session): Unit = {
       val htable = session.database.getTable(table.tableName)
       val buf = htable.createInsertRow
-      converter.asInstanceOf[ResultConverter[MemoryResultConverterDomain, Any]].set(value, buf)
+      converter.asInstanceOf[ResultConverter[MemoryResultConverterDomain, Any]].set(value, buf, 0)
       htable.append(buf.toIndexedSeq)
     }
 
@@ -210,7 +210,7 @@ trait MemoryProfile extends RelationalProfile with MemoryQueryingProfile { self:
     class InsertResultConverter(tidx: Int) extends ResultConverter[MemoryResultConverterDomain, Any] {
       def read(pr: MemoryResultConverterDomain#Reader) = ??
       def update(value: Any, pr: MemoryResultConverterDomain#Updater) = ??
-      def set(value: Any, pp: MemoryResultConverterDomain#Writer) = pp(tidx) = value
+      def set(value: Any, pp: MemoryResultConverterDomain#Writer, offset: Int) = pp(tidx + offset) = value
       override def getDumpInfo = super.getDumpInfo.copy(mainInfo = s"tidx=$tidx")
       def width = 1
     }

--- a/slick/src/main/scala/slick/memory/MemoryQueryingProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryQueryingProfile.scala
@@ -95,7 +95,7 @@ trait MemoryQueryingProfile extends BasicProfile { self: MemoryQueryingProfile =
         else v
       }
       def update(value: Any, pr: MemoryResultConverterDomain#Updater) = ??
-      def set(value: Any, pp: MemoryResultConverterDomain#Writer) = ??
+      def set(value: Any, pp: MemoryResultConverterDomain#Writer, offset: Int) = ??
       override def getDumpInfo = super.getDumpInfo.copy(mainInfo = s"ridx=$ridx, nullable=$nullable")
       def width = 1
     }


### PR DESCRIPTION
It solves https://github.com/slick/slick/issues/1272.

Another possible implementation is [here](https://github.com/jkugiya/slick/pull/1), but i think this is better approch. (Building SQL are on `JdbcStatementBuilderComponent`)

- ~~I haven't fully investigated how to handle the return value when there are multiple values. It could be `MultiInsertResult` as well as `++=`.~~
  - It returns `MultiInsertResult`, but it may returns Nil if the driver doesn't support returning each ids.
- I think this implementation can be applied to the implementation of upsert with multiple values. On the other hand, I think we need to consider how we should name it in that case. (Uniform naming between insert and upsert is desirable, I have also implemented batch upsert #2397).
  1. The API signature will be a little more difficult, following is also possible.
    ```scala
    def ++= (values: Iterable[T])(implicit im: InsertMode = InsertMode.BatchInsert): ProfileAction[MultiInsertResult, NoStream, Effect.Write] = 
      im match {
        case InsertMode.BatchInsert => batchInsertAll(values)
        case InsertMode.MultipleValues =>insertAllByMultipleValues(values)
      }
    ```
  2. Adding new methods, simply
    ```scala
  // use alias
  def ++=(values: Iterable[T]): ProfileAction[MultiInsertResult, NoStream, Effect.Write] = insertAllBatch(values)
  // batch insert
  def insertAllBatch(values: Iterable[T]): ProfileAction[MultiInsertResult, NoStream, Effect.Write]
  // multiple rows 
  def insertAll(values: Iterable[T]): ProfileAction[MultiInsertResult, NoStream, Effect.Write]
  def insertOrUpdateAllBatch(values: Iterable[T]): ProfileAction[MultiInsertResult, NoStream, Effect.Write]
  def insertOrUpdateAll(values: Iterable[T]): ProfileAction[MultiInsertResult, NoStream, Effect.Write] 
    ```