### PR TITLE
MS SQLServer specific UUID datatype implementation

### DIFF
--- a/slick-testkit/src/codegen/resources/dbs/uuid-sqlserver.sql
+++ b/slick-testkit/src/codegen/resources/dbs/uuid-sqlserver.sql
@@ -1,0 +1,5 @@
+create table "person" ("id" INTEGER NOT NULL PRIMARY KEY,
+                       "uuid" UNIQUEIDENTIFIER NOT NULL,
+                       "uuid_def" UNIQUEIDENTIFIER DEFAULT('2f3f866c-d8e6-11e2-bb56-50e549c9b654'),
+                       "uuid_func" UNIQUEIDENTIFIER DEFAULT NEWID()
+                      );

--- a/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateMainSources.scala
+++ b/slick-testkit/src/codegen/scala/slick/test/codegen/GenerateMainSources.scala
@@ -207,6 +207,7 @@ val  SimpleA = CustomTyping.SimpleA
           }
         })
     },
+    new UUIDConfig("SQLServer1", StandardTestDBs.SQLServer2014SQLJDBC, "SQLServer2014SQLJDBC", Seq("/dbs/uuid-sqlserver.sql")),
     new Config("EmptyDB", StandardTestDBs.H2Mem, "H2Mem", Nil),
     new Config("Oracle1", StandardTestDBs.Oracle, "Oracle", Seq("/dbs/oracle1.sql")) {
       override def useSingleLineStatements = true

--- a/test-dbs/testkit.appveyor.conf
+++ b/test-dbs/testkit.appveyor.conf
@@ -115,7 +115,7 @@ sqlserver-sqljdbc {
 
     ]
   drop = [
-    use ${adminDB}
+    print('Skipped intentionally')
   ]
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }
@@ -139,7 +139,7 @@ sqlserver2012-sqljdbc {
 
     ]
   drop = [
-    use ${testDB}
+    print('Skipped intentionally')
   ]
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }
@@ -163,7 +163,7 @@ sqlserver2014-sqljdbc {
 
     ]
   drop = [
-    use ${testDB}
+    print('Skipped intentionally')
   ]
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }
@@ -188,7 +188,7 @@ sqlserver2017-sqljdbc {
 
     ]
   drop = [
-    use ${admindb}
+    print('Skipped intentionally')
   ]
   driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
 }


### PR DESCRIPTION
Fixes #2291 

Changes compared to base type:
* allow literal support (the code from `PosgresProfile` as the format is compatible with SQLServer)
* `fromBytes` and `toBytes` reimplemented with Scala version of utilities found in mssql-jdbc driver of version 10.2.0
* `sqlType` changed to `java.sql.Types.BINARY`, this is questionable, it is `OTHER` in super type, but `VARBINARY` for Oracle. I see this datatype as binary with constant size of 16 bytes, so, selected this type, but I'm not an expert on JDBC internals.

The only significant change from Java code in mssql-jdbc is at line 466
```scala
      if (inputGUID.length != 16) return null
```

Original code throws exception, very specific one for SQLServer and I don't know if it is good to throw exceptions in this place in slick (probably not). Also, this is like a should never happen under normal operation scenario.

I tested it with modified playframework slick example application and with some other application, but don't know how to provide a good integration test for this (I read docs on testkit, but didn't manage catch up immediately).
