### PR TITLE
Avoid compiling entire project on Intellij import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,10 +157,11 @@ lazy val testkit =
   project
     .in(file("slick-testkit"))
     .configs(DocTest)
-    .dependsOn(slick, codegen % "compile->compile", hikaricp)
+    .dependsOn(slick, codegen % s"compile->compile;${TypeProviders.TypeProvidersConfig.name}->test", hikaricp)
     .settings(
       slickGeneralSettings,
-      compilerDependencySetting("provided"),
+      compilerDependencySetting(Provided.name),
+      compilerDependencySetting(TypeProviders.TypeProvidersConfig.name),
       inConfig(DocTest)(Defaults.testSettings),
       TypeProviders.codegenSettings,
       extTarget("testkit"),
@@ -181,7 +182,7 @@ lazy val testkit =
         Dependencies.junit ++:
           (Dependencies.reactiveStreamsTCK % Test) +:
           (Dependencies.logback +: Dependencies.testDBs).map(_ % Test) ++:
-          (Dependencies.logback +: Dependencies.testDBs).map(_ % "codegen"),
+          (Dependencies.logback +: Dependencies.testDBs).map(_ % TypeProviders.TypeProvidersConfig),
       run / fork := true,
       //connectInput in run := true,
       run / javaOptions += "-Dslick.ansiDump=true",

--- a/project/TypeProviders.scala
+++ b/project/TypeProviders.scala
@@ -7,18 +7,16 @@ object TypeProviders {
 
   /** Slick type provider code gen  */
   val typeProviders = taskKey[Seq[File]]("Type provider code generation")
-  val TypeProvidersConfig = config("codegen").hide
-  val CompileConfig = config("compile")
+  val TypeProvidersConfig = config("codegen").hide.extend(Compile)
+  private val Test = sbt.Test.extend(TypeProvidersConfig)
   def codegenSettings = {
     inConfig(TypeProvidersConfig)(Defaults.configSettings) ++
+    inConfig(Test)(Defaults.configSettings) ++
     Seq(
       Test / sourceGenerators += typeProviders.taskValue,
       typeProviders := typeProvidersTask.value,
-      ivyConfigurations += TypeProvidersConfig.extend(Compile),
-      (Test / compile) := ((Test / compile) dependsOn (TypeProvidersConfig / compile)).value,
-      TypeProvidersConfig / unmanagedClasspath ++= (CompileConfig / fullClasspath).value,
-      TypeProvidersConfig / unmanagedClasspath ++= (LocalProject("codegen") / Test / fullClasspath).value,
-      Test / unmanagedClasspath ++= (TypeProvidersConfig / fullClasspath).value,
+      ivyConfigurations += TypeProvidersConfig,
+      ivyConfigurations += Test,
       Test / packageSrc / mappings ++= {
         val src = (Test / sourceDirectory).value / "codegen"
         val inFiles = src ** "*.scala"


### PR DESCRIPTION
Use declarative dependencies instead of calling fullClasspath directly