### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Slick is a functional database library for Scala.
 
-Slick allows you to work with relational databases almost as if you were using 
+It allows you to work with relational databases almost as if you were using 
 Scala collections, while at the same time giving you full control over when a 
 database access happens and what data is transferred. By writing your queries 
 in Scala you can benefit from the static type checking, compile-time safety, and 
@@ -15,7 +15,22 @@ Slick also features an advanced query compiler which can generate SQL for a vari
 of different database engines from the same Scala code, allowing you to focus on
 application logic without worrying about database-specific syntax and quirks.
 
-## Documentation
+## Resources
+
+- full documentation, including Scaladocs and more complex examples, can be 
+found on the [Slick website](https://scala-slick.org)
+
+- we have an active [gitter channel](https://gitter.im/slick/slick) where you
+can ask for help
+
+- think you've found a bug? Have an idea for a new feature? Please raise it in
+our [issue tracker](https://github.com/slick/slick/issues) here on github
+
+- our friends at [`underscore.io`](https://underscore.io/) have written "Essential 
+Slick", an excellent guide to using slick from first principles, which is now 
+available [as a free download](https://underscore.io/books/essential-slick/)
+
+## Example
 
 As a simple example we will create a Scala object `Coffee`, and a table to store 
 instances of this object in the database:
@@ -47,9 +62,6 @@ coffees.map(_.name)
 // SQL: select NAME, PRICE from COFFEES where PRICE < 10.0 order by NAME
 coffees.filter(_.price < 10.0).sortBy(_.name)
 ```
-
-Full documentation, including Scaladocs and more complex examples, can be 
-found on the [Slick website](https://scala-slick.org).
 
 ## Database support
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,80 @@
-Slick
-=====
+# Slick
 
 [![Maven](https://img.shields.io/maven-central/v/com.typesafe.slick/slick_2.13.svg)](http://mvnrepository.com/artifact/com.typesafe.slick/slick_2.13) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/slick/slick?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Slick is a modern database query and access library for Scala. It allows you
-to work with stored data almost as if you were using Scala collections while
-at the same time giving you full control over when a database access happens
-and which data is transferred. You can write your database queries in Scala
-instead of SQL, thus profiting from the static checking, compile-time safety
-and compositionality of Scala. Slick features an extensible query compiler
-which can generate code for different backends.
+Slick is a functional database library for Scala.
 
-The following database systems are directly supported for type-safe queries.
-These are the databases and driver versions that have explicit automated tests.
+Slick allows you to work with relational databases almost as if you were using 
+Scala collections, while at the same time giving you full control over when a 
+database access happens and what data is transferred. By writing your queries 
+in Scala you can benefit from the static type checking, compile-time safety, and 
+compositionality of Scala, while retaining the ability to drop down to raw SQL 
+where needed for custom or advanced database features.
+
+Slick also features an advanced query compiler which can generate SQL for a variety
+of different database engines from the same Scala code, allowing you to focus on
+application logic without worrying about database-specific syntax and quirks.
+
+## Documentation
+
+As a simple example we will create a Scala object `Coffee`, and a table to store 
+instances of this object in the database:
+
+```scala
+// First declare our Scala object
+final case class Coffee(name: String, price: Double)
+
+// Next define how Slick maps from a database table to Scala objects
+class Coffees(tag: Tag) extends Table[Coffee](tag, "COFFEES") {
+  def name  = column[String]("NAME")
+  def price = column[Double]("PRICE")
+  def * = (name, price).mapTo[Coffee]
+}
+
+// The `TableQuery` object gives us access to Slick's rich query API
+val coffees = TableQuery[Coffees]
+
+// Inserting is done by appending to our query object
+// as if it were a regular Scala collection
+// SQL: insert into COFFEES (NAME, PRICE) values ('Latte', 2.50)
+coffees += Coffee("Latte", 2.50)
+
+// Fetching data is also done using the query object
+// SQL: select NAME from COFFEES
+coffees.map(_.name)
+
+// More complex queries can be chained together
+// SQL: select NAME, PRICE from COFFEES where PRICE < 10.0 order by NAME
+coffees.filter(_.price < 10.0).sortBy(_.name)
+```
+
+Full documentation, including Scaladocs and more complex examples, can be 
+found on the [Slick website](https://scala-slick.org).
+
+## Database support
+
+The following databases are directly supported by Slick, and are currently covered
+by a large suite of automated tests to ensure compatibility:
 
 |Database|JDBC Driver|
 |--------|-----------|
-|SQLServer 2008, 2012, 2014, 2017|[jtds:1.3.1](http://sourceforge.net/projects/jtds/files/jtds/) and [msjdbc:7.2.2](https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server?view=sql-server-2017)|
-|Oracle 11g|[ojdbc7:12.1.0.2](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|
 |DB2 10.5|[db2jcc4:4.19.20](http://www-01.ibm.com/support/docview.wss?uid=swg21363866)|
+|Derby/JavaDB|derby:10.14.2.0|
+|H2|com.h2database.h2:1.4.199|
+|HSQLDB/HyperSQL|hsqldb:2.4.1|
 |MySQL|mysql-connector-java:8.0.16|
+|Oracle 11g|[ojdbc7:12.1.0.2](http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html)|
 |PostgreSQL|postgresql:42.2.5|
 |SQLite|sqlite-jdbc:3.27.2.1|
-|Derby/JavaDB|derby:10.14.2.0|
-|HSQLDB/HyperSQL|hsqldb:2.4.1|
-|H2|com.h2database.h2:1.4.199|
+|SQLServer 2008, 2012, 2014, 2017|[jtds:1.3.1](http://sourceforge.net/projects/jtds/files/jtds/) and [msjdbc:7.2.2](https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server?view=sql-server-2017)|
 
-Accessing other database systems is possible, with a reduced feature set.
+Accessing other database systems is possible, although possibly with a reduced feature 
+set.
 
-The [manual and scaladocs](https://scala-slick.org/docs/) for Slick can be
-found on the [Slick web site](https://scala-slick.org).
+## Contributing
 
-## Maintenance status
+Slick is maintained by the Scala community. Pull requests are very welcome, and we
+ask that all contributors abide by the [Lightbend Community Code of Conduct](https://www.lightbend.com/conduct).
 
-Slick is community-maintained by a loose assortment of volunteers.
-Please help if you can.
-
-Lightbend staff (such as @SethTisue) may be able to assist with
+Lightbend staff (such as @SethTisue) may be able to assist directly with
 administrative issues.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ application logic without worrying about database-specific syntax and quirks.
 
 ## Resources
 
-- full documentation, including Scaladocs and more complex examples, can be 
+- Full documentation, including Scaladocs and more complex examples, can be 
 found on the [Slick website](https://scala-slick.org)
 
-- we have an active [gitter channel](https://gitter.im/slick/slick) where you
+- We have an active [gitter channel](https://gitter.im/slick/slick) where you
 can ask for help
 
-- think you've found a bug? Have an idea for a new feature? Please raise it in
+- Think you've found a bug? Have an idea for a new feature? Please raise it in
 our [issue tracker](https://github.com/slick/slick/issues) here on github
 
-- our friends at [`underscore.io`](https://underscore.io/) have written "Essential 
+- Our friends at [`underscore.io`](https://underscore.io/) have written "Essential 
 Slick", an excellent guide to using slick from first principles, which is now 
 available [as a free download](https://underscore.io/books/essential-slick/)
 
@@ -85,8 +85,8 @@ set.
 
 ## Contributing
 
-Slick is maintained by the Scala community. Pull requests are very welcome, and we
+Slick is community-maintained: pull requests are very welcome, and we
 ask that all contributors abide by the [Lightbend Community Code of Conduct](https://www.lightbend.com/conduct).
 
-Lightbend staff (such as @SethTisue) may be able to assist directly with
+Lightbend staff (such as @SethTisue) may be able to assist with
 administrative issues.

--- a/doc/paradox/upgrade.md
+++ b/doc/paradox/upgrade.md
@@ -29,6 +29,37 @@ Latest changes
 
 See @ref:[the generated tables of incompatible changes](compat-report.md)
 
+Upgrade from 3.3 to 3.4
+-----------------------
+
+The full list of changes and bug fixes in version 3.4 is [available on github](https://github.com/slick/slick/discussions/2344). 
+
+### Dependency upgrades
+
+Slick 3.4 updates the following upstream dependencies. If you use these libraries as part of your build, 
+you should update your dependency versions to match:
+
+|Dependency|Slick 3.3 depends on|Slick 3.4 depends on|Notes|
+|----------|--------------------|--------------------|-----|
+| [com.typesafe:config](https://github.com/lightbend/config) | 1.3.2 | 1.4.2 | See the `config` library's [release notes](https://github.com/lightbend/config/blob/main/NEWS.md) for changes. |
+| [com.zaxxer:HikariCP](https://github.com/brettwooldridge/HikariCP) | 3.2.0 | 4.0.3 | See the `HikariCP` [changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) for changes. This only affects users who depend on the `slick-hikaricp` artifact.  |
+| [org.scala-lang.modules:scala-collection-compat](https://github.com/scala/scala-collection-compat) | 2.0.0 | 2.6.0 | Versions >= 2.0.0 should be binary-compatible, so no issues are expected. This only affects users building with Scala 2.11 or 2.12. |
+
+### AsyncExecutor defaults
+
+`AsyncExecutor` wraps the thread pool that Slick uses to run blocking I/O (such as database queries). The
+previous default constructor arguments could potentially cause deadlocks in some cases, so Slick 3.4 changes these 
+to safer defaults. In most cases this should be a drop-in replacement but users are encourage to test performance
+carefully after upgrading. See issue [#1938](https://github.com/slick/slick/issues/1938) for details.  
+
+### PostgreSQL `java.time` mappings
+
+The following bug fixes are highlighted here because they change the default mapping behaviour for some `java.time`
+columns in PostgreSQL:
+
+- `java.time.Instant.MIN` and `java.time.Instant.MAX` are now correctly mapped to `-infinity` and `infinity` 
+- respectively in PostgreSQL profile ([#2237](https://github.com/slick/slick/issues/2237))
+- changes to handling of timezone part of `java.time.Instant` in PostgreSQL profile ([#2005](https://github.com/slick/slick/issues/2005))
 
 Upgrade from 3.2 to 3.3
 -----------------------

--- a/doc/paradox/upgrade.md
+++ b/doc/paradox/upgrade.md
@@ -58,7 +58,7 @@ The following bug fixes are highlighted here because they change the default map
 columns in PostgreSQL:
 
 - `java.time.Instant.MIN` and `java.time.Instant.MAX` are now correctly mapped to `-infinity` and `infinity` 
-- respectively in PostgreSQL profile ([#2237](https://github.com/slick/slick/issues/2237))
+  respectively in PostgreSQL profile ([#2237](https://github.com/slick/slick/issues/2237))
 - changes to handling of timezone part of `java.time.Instant` in PostgreSQL profile ([#2005](https://github.com/slick/slick/issues/2005))
 
 Upgrade from 3.2 to 3.3


### PR DESCRIPTION
Changes to top-level `README.md`

- expand top section (copy taken from main docs site)
- add "Resources" section with links to docs, gitter, github issues, and the underscore.io book
- add simple example code (copy taken from main docs site)
- make "Contributing" a bit more welcoming

Changes to `upgrade.md`

- add section for migration from `3.3 -> 3.4` upgrade