### PR TITLE
Attach base statement as child for asTry dumpInfo

### DIFF
--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -358,7 +358,7 @@ case class FailedAction[-E <: Effect](a: DBIOAction[_, NoStream, E]) extends DBI
 
 /** A DBIOAction that represents an `asTry` operation. */
 case class AsTryAction[+R, -E <: Effect](a: DBIOAction[R, NoStream, E]) extends DBIOAction[Try[R], NoStream, E] {
-  def getDumpInfo = DumpInfo("asTry")
+  def getDumpInfo = DumpInfo("asTry", children = Vector(("try", a)))
 }
 
 /** A DBIOAction that attaches a name for logging purposes to another action. */


### PR DESCRIPTION
The `getDumpInfo` method of `asTry` should have the action that is to be tried as a child for logging purposes.

This is my first contribution here, sorry if there's a template I need to be following or something. I created [this issue](https://github.com/slick/slick/issues/2583) for the problem and this single line is all that's needed for the solution. I am happy to add tests if reviewers think it appropriate but I followed exactly the convention established in `CleanUpAction`