### PR TITLE
build.sbt: testAll should run versionPolicyCheck on actual modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -340,7 +340,10 @@ lazy val root =
           codegen / Compile / packageDoc,
           hikaricp / Compile / packageDoc,
           testkit / Compile / packageDoc,
-          versionPolicyCheck
+          slick / versionPolicyCheck,
+          testkit / versionPolicyCheck,
+          hikaricp / versionPolicyCheck,
+          codegen / versionPolicyCheck
         ).value
       }
     )


### PR DESCRIPTION
Was just running it on root, I think