### PR TITLE
Explcitly handle this.type soundness reported as error since Scala 3.4.x

### DIFF
--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -180,7 +180,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
             try prit.close() catch ignoreFollowOnError
             throw ex
         }
-        if(state < 2) this else null
+        if(state < 2) this else null.asInstanceOf[this.type]
       }
       def end = if(state > 1) throw new SlickException("After end of result set") else state > 0
       override def toString = s"Mutator(state = $state, current = $current)"


### PR DESCRIPTION
After merging https://github.com/lampepfl/dotty/pull/17470 in 3.4.x and running Open Community Build we found out it is no longer compiling - [build logs](https://github.com/VirtusLab/community-build3/actions/runs/5836591202/job/15831389412). However, the compiler team has decided that that reason for that is not a new regression, but rather unsafe usage of `null` for method returning `this.type` which can lead to unsoundness. Without further inspection of code it's hard to decide if returning to null is unsafe for this use case. 

To allow for further testing this project in the Open Community Build I propose a temporary workaround which explcitly cast null to `this.type` to allow to pass compilation.