### PR TITLE
.github/workflows: generate fewer runs

### DIFF
--- a/.github/workflows/check-scaladoc-links.yml
+++ b/.github/workflows/check-scaladoc-links.yml
@@ -4,7 +4,7 @@ on:
  pull_request:
    branches: ['**']
  push:
-   branches: ['**']
+   branches: ['main']
    tags: ['**']
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
  pull_request:
    branches: ['**']
  push:
-   branches: ['**']
+   branches: ['main']
    tags: [v*]
 
 jobs:
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
       matrix:
         java: [8, 11, 17]
         scala: [2.12.15, 2.13.8]


### PR DESCRIPTION
 - Don't disable fail-fast
 - Push event should only trigger for branch `main`