### PR TITLE
use `CollectionConverters` instead of deprecated `JavaConverters`

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DBTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DBTest.scala
@@ -2,7 +2,7 @@ package com.typesafe.slick.testkit.util
 
 import slick.dbio.DBIO
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import org.junit.{After, Before}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/GitHubActionsRunListener.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/GitHubActionsRunListener.scala
@@ -3,7 +3,7 @@ package com.typesafe.slick.testkit.util
 import java.nio.file.{Files, Paths}
 import java.time.Duration
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.junit.runner.notification.{Failure, RunListener}
 import org.junit.runner.{Description, Result}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/SimpleParentRunner.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/SimpleParentRunner.scala
@@ -4,7 +4,7 @@ import org.junit.runner.{Runner, Description}
 import org.junit.runner.notification.{StoppedByUserException, Failure, RunNotifier}
 import org.junit.runner.manipulation.{Ordering => _, _}
 import org.junit.runners.model._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.lang.reflect.InvocationTargetException
 
 /**

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.{ConfigValueFactory, Config, ConfigFactory}
 import java.io.File
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import slick.SlickException
 

--- a/slick-testkit/src/test/scala/slick/test/jdbc/MBeansTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/MBeansTest.scala
@@ -11,7 +11,7 @@ import slick.jdbc.H2Profile.api._
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class MBeansTest {
 

--- a/slick-testkit/src/test/scala/slick/test/lifted/MySQLDDLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/MySQLDDLTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Test case for the MySQL SQL DDL overrides */
 @RunWith(classOf[Parameterized])

--- a/slick/src/main/scala/slick/jdbc/DriverDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DriverDataSource.scala
@@ -12,7 +12,7 @@ import slick.SlickException
 import slick.util.{ClassLoaderUtil, Logging, ignoreFollowOnError}
 
 import scala.beans.BeanProperty
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 /** A DataSource that wraps the DriverManager API. It can be configured as a Java Bean and used

--- a/slick/src/main/scala/slick/util/BeanConfigurator.scala
+++ b/slick/src/main/scala/slick/util/BeanConfigurator.scala
@@ -3,7 +3,7 @@ package slick.util
 import java.beans.Introspector
 import java.util.Properties
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.ConfigFactory
 

--- a/slick/src/main/scala/slick/util/GlobalConfig.scala
+++ b/slick/src/main/scala/slick/util/GlobalConfig.scala
@@ -49,7 +49,7 @@ object GlobalConfig {
 
 /** Extension methods to make Typesafe Config easier to use */
 class ConfigExtensionMethods(val c: Config) extends AnyVal {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   def getBooleanOr(path: String, default: => Boolean = false) = if(c.hasPath(path)) c.getBoolean(path) else default
   def getIntOr(path: String, default: => Int = 0) = if(c.hasPath(path)) c.getInt(path) else default

--- a/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
+++ b/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
@@ -182,7 +182,7 @@ class ManagedArrayBlockingQueue[E >: Null <: PrioritizedRunnable](maximumInUse: 
   }
 
   def iterator: util.Iterator[E] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     // copy all items from queues and build a snapshot
     val items = locked {


### PR DESCRIPTION
fix warnings.
we can use `CollectionConverters` because scala-collection-compat provide `CollectionConverters` for Scala 2.12

- https://github.com/scala/scala/blob/da17a60eba0bdefad8c80154875ab9da419f94e0/src/library/scala/collection/JavaConverters.scala#L78
- https://github.com/scala/scala-collection-compat/blob/56d849a612862ef3b91745b76fa93a47a295ed3d/compat/src/main/scala-2.11_2.12/scala/jdk/CollectionConverters.scala