### PR TITLE
Only use scala-collection-compat for Scala 2.12

### DIFF
--- a/doc/paradox/upgrade.md
+++ b/doc/paradox/upgrade.md
@@ -35,6 +35,19 @@ Upgrade from 3.4.x to 3.5.0
 - `SynchronousDatabaseAction` has 5 type parameters instead of 4. See for instance
   https://github.com/tminglei/slick-pg/pull/651/files#diff-208b921209dd4b53867be1f55f1fa054d81f6473575ae4b7efd960a3d8c7a298L17
 
+### Dependency upgrades
+
+Slick 3.5.x drops [scala-collection-compat](https://github.com/scala/scala-collection-compat) for Scala versions
+2.13 and higher. This shouldn't affect end users unless you happen to be transitively relying on
+`scala-collection-compat` on a version of Scala 2.13 or higher. If this is the case then it's recommended to migrate
+your codebase away from `scala-collection-compat`, otherwise if this is not possible then you can just add the
+
+```sbt
+"org.scala-lang.modules" %% "scala-collection-compat" % "2.10.0"
+```
+
+dependency manually.
+
 Upgrade from 3.3.x to 3.4.0
 -----------------------
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,5 @@
 import sbt.*
+import sbt.Keys.scalaVersion
 
 /** Dependencies for reuse in different parts of the build */
 object Dependencies {
@@ -13,9 +14,17 @@ object Dependencies {
   val reactiveStreamsVersion = "1.0.4"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion
   val reactiveStreamsTCK = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion
-  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
 
-  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams, scalaCollectionCompat)
+  val scalaCollectionCompat = Def.setting {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n == 12 =>
+        Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0")
+      case _ =>
+        Seq.empty
+    }
+  }
+
+  def mainDependencies = Seq(slf4j, typesafeConfig, reactiveStreams)
 
   val junit = Seq(
     "junit" % "junit-dep" % "4.11",

--- a/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractSourceCodeGenerator.scala
@@ -1,12 +1,12 @@
 package slick.codegen
 
-import scala.collection.compat.*
 
 import slick.{SlickException, model as m}
 import slick.ast.ColumnOption
 import slick.model.ForeignKeyAction
 import slick.relational.RelationalProfile
 import slick.sql.SqlProfile
+import slick.compat.collection.*
 
 /** Base implementation for a Source code String generator */
 abstract class AbstractSourceCodeGenerator(model: m.Model)
@@ -319,8 +319,8 @@ class $name(_tableTag: Tag) extends profile.api.Table[$elementType](_tableTag, $
           else if(!p.model.nullable && f.model.nullable) (s"Rep.Some($pk)", fk)
           else (pk, fk)
         }.unzip
-        val fkExpr = compoundValue(fkColumns)
-        val pkExpr = compoundValue(pkColumns)
+        val fkExpr = compoundValue(fkColumns.toSeq)
+        val pkExpr = compoundValue(pkColumns.toSeq)
         s"lazy val $name = " +
           s"""foreignKey("$dbName", $fkExpr, $pkTable)(r => $pkExpr, onUpdate=$onUpdate, onDelete=$onDelete)"""
       }

--- a/slick-compat-collections/src/main/scala-2.12/slick/compat/collection/CompatImpl.scala
+++ b/slick-compat-collections/src/main/scala-2.12/slick/compat/collection/CompatImpl.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package slick.compat.collection
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
+
+/**
+ * INTERNAL API
+ *
+ * Based on https://github.com/scala/scala-collection-compat/blob/master/compat/src/main/scala-2.11_2.12/scala/collection/compat/CompatImpl.scala
+ * but reproduced here so we don't need to add a dependency on this library. It contains much more than we need right now, and is
+ * not promising binary compatibility yet at the time of writing.
+ */
+private[collection] object CompatImpl {
+  def simpleCBF[A, C](f: => Builder[A, C]): CanBuildFrom[Any, A, C] = new CanBuildFrom[Any, A, C] {
+    def apply(from: Any): Builder[A, C] = apply()
+    def apply(): Builder[A, C] = f
+  }
+}

--- a/slick-compat-collections/src/main/scala-2.12/slick/compat/collection/package.scala
+++ b/slick-compat-collections/src/main/scala-2.12/slick/compat/collection/package.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package slick.compat
+
+import scala.collection as c
+import scala.collection.{GenTraversable, IterableView, immutable as i, mutable as m}
+import scala.collection.generic.{CanBuildFrom, GenericCompanion, Sorted, SortedSetFactory}
+import scala.language.higherKinds
+import scala.language.implicitConversions
+import scala.runtime.Tuple2Zipped
+
+/**
+ * INTERNAL API
+ *
+ * Based on https://github.com/scala/scala-collection-compat/blob/master/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+ * but reproduced here so we don't need to add a dependency on this library. It contains much more than we need right now, and is
+ * not promising binary compatibility yet at the time of writing.
+ */
+package object collection {
+  import CompatImpl.*
+
+  /**
+   * A factory that builds a collection of type `C` with elements of type `A`.
+   *
+   * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+   */
+  private[slick] type Factory[-A, +C] = CanBuildFrom[Nothing, A, C]
+
+  private[slick] type LazyList[+T] = scala.collection.immutable.Stream[T]
+  private[slick] val LazyList = scala.collection.immutable.Stream
+
+  private[slick] implicit final class FactoryOps[-A, +C](private val factory: Factory[A, C]) {
+
+    /**
+     * @return A collection of type `C` containing the same elements
+     *         as the source collection `it`.
+     * @param it Source collection
+     */
+    def fromSpecific(it: TraversableOnce[A]): C = (factory() ++= it).result()
+
+    /**
+     * Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+     * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections.
+     */
+    def newBuilder: m.Builder[A, C] = factory()
+  }
+
+  implicit class IterableFactoryExtensionMethods[CC[X] <: GenTraversable[X]]
+    (private val fact: GenericCompanion[CC]) {
+      def from[A](source: TraversableOnce[A]): CC[A] =
+        fact.apply(source.toSeq: _*)
+  }
+
+  private[slick] implicit def genericCompanionToCBF[A, CC[X] <: GenTraversable[X]]
+    (fact: GenericCompanion[CC]): CanBuildFrom[Any, A, CC[A]] =
+      simpleCBF(fact.newBuilder[A])
+
+  private[slick] implicit def sortedSetCompanionToCBF[
+    A: Ordering, CC[X] <: c.SortedSet[X] with c.SortedSetLike[X, CC[X]]]
+    (fact: SortedSetFactory[CC]): CanBuildFrom[Any, A, CC[A]] =
+      simpleCBF(fact.newBuilder[A])
+
+  private[slick] def build[T, CC](builder: m.Builder[T, CC], source: TraversableOnce[T]): CC = {
+    builder ++= source
+    builder.result()
+  }
+
+  private[slick] implicit final class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type) extends AnyVal {
+    def from[K: Ordering, V](source: TraversableOnce[(K, V)]): i.SortedMap[K, V] =
+      build(i.SortedMap.newBuilder[K, V], source)
+  }
+
+  private[slick] implicit final class ImmutableTreeMapExtensions(private val fact: i.TreeMap.type) extends AnyVal {
+    def from[K: Ordering, V](source: TraversableOnce[(K, V)]): i.TreeMap[K, V] =
+      build(i.TreeMap.newBuilder[K, V], source)
+  }
+
+  private[slick] implicit final class IterableExtensions(private val fact: Iterable.type) extends AnyVal {
+    def single[A](a: A): Iterable[A] = new Iterable[A] {
+      override def iterator = Iterator.single(a)
+      override def sizeHintIfCheap: Int = 1
+      override def hasDefiniteSize: Boolean = true
+      override def head = a
+      override def headOption = Some(a)
+      override def last = a
+      override def lastOption = Some(a)
+      override def view = new IterableView[A, Iterable[A]] {
+        override def iterator: Iterator[A] = Iterator.single(a)
+        override def sizeHintIfCheap: Int = 1
+        override def hasDefiniteSize: Boolean = true
+        override protected def underlying: Iterable[A] = this
+      }
+      override def take(n: Int) = if (n > 0) this else Iterable.empty
+      override def takeRight(n: Int) = if (n > 0) this else Iterable.empty
+      override def drop(n: Int) = if (n > 0) Iterable.empty else this
+      override def dropRight(n: Int) = if (n > 0) Iterable.empty else this
+      override def tail = Iterable.empty
+      override def init = Iterable.empty
+    }
+  }
+
+  private[slick] implicit final class SortedExtensionMethods[K, T <: Sorted[K, T]](private val fact: Sorted[K, T]) {
+    def rangeFrom(from: K): T = fact.from(from)
+    def rangeTo(to: K): T = fact.to(to)
+    def rangeUntil(until: K): T = fact.until(until)
+  }
+
+  // This really belongs into scala.collection but there's already a package object
+  // in scala-library so we can't add to it
+  type IterableOnce[+X] = c.TraversableOnce[X]
+  val IterableOnce = c.TraversableOnce
+
+  implicit def toMapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]]
+    (self: IterableView[(K, V), C]): MapViewExtensionMethods[K, V, C] =
+      new MapViewExtensionMethods[K, V, C](self)
+
+  implicit def toIterableExtensionMethods[A](self: Iterable[A]): IterableExtensionMethods[A] =
+    new IterableExtensionMethods[A](self)
+
+  implicit final class ImmutableSortedSetOps[A](val real: i.SortedSet[A]) extends AnyVal {
+    def unsorted: i.Set[A] = real
+  }
+
+  object JavaConverters extends scala.collection.convert.DecorateAsJava with scala.collection.convert.DecorateAsScala
+
+  implicit def toTraversableOnceExtensionMethods[A](self: TraversableOnce[A]): TraversableOnceExtensionMethods[A] =
+    new TraversableOnceExtensionMethods[A](self)
+}
+
+final class TraversableOnceExtensionMethods[A](private val self: c.TraversableOnce[A]) extends AnyVal {
+  def iterator: Iterator[A] = self.toIterator
+}
+
+final class MapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]]
+  (private val self: IterableView[(K, V), C]) extends AnyVal {
+    def mapValues[W, That](f: V => W)(implicit bf: CanBuildFrom[IterableView[(K, V), C], (K, W), That]): That =
+      self.map[(K, W), That] { case (k, v) => (k, f(v)) }
+
+    def filterKeys(p: K => Boolean): IterableView[(K, V), C] =
+      self.filter { case (k, _) => p(k) }
+}
+
+final class IterableExtensionMethods[A](private val self: Iterable[A]) extends AnyVal {
+  def lazyZip[B](that: Iterable[B]): Tuple2Zipped[A, Iterable[A], B, Iterable[B]] =
+    (self, that).zipped
+}

--- a/slick-compat-collections/src/main/scala-2.13+/slick/compat/collection/collection.scala
+++ b/slick-compat-collections/src/main/scala-2.13+/slick/compat/collection/collection.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package slick.compat
+
+package object collection {
+  private[slick] type Factory[-A, +C] = scala.collection.Factory[A, C]
+  private[slick] val Factory = scala.collection.Factory
+
+  private[slick] type LazyList[+T] = scala.collection.immutable.LazyList[T]
+  private[slick] val LazyList = scala.collection.immutable.LazyList
+
+  object JavaConverters
+    extends scala.collection.convert.AsJavaExtensions
+      with scala.collection.convert.AsScalaExtensions
+
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -4,7 +4,6 @@ import java.lang.reflect.Method
 import java.util.concurrent.{ExecutionException, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.compat.*
 import scala.concurrent.*
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
@@ -19,6 +18,7 @@ import slick.lifted.Rep
 import slick.relational.RelationalCapabilities
 import slick.sql.SqlCapabilities
 import slick.util.DumpInfo
+import slick.compat.collection.*
 
 import org.junit.runner.Description
 import org.junit.runner.notification.RunNotifier

--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -1,11 +1,11 @@
 package slick.ast
 
-import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 
 import slick.SlickException
 import slick.ast.TypeUtil.*
+import slick.compat.collection.LazyList
 import slick.util.{ConstArray, Dumpable, DumpInfo, GlobalConfig}
 
 /** A node in the Slick AST.

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -1,13 +1,13 @@
 package slick.ast
 
 import scala.annotation.{implicitNotFound, tailrec}
-import scala.collection.compat.*
 import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.reflect.{ClassTag, classTag as mkClassTag}
 
 import slick.SlickException
 import slick.util.{ConstArray, Dumpable, DumpInfo, TupleSupport}
+import slick.compat.collection.*
 
 /** Super-trait for all types */
 trait Type extends Dumpable {

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -3,7 +3,6 @@ package slick.basic
 import java.io.Closeable
 import java.util.concurrent.atomic.{AtomicLong, AtomicReferenceArray}
 
-import scala.collection.compat.*
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
@@ -11,6 +10,7 @@ import scala.util.control.NonFatal
 import slick.SlickException
 import slick.dbio.*
 import slick.util.*
+import slick.compat.collection.*
 import slick.util.AsyncExecutor.{Continuation, Fresh, Priority, WithConnection}
 
 import com.typesafe.config.Config

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -1,6 +1,5 @@
 package slick.dbio
 
-import scala.collection.compat.*
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,6 +9,7 @@ import scala.util.control.NonFatal
 import slick.SlickException
 import slick.basic.BasicBackend
 import slick.util.{ignoreFollowOnError, Dumpable, DumpInfo}
+import slick.compat.collection.*
 
 import org.reactivestreams.Subscription
 

--- a/slick/src/main/scala/slick/jdbc/Invoker.scala
+++ b/slick/src/main/scala/slick/jdbc/Invoker.scala
@@ -1,9 +1,9 @@
 package slick.jdbc
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.compat.*
 
 import slick.util.CloseableIterator
+import slick.compat.collection.*
 
 /** Base trait for all statement invokers of result element type R. */
 trait Invoker[+R] { self =>

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -2,7 +2,6 @@ package slick.jdbc
 
 import java.sql.{PreparedStatement, ResultSet, Statement}
 
-import scala.collection.compat.*
 import scala.collection.mutable.Builder
 import scala.language.existentials
 import scala.util.control.NonFatal
@@ -16,6 +15,7 @@ import slick.lifted.{CompiledStreamingExecutable, FlatShapeLevel, Query, Shape}
 import slick.relational.{CompiledMapping, ResultConverter}
 import slick.sql.{FixedSqlAction, FixedSqlStreamingAction, SqlActionComponent}
 import slick.util.{ignoreFollowOnError, DumpInfo, SQLBuilder}
+import slick.compat.collection.*
 
 
 trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -6,10 +6,10 @@ import java.net.URL
 import java.sql.{Array as _, *}
 import java.util.Calendar
 
-import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 
 import slick.jdbc.JdbcBackend.{benchmarkLogger, parameterLogger, statementAndParameterLogger, statementLogger}
+import slick.compat.collection.*
 import slick.util.TableDump
 
 /** A wrapper for `java.sql.Statement` that logs statements and benchmark results

--- a/slick/src/main/scala/slick/jdbc/PositionedResult.scala
+++ b/slick/src/main/scala/slick/jdbc/PositionedResult.scala
@@ -3,8 +3,7 @@ package slick.jdbc
 import java.io.Closeable
 import java.sql.{Blob, Clob, Date, ResultSet, Time, Timestamp, Array as _}
 
-import scala.collection.compat.*
-
+import slick.compat.collection.*
 import slick.util.{CloseableIterator, ReadAheadIterator}
 
 /**

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -2,9 +2,9 @@ package slick.jdbc
 
 import java.sql.PreparedStatement
 
-import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 
+import slick.compat.collection.*
 import slick.util.{CloseableIterator, SlickLogger, TableDump}
 
 import org.slf4j.LoggerFactory

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -2,13 +2,12 @@ package slick.jdbc
 
 import java.sql.PreparedStatement
 
-import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
 import slick.dbio.Effect
 import slick.sql.SqlStreamingAction
-
+import slick.compat.collection.*
 
 class ActionBasedSQLInterpolation(val s: StringContext) extends AnyVal {
   /** Build a SQLActionBuilder via string interpolation */

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -3,12 +3,12 @@ package slick.lifted
 
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.compat.*
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 import slick.SlickException
 import slick.ast.*
+import slick.compat.collection.*
 import slick.util.{ConstArray, ProductWrapper, TupleSupport}
 
 /** A type class that encodes the unpacking `Mixed => Unpacked` of a

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -1,6 +1,5 @@
 package slick.memory
 
-import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.{Failure, Try}
@@ -8,6 +7,7 @@ import scala.util.{Failure, Try}
 import slick.SlickException
 import slick.basic.BasicBackend
 import slick.relational.RelationalBackend
+import slick.compat.collection.*
 import slick.util.Logging
 
 import com.typesafe.config.Config

--- a/slick/src/main/scala/slick/memory/DistributedProfile.scala
+++ b/slick/src/main/scala/slick/memory/DistributedProfile.scala
@@ -1,6 +1,5 @@
 package slick.memory
 
-import scala.collection.compat.*
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -11,6 +10,7 @@ import slick.basic.{FixedBasicAction, FixedBasicStreamingAction}
 import slick.compiler.*
 import slick.dbio.*
 import slick.relational.{CompiledMapping, RelationalProfile, ResultConverter}
+import slick.compat.collection.*
 import slick.util.{??, DumpInfo, RefId}
 
 /** A profile for distributed queries. */
@@ -106,7 +106,7 @@ class DistributedProfile(val profiles: RelationalProfile*) extends MemoryQueryin
         ).toVector)
       case CollectionType(_, elType) =>
         val v = value.asInstanceOf[Iterable[?]]
-        val b = v.iterableFactory.newBuilder[Any]
+        val b = Iterable.newBuilder[Any]
         v.foreach(v => b += wrapScalaValue(v, elType))
         b.result()
       case _ => value

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -2,7 +2,6 @@ package slick.memory
 
 import java.util.concurrent.atomic.AtomicLong
 
-import scala.collection.compat.*
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -10,6 +9,7 @@ import slick.SlickException
 import slick.ast.*
 import slick.lifted.{Constraint, Index, PrimaryKey}
 import slick.relational.{RelationalBackend, RelationalProfile}
+import slick.compat.collection.*
 import slick.util.Logging
 
 import com.typesafe.config.Config

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -1,6 +1,5 @@
 package slick.memory
 
-import scala.collection.compat.*
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.existentials
@@ -12,6 +11,7 @@ import slick.basic.{FixedBasicAction, FixedBasicStreamingAction}
 import slick.compiler.*
 import slick.dbio.*
 import slick.relational.{CompiledMapping, RelationalProfile, ResultConverter, ResultConverterCompiler}
+import slick.compat.collection.*
 import slick.util.{??, DumpInfo}
 
 /** A profile for interpreted queries on top of the in-memory database. */

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -2,13 +2,13 @@ package slick.memory
 
 import java.util.regex.Pattern
 
-import scala.collection.compat.*
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import slick.SlickException
 import slick.ast.*
 import slick.ast.TypeUtil.typeToTypeUtil
+import slick.compat.collection.*
 import slick.util.{ConstArray, Logging, SlickLogger}
 
 import org.slf4j.LoggerFactory

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -3,9 +3,9 @@ package slick.util
 import java.util.Arrays
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.compat.*
 import scala.collection.immutable
 import scala.reflect.ClassTag
+import slick.compat.collection.*
 import scala.util.hashing.MurmurHash3
 
 /** An efficient immutable array implementation which is used in the AST. Semantics are generally

--- a/slick/src/main/scala/slick/util/TableDump.scala
+++ b/slick/src/main/scala/slick/util/TableDump.scala
@@ -1,8 +1,8 @@
 package slick.util
 
-import scala.collection.compat.*
 import scala.collection.mutable.ArrayBuffer
 
+import slick.compat.collection.*
 import slick.util.LogUtil.*
 
 /** Utility methods for creating result set debug output. */


### PR DESCRIPTION
The primary goal of this PR is to drop the `scala-collection-compat` dependency for Scala versions 2.13 and higher. This reduces a dependency for Slick users that don't use Scala 2.12 and it also means that when you decide to drop Scala 2.12 you can do so easily without breaking Scala 2.13+ users. At least with Akka/Pekko historically `scala-collection-compat `didn't have a stable binary ABI (which was the original reason why it was inlined in Akka/Pekko).