### PR TITLE
Remove headOption extension method for ReadAheadIterator

### DIFF
--- a/slick/src/main/scala/slick/util/ReadAheadIterator.scala
+++ b/slick/src/main/scala/slick/util/ReadAheadIterator.scala
@@ -45,11 +45,3 @@ trait ReadAheadIterator[+T] extends BufferedIterator[T] {
     } else throw new NoSuchElementException("next on empty iterator");
   }
 }
-
-object ReadAheadIterator {
-
-  /** Feature implemented in Scala library 2.12 this maintains functionality for 2.11 */
-  final implicit class headOptionReverseCompatibility[T](val readAheadIterator: ReadAheadIterator[T]) extends AnyVal {
-    def headOption : Option[T] = if (readAheadIterator.hasNext) Some(readAheadIterator.head) else None
-  }
-}


### PR DESCRIPTION
It hasn't been needed since Scala 2.11 was dropped.

See #1573