### PR TITLE
Doc/generic jdbc connection

### DIFF
--- a/doc/code/GenericJdbcProfile.scala
+++ b/doc/code/GenericJdbcProfile.scala
@@ -1,5 +1,7 @@
+//#genericJdbcProfile
 package com.typesafe.slick.docs
 
 import slick.jdbc.JdbcProfile
 
 object GenericJdbcProfile extends JdbcProfile
+//#genericJdbcProfile

--- a/doc/code/GenericJdbcProfile.scala
+++ b/doc/code/GenericJdbcProfile.scala
@@ -1,0 +1,5 @@
+package com.typesafe.slick.docs
+
+import slick.jdbc.JdbcProfile
+
+object GenericJdbcProfile extends JdbcProfile

--- a/doc/code/application.conf
+++ b/doc/code/application.conf
@@ -62,3 +62,16 @@ altDatabaseUrl {
   }
 }
 //#altdburl
+
+//#databricks_db
+databricks_db {
+  profile = "db.MyProfile$"
+  db {
+    driver = "com.databricks.client.jdbc.Driver"
+    url = "jdbc:databricks://DATABRICKS_HOST:443;HttpPath=/sql/1.0/endpoints/XXXXXXXXX;TransportMode=http;SSL=1"
+    PWD = "????????????"
+    UID = "token"
+    AuthMech = "3"
+  }
+}
+//#databricks_db

--- a/doc/code/application.conf
+++ b/doc/code/application.conf
@@ -65,7 +65,7 @@ altDatabaseUrl {
 
 //#databricks_db
 databricks_db {
-  profile = "db.MyProfile$"
+  profile = "com.typesafe.slick.docs.GenericJdbcProfile$"
   db {
     driver = "com.databricks.client.jdbc.Driver"
     url = "jdbc:databricks://DATABRICKS_HOST:443;HttpPath=/sql/1.0/endpoints/XXXXXXXXX;TransportMode=http;SSL=1"

--- a/doc/paradox/database.md
+++ b/doc/paradox/database.md
@@ -186,18 +186,8 @@ empty object. Not overriding any fields or methods provides basic functionality.
 @@snip [GenericJdbcProfile.scala](../code/GenericJdbcProfile.scala) { #genericJdbcProfile }
 
 This profile can then be used in the configuration.
-```conf
-databricks_db {
-  profile = "db.MyProfile$"
-  db {
-    driver = "com.databricks.client.jdbc.Driver"
-    url = "jdbc:databricks://DATABRICKS_HOST:443;HttpPath=/sql/1.0/endpoints/XXXXXXXXX;TransportMode=http;SSL=1"
-    PWD = "????????????"
-    UID = "token"
-    AuthMech = "3"
-  }
-}
-```
+
+@@snip [application.conf](../code/application.conf) { #databricks_db }
 
 Other Multi-DB Patterns
 -----------------------

--- a/doc/paradox/database.md
+++ b/doc/paradox/database.md
@@ -167,6 +167,38 @@ You can use different database systems in your application by either switching o
 config (e.g. different `application.conf` files for development and production) or by passing a config path into
 the application. This way of implementing multi-database support is also used when building a Play app with Slick.
 
+Generic JDBC Connection
+-----------------------
+Sometimes a database system provides a JDBC driver, but no specific profile for its dialect has been implemented
+for Slick, yet. It is still possible to connect to such a database with not much effort and use the generic JDBC
+feature set.
+
+Here is an example for setting up a connection to a Databricks DB.
+
+build.sbt
+```sbt
+libraryDependencies += "com.databricks" % "databricks-jdbc" % "2.6.29"
+```
+
+To configure the connection a profile is required. It is sufficient to extend the `JdbcProfile` trait with an
+empty object. Not overriding any fields or methods provides basic functionality.
+
+@@snip [GenericJdbcProfile.scala](../code/GenericJdbcProfile.scala) { #genericJdbcProfile }
+
+This profile can then be used in the configuration.
+```conf
+databricks_db {
+  profile = "db.MyProfile$"
+  db {
+    driver = "com.databricks.client.jdbc.Driver"
+    url = "jdbc:databricks://DATABRICKS_HOST:443;HttpPath=/sql/1.0/endpoints/XXXXXXXXX;TransportMode=http;SSL=1"
+    PWD = "????????????"
+    UID = "token"
+    AuthMech = "3"
+  }
+}
+```
+
 Other Multi-DB Patterns
 -----------------------
 

--- a/doc/paradox/database.md
+++ b/doc/paradox/database.md
@@ -56,6 +56,28 @@ To use the MySQL driver, the following library dependency needs to be configured
 libraryDependencies += "mysql" % "mysql-connector-java" % "6.0.6"
 ```
 
+##### Generic JDBC
+Sometimes a database system provides a JDBC driver, but no specific profile for its dialect has been implemented
+for Slick, yet. It is still possible to connect to such a database with not much effort and use the generic JDBC
+feature set.
+
+Here is an example for setting up a connection to a Databricks DB using the Databricks JDBC driver, depended on via SBT:
+```scala
+libraryDependencies += "com.databricks" % "databricks-jdbc" % "2.6.29"
+```
+
+To configure the connection a profile implementation is required. It is sufficient to extend the `JdbcProfile` trait with an
+empty object.
+
+@@snip [GenericJdbcProfile.scala](../code/GenericJdbcProfile.scala) { #genericJdbcProfile }
+
+Now this profile can be used in the configuration.
+
+@@snip [application.conf](../code/application.conf) { #databricks_db }
+
+Connection parameters for database systems can differ significantly.
+Please refer to the respective documentation.
+
 Using a JDBC URL
 ----------------
 
@@ -166,28 +188,6 @@ a matching type in the external configuration file. Since we're using the basic 
 You can use different database systems in your application by either switching out or overriding the application
 config (e.g. different `application.conf` files for development and production) or by passing a config path into
 the application. This way of implementing multi-database support is also used when building a Play app with Slick.
-
-Generic JDBC Connection
------------------------
-Sometimes a database system provides a JDBC driver, but no specific profile for its dialect has been implemented
-for Slick, yet. It is still possible to connect to such a database with not much effort and use the generic JDBC
-feature set.
-
-Here is an example for setting up a connection to a Databricks DB.
-
-build.sbt
-```sbt
-libraryDependencies += "com.databricks" % "databricks-jdbc" % "2.6.29"
-```
-
-To configure the connection a profile is required. It is sufficient to extend the `JdbcProfile` trait with an
-empty object. Not overriding any fields or methods provides basic functionality.
-
-@@snip [GenericJdbcProfile.scala](../code/GenericJdbcProfile.scala) { #genericJdbcProfile }
-
-This profile can then be used in the configuration.
-
-@@snip [application.conf](../code/application.conf) { #databricks_db }
 
 Other Multi-DB Patterns
 -----------------------


### PR DESCRIPTION
Guide to connect using any JDBC driver via a generic JdbcProfile implementation. The example uses a Databricks db.