### PR TITLE
build.sbt: set site description setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -276,6 +276,7 @@ lazy val site: Project =
     .in(file("doc"))
     .enablePlugins(Docs)
     .settings(
+      description := "Scala Slick documentation",
       scaladocDirs := Seq(
         "api" -> (slick / Compile / doc).value,
         "codegen-api" -> (codegen / Compile / doc).value,


### PR DESCRIPTION
Should be used in the site description meta tag,
per https://developer.lightbend.com/docs/paradox/current/configuration.html