### PR TITLE
Revert drop scala 212

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 17 ]
-        scala: [ 2.13.x ]
+        scala: [ 2.12.x, 2.13.x ]
 
     services:
       postgres:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,9 @@ pull_request_rules:
 
   - name: Automatic merge on approval
     conditions:
+      - "check-success=Build and Test (8, 2.12.x)"
       - "check-success=Build and Test (8, 2.13.x)"
+      - "check-success=Build and Test (17, 2.12.x)"
       - "check-success=Build and Test (17, 2.13.x)"
       - "#changes-requested-reviews-by=0"
       - or:

--- a/build.sbt
+++ b/build.sbt
@@ -33,16 +33,7 @@ inThisBuild(
         Developer("szeiger", "Stefan Zeiger", "", url("http://szeiger.de")),
         Developer("hvesalai", "Heikki Vesalainen", "", url("https://github.com/hvesalai/"))
       ),
-    scmInfo := Some(ScmInfo(url("https://github.com/slick/slick"), "scm:git:git@github.com:slick/slick.git")),
-    scalacOptions ++=
-      List(
-        "-deprecation",
-        "-feature",
-        "-unchecked",
-        "-Xsource:3",
-        "-Wunused:imports",
-        "-Wconf:cat=unused-imports&src=src_managed/.*:silent"
-      )
+    scmInfo := Some(ScmInfo(url("https://github.com/slick/slick"), "scm:git:git@github.com:slick/slick.git"))
   )
 )
 
@@ -63,6 +54,24 @@ def slickGeneralSettings =
       _.withConfigurations(Vector(Compile, Runtime, Optional))
     },
     sonatypeProfileName := "com.typesafe.slick",
+    scalacOptions ++=
+      List(
+        "-deprecation",
+        "-feature",
+        "-unchecked",
+        "-Xsource:3",
+        "-Wconf:cat=unused-imports&src=src_managed/.*:silent"
+      ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 12)) => List("-Ywarn-unused:imports", "-language:higherKinds")
+        case Some((2, 13)) =>
+          List(
+            "-Wunused:imports",
+            "-Wconf:cat=unused-imports&origin=scala\\.collection\\.compat\\._:s",
+            "-Wconf:cat=deprecation&origin=scala\\.math\\.Numeric\\.signum:s"
+          )
+        case _             =>
+          Nil
+      }),
     Compile / doc / scalacOptions ++= Seq(
       "-doc-title", name.value,
       "-doc-version", version.value,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.*
 
 /** Dependencies for reuse in different parts of the build */
 object Dependencies {
@@ -9,8 +9,9 @@ object Dependencies {
   val reactiveStreamsVersion = "1.0.4"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
   val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.10.0"
 
-  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
+  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams, scalaCollectionCompat)
 
   val junit = Seq(
     "junit" % "junit-dep" % "4.11",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 /** Dependencies for reuse in different parts of the build */
 object Dependencies {
-  val scalaVersions = Seq("2.13.11") // When updating these also update ci.yml and .mergify.yml
+  val scalaVersions = Seq("2.12.17", "2.13.11") // When updating these also update ci.yml and .mergify.yml
 
   val slf4j = "org.slf4j" % "slf4j-api" % "2.0.7"
   val typesafeConfig = "com.typesafe" % "config" % "1.4.2"

--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -1,6 +1,8 @@
 package slick.codegen
 
-import slick.{SlickException, model => m}
+import scala.collection.compat.*
+
+import slick.{SlickException, model as m}
 import slick.ast.ColumnOption
 import slick.model.ForeignKeyAction
 import slick.relational.RelationalProfile
@@ -254,9 +256,10 @@ class $name(_tableTag: Tag) extends profile.api.Table[$elementType](_tableTag, $
     }
 
     class AbstractSourceCodeColumnDef(model: m.Column) extends AbstractColumnDef(model) {
-      import ColumnOption._
-      import RelationalProfile.ColumnOption._
-      import SqlProfile.ColumnOption._
+
+      import ColumnOption.*
+      import RelationalProfile.ColumnOption.*
+      import SqlProfile.ColumnOption.*
       def columnOptionCode = {
         case ColumnOption.PrimaryKey => Some(s"O.PrimaryKey")
         case Default(_)              => Some(s"O.Default(${default.get})") // .get is safe here
@@ -323,7 +326,7 @@ class $name(_tableTag: Tag) extends profile.api.Table[$elementType](_tableTag, $
         val fkExpr = compoundValue(fkColumns)
         val pkExpr = compoundValue(pkColumns)
         s"lazy val $name = " +
-          s"foreignKey(\"$dbName\", $fkExpr, $pkTable)(r => $pkExpr, onUpdate=$onUpdate, onDelete=$onDelete)"
+          s"""foreignKey("$dbName", $fkExpr, $pkTable)(r => $pkExpr, onUpdate=$onUpdate, onDelete=$onDelete)"""
       }
     }
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -4,6 +4,7 @@ import java.lang.reflect.Method
 import java.util.concurrent.{ExecutionException, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.collection.compat.*
 import scala.concurrent.*
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag

--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -1,5 +1,6 @@
 package slick.ast
 
+import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -1,7 +1,8 @@
 package slick.ast
 
 import scala.annotation.{implicitNotFound, tailrec}
-import scala.collection.{mutable, Factory}
+import scala.collection.compat.*
+import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.reflect.{ClassTag, classTag as mkClassTag}
 

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -3,6 +3,7 @@ package slick.basic
 import java.io.Closeable
 import java.util.concurrent.atomic.{AtomicLong, AtomicReferenceArray}
 
+import scala.collection.compat.*
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -1,15 +1,17 @@
 package slick.dbio
 
-import org.reactivestreams.Subscription
+import scala.collection.compat.*
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.{Factory, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import slick.SlickException
 import slick.basic.BasicBackend
-import slick.util.{DumpInfo, Dumpable, ignoreFollowOnError}
+import slick.util.{ignoreFollowOnError, Dumpable, DumpInfo}
+
+import org.reactivestreams.Subscription
 
 /** A Database I/O Action that can be executed on a database. The DBIOAction type allows a
   * separation of execution logic and resource usage management logic from composition logic.

--- a/slick/src/main/scala/slick/jdbc/Invoker.scala
+++ b/slick/src/main/scala/slick/jdbc/Invoker.scala
@@ -1,7 +1,7 @@
 package slick.jdbc
 
-import scala.annotation.unchecked.uncheckedVariance as uV
-import scala.collection.Factory
+import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.compat.*
 
 import slick.util.CloseableIterator
 
@@ -37,7 +37,8 @@ trait Invoker[+R] { self =>
   }
 
   /** Execute the statement and return a fully materialized collection. */
-  final def buildColl[C[_]](implicit session: JdbcBackend#Session, canBuildFrom: Factory[R, C[R @uV]]): C[R @uV] = {
+  final def buildColl[C[_]](implicit session: JdbcBackend#Session,
+                            canBuildFrom: Factory[R, C[R @uncheckedVariance]]): C[R @uncheckedVariance] = {
     val b = canBuildFrom.newBuilder
     foreach({ x => b += x }, 0)
     b.result()

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -2,6 +2,7 @@ package slick.jdbc
 
 import java.sql.{PreparedStatement, Statement}
 
+import scala.collection.compat.*
 import scala.collection.mutable.Builder
 import scala.language.existentials
 import scala.util.control.NonFatal

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -6,6 +6,7 @@ import java.net.URL
 import java.sql.{Array as _, *}
 import java.util.Calendar
 
+import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 
 import slick.jdbc.JdbcBackend.{benchmarkLogger, parameterLogger, statementAndParameterLogger, statementLogger}

--- a/slick/src/main/scala/slick/jdbc/PositionedResult.scala
+++ b/slick/src/main/scala/slick/jdbc/PositionedResult.scala
@@ -1,9 +1,9 @@
 package slick.jdbc
 
 import java.io.Closeable
-import java.sql.{Array as _, *}
+import java.sql.{Blob, Clob, Date, ResultSet, Time, Timestamp, Array as _}
 
-import scala.collection.Factory
+import scala.collection.compat.*
 
 import slick.util.{CloseableIterator, ReadAheadIterator}
 

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -2,6 +2,7 @@ package slick.jdbc
 
 import java.sql.PreparedStatement
 
+import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 
 import slick.util.{CloseableIterator, SlickLogger, TableDump}

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -2,6 +2,7 @@ package slick.jdbc
 
 import java.sql.PreparedStatement
 
+import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
@@ -32,7 +33,7 @@ object SQLInterpolation {
     else {
       val b = new StringBuilder
       val remaining = new ArrayBuffer[SetParameter[Unit]]
-      typedParams.zip(strings.iterator).foreach { zipped =>
+      typedParams.zip(strings.iterator.to(Iterable)).foreach { zipped =>
         val p = zipped._1.param
         var literal = false
         def decode(s: String): String =

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -3,6 +3,7 @@ package slick.lifted
 
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.compat.*
 import scala.language.experimental.macros
 import scala.language.implicitConversions
 import scala.reflect.ClassTag

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -1,15 +1,17 @@
 package slick.memory
 
+import scala.collection.compat.*
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.util.{Failure, Try}
+
+import slick.SlickException
+import slick.basic.BasicBackend
+import slick.relational.RelationalBackend
+import slick.util.Logging
+
 import com.typesafe.config.Config
 import org.reactivestreams.Subscriber
-
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.{ExecutionContext, Future, blocking}
-import scala.util.{Failure, Try}
-import slick.SlickException
-import slick.relational.RelationalBackend
-import slick.basic.BasicBackend
-import slick.util.Logging
 
 /** The backend for DistributedProfile. */
 trait DistributedBackend extends RelationalBackend with Logging {

--- a/slick/src/main/scala/slick/memory/DistributedProfile.scala
+++ b/slick/src/main/scala/slick/memory/DistributedProfile.scala
@@ -1,5 +1,6 @@
 package slick.memory
 
+import scala.collection.compat.*
 import scala.collection.mutable
 
 import slick.SlickException

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -2,18 +2,18 @@ package slick.memory
 
 import java.util.concurrent.atomic.AtomicLong
 
-import com.typesafe.config.Config
-
-import org.reactivestreams.Subscriber
-
+import scala.collection.compat.*
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
-import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.{ExecutionContext, Future}
 
 import slick.SlickException
-import slick.ast._
-import slick.lifted.{PrimaryKey, Constraint, Index}
-import slick.relational.{RelationalProfile, RelationalBackend}
+import slick.ast.*
+import slick.lifted.{Constraint, Index, PrimaryKey}
+import slick.relational.{RelationalBackend, RelationalProfile}
 import slick.util.Logging
+
+import com.typesafe.config.Config
+import org.reactivestreams.Subscriber
 
 /** A simple database engine that stores data in heap data structures. */
 trait HeapBackend extends RelationalBackend with Logging {

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -1,5 +1,6 @@
 package slick.memory
 
+import scala.collection.compat.*
 import scala.collection.mutable
 import scala.language.existentials
 import scala.reflect.ClassTag

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -410,9 +410,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
       var len = s.length
       while(len > 0 && s.charAt(len-1) == ' ') len -= 1
       if(len == s.length) s else s.substring(0, len)
-    case Library.Sign =>
-      val n = args(0)._1.asInstanceOf[ScalaNumericType[Any]].numeric
-      n.toInt(n.sign(args(0)._2))
+    case Library.Sign => args(0)._1.asInstanceOf[ScalaNumericType[Any]].numeric.signum(args(0)._2)
     case Library.Trim => args(0)._2.asInstanceOf[String].trim
     case Library.UCase => args(0)._2.asInstanceOf[String].toUpperCase
     case Library.User => ""

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -2,8 +2,9 @@ package slick.memory
 
 import java.util.regex.Pattern
 
+import scala.collection.compat.*
 import scala.collection.mutable
-import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.collection.mutable.ArrayBuffer
 
 import slick.SlickException
 import slick.ast.*
@@ -29,7 +30,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
   override protected[this] lazy val logger = new SlickLogger(LoggerFactory.getLogger(classOf[QueryInterpreter]))
   import QueryInterpreter.*
 
-  val scope = new HashMap[TermSymbol, Any]
+  val scope = new mutable.HashMap[TermSymbol, Any]
   var indent = 0
   type Coll = Iterable[Any]
 
@@ -187,7 +188,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         b.result()
       case GroupBy(gen, from, by, _) =>
         val fromV = run(from).asInstanceOf[Coll]
-        val grouped = new HashMap[Any, ArrayBuffer[Any]]()
+        val grouped = new mutable.HashMap[Any, ArrayBuffer[Any]]()
         fromV.foreach { v =>
           scope(gen) = v
           grouped.getOrElseUpdate(run(by), new ArrayBuffer[Any]()) += v

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -3,6 +3,7 @@ package slick.util
 import java.util.Arrays
 
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.compat.*
 import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3

--- a/slick/src/main/scala/slick/util/TableDump.scala
+++ b/slick/src/main/scala/slick/util/TableDump.scala
@@ -1,8 +1,9 @@
 package slick.util
 
+import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 
-import slick.util.LogUtil._
+import slick.util.LogUtil.*
 
 /** Utility methods for creating result set debug output. */
 class TableDump(maxColumnWidth: Int = 20) {


### PR DESCRIPTION
As discussed in https://github.com/slick/slick/issues/2177 this PR adds back support for Scala 2.12 in Slick

@nafg Note that I have tried this change ontop of the https://github.com/slick/slick/tree/nafg/dottyquery branch and it fails to compile because the branch assumes Scala 2.13, i.e. you will need to modify https://github.com/slick/slick/blob/a1e9de093134174cdb9f020e7ab371eee0f89a30/build.sbt#L60 so that you use the Scala 2.12 equivalent of `-Wunused:imports` with `CrossVersion.partialVersion(scalaVersion.value)` or `scalaBinaryVersion.value`.