### PR TITLE
build.sbt: buildCompatReport: include header,

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -294,14 +294,11 @@ lazy val site: Project =
         val file = (buildCompatReport / target).value / "compat-report.md"
         IO.write(
           file,
-          if (compatReports.forall(_.trim.isEmpty))
-            "There are no incompatible changes"
-          else
-            compatReports.sorted.mkString(
-              "## Incompatible changes\n\n",
-              "\n\n",
-              "\n"
-            )
+          "## Incompatible changes\n\n" +
+            (if (compatReports.forall(_.trim.isEmpty))
+              "There are no incompatible changes"
+            else
+              compatReports.sorted.mkString("", "\n\n", "\n"))
         )
         file
       },


### PR DESCRIPTION
regardless of whether there are incompatible changes or not.
This is required for the TOC.
