### PR TITLE
Add exceptionOverrideClassName config for HikariCP

### DIFF
--- a/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
+++ b/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala
@@ -44,6 +44,7 @@ object HikariCPJdbcDataSource extends JdbcDataSourceFactory {
 
     // Frequently used pool configuration
     c.getBooleanOpt("autoCommit").foreach(hconf.setAutoCommit)
+    c.getStringOpt("exceptionOverrideClassName").foreach(hconf.setExceptionOverrideClassName)
 
     val numThreads = c.getIntOr("numThreads", 20)
 

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -266,6 +266,7 @@ trait JdbcBackend extends RelationalBackend {
       *         connection leak. A value of 0 means leak detection is disabled. Lowest acceptable value
       *         for enabling leak detection is 10s.</li>
       *       <li>`schema` (String, optional): Default catalog for new connections.</li>
+      *       <li>`exceptionOverrideClassName` (String, optional): SQLExceptionOverride class name</li>
       *     </ul>
       *   </li>
       *   <li>Driver or DataSource configuration:


### PR DESCRIPTION
This aims to use HikariCP's exception override function.

https://github.com/brettwooldridge/HikariCP/blob/58b87f4be23642dffd7daca912de23b8bc25f44b/src/main/java/com/zaxxer/hikari/HikariConfig.java#L877

Usecase of this is for avoiding to evict connection when some SQLException is occurred.  
AWS JDBC Driver for MySQL is one of the example that needs the function.

https://github.com/awslabs/aws-mysql-jdbc#connection-pooling