### PR TITLE
Exclude slf4j from HikariCP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,7 @@ lazy val hikaricp =
       description := "HikariCP integration for Slick (Scala Language-Integrated Connection Kit)",
       scaladocSourceUrl("slick-hikaricp"),
       test := {}, testOnly := {}, // suppress test status output
-      libraryDependencies += Dependencies.hikariCP,
+      libraryDependencies += Dependencies.hikariCP.exclude("org.slf4j", "*"),
     )
 
 lazy val `reactive-streams-tests` =


### PR DESCRIPTION
Fixes #2410

Excludes slf4j transitive dependency of HikariCP as it may resolve (depending on Java version) to alpha version.