### PR TITLE
Resolving stack overflow in MySQLQueryBuilder

### DIFF
--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -241,7 +241,7 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
           case node => expr(node)
         }
         b"\)"
-      case _ => super.expr(n, skipParens)
+      case _ => super.expr(n)
     }
 
     override protected def buildFetchOffsetClause(fetch: Option[Node], offset: Option[Node]) = (fetch, offset) match {


### PR DESCRIPTION
Hi there 👋

I tried the Scala3-supported Slick with MySQL and got a stack overflow.

The [expr](https://github.com/slick/slick/pull/2187/files#diff-776df962449d573db74a1079763acd22d5652df82b6458d32007bc8937c02742R316) method is created with the same naming and arguments as the existing one, and it is changed to call the expr method of the process that has been performed so far.
In this case, if the expr method is overwritten in the inheritance destination and the newly created expr method is called, the expr method called in the process will call the one overwritten by itself, resulting in an infinite loop.

If there is a condition match within an expr method that has been overridden in the inherited destination that does not match, change it so that the newly created non-expr method of the direct inheritance source is called.

Since other classes that inherit from QueryBuilder seemed to have similar fixes, it is assumed that only MySQL omitted to support this.

https://github.com/alexFrankfurt/slick/pull/1 Reproductions

## Version used
- Scala 3.2.0
- Slick 3.5.0 (Latest in nafg/dottyquery branch)

## Executable code

```scala
case class Person(
  id:   Option[Long],
  name: String,
  age:  Option[Int],
)

class PersonTable(tag: Tag) extends Table[Person](tag, "person"):
  def id   = column[Long]("id", O.PrimaryKey, O.AutoInc)
  def name = column[String]("name")
  def age  = column[Option[Int]]("age")

  def * = (id.?, name, age).mapTo[Person]

object Example:

  private val dataSource = ???

  private val personTable = TableQuery[PersonTable]
  private val db = Database.forDataSource(dataSource, None)

  def main(args: Array[String]): Unit =
    val query = for {
      p <- personTable.filter(_.name === "takapi327")
    } yield p.name
    val result = db.run(query.result.headOption)
    result.map(println(_))

    Await.result(result, Duration.Inf)
    db.close
```

## Error Description
```shell
[error] Exception in thread "main" java.lang.StackOverflowError
[error]         at slick.jdbc.MySQLProfile$MySQLQueryBuilder.expr(MySQLProfile.scala:216)
[error]         at slick.jdbc.JdbcStatementBuilderComponent$QueryBuilder.expr$$anonfun$1(JdbcStatementBuilderComponent.scala:317)
[error]         at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[error]         at slick.jdbc.JdbcStatementBuilderComponent$QueryBuilder.withSkipParens(JdbcStatementBuilderComponent.scala:125)
[error]         at slick.jdbc.JdbcStatementBuilderComponent$QueryBuilder.expr(JdbcStatementBuilderComponent.scala:317)
[error]         at slick.jdbc.MySQLProfile$MySQLQueryBuilder.expr(MySQLProfile.scala:228)
...
[error] Nonzero exit code returned from runner: 1
```
