### PR TITLE
fix warning in `TransactionTest`

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TransactionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TransactionTest.scala
@@ -1,5 +1,6 @@
 package com.typesafe.slick.testkit.tests
 
+import com.typesafe.slick.testkit.tests.TransactionTest.ExpectedException
 import com.typesafe.slick.testkit.util.{AsyncTest, JdbcTestDB}
 
 import slick.jdbc.TransactionIsolation
@@ -16,7 +17,6 @@ class TransactionTest extends AsyncTest[JdbcTestDB] {
 
     val getTI = SimpleDBIO(_.connection.getTransactionIsolation)
 
-    class ExpectedException extends RuntimeException
 
     ts.schema.create andThen { // failed transaction
       (for {
@@ -73,4 +73,8 @@ class TransactionTest extends AsyncTest[JdbcTestDB] {
       } yield ()).withPinnedSession
     }}
   }
+}
+
+object TransactionTest {
+  private class ExpectedException extends RuntimeException
 }


### PR DESCRIPTION
avoid local class


```
[warn] -- Unchecked Warning: /home/runner/work/slick/slick/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TransactionTest.scala:27:55 
[warn] 27 |      } yield ()).transactionally.failed.map(_ should (_.isInstanceOf[ExpectedException]))
[warn]    |                                                       ^
[warn]    |the type test for ExpectedException cannot be checked at runtime because it's a local class
[warn] -- Unchecked Warning: /home/runner/work/slick/slick/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TransactionTest.scala:53:71 
[warn] 53 |      } yield ()).transactionally.transactionally.failed.map(_ should (_.isInstanceOf[ExpectedException]))
[warn]    |                                                                       ^
[warn]    |the type test for ExpectedException cannot be checked at runtime because it's a local class
```