### PR TITLE
Fix `getOrElse` type inference issue in Scala 3, closes #2761

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/QueryMethodTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/QueryMethodTest.scala
@@ -67,5 +67,14 @@ class QueryMethodTest {
     val s12 = ts.filterNotIf(false)(_.myString endsWith "nope").filterNotIf(true)(_.myString === "stack").filterNotIf(true)(_.myString endsWith "yes").result.statements.head
     println(s12)
     assertTrue("filterNotIf stacks", s12 endsWith """where (not ("myString" = 'stack')) and (not ("myString" like '%yes' escape '^'))""")
+
+    val z = Rep.None[Int].getOrElse(0) //https://github.com/slick/slick/issues/2674
+    val s13 = z.result.statements.head
+    println(s13)
+    assertTrue("zero", s13 == "select null")
+
+    def rep1: Rep[Option[Boolean]] = ???
+    def rep2: Rep[Boolean] = ???
+    def rep3: Rep[Boolean] = rep1.getOrElse(rep2) //checking that it compiles https://github.com/slick/slick/issues/2761
   }
 }

--- a/slick/src/main/scala-2/slick/lifted/ShapedValue.scala
+++ b/slick/src/main/scala-2/slick/lifted/ShapedValue.scala
@@ -93,5 +93,7 @@ object ShapedValue {
     """
   }
 
-  type Unconst[P, P2] = P
+  //stub for scala3 compat
+  type Unconst[P] = P
+  def Unconst[P](p: P): Unconst[P] = p
 }

--- a/slick/src/main/scala-3/slick/lifted/ShapedValue.scala
+++ b/slick/src/main/scala-3/slick/lifted/ShapedValue.scala
@@ -79,11 +79,12 @@ object ShapedValue {
     '{ new MappedProjection[R]($sv.toNode, MappedScalaType.Mapper($g, $f, None), $rct) }
   }
 
-  // Turn ConstColumn into Rep at the top level on Dotty to avoid ClassCastExceptions
-  type Unconst[P, P2] = P2 match {
-    case ConstColumn[t] => Rep[t]
-    case _ => P2
+  //avoid inferring Rep subtypes (such as ConstColumn)
+  type Unconst[P] = P match {
+    case Rep[t] => Rep[t]
+    case _ => P
   }
+  def Unconst[P](p: P): Unconst[P] = p.asInstanceOf[Unconst[P]]
 }
 
 @FunctionalInterface

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -212,11 +212,11 @@ final class AnyOptionExtensionMethods[O <: Rep[?], P](val r: O) extends AnyVal {
   }
 
   /** Get the value inside this Option, if it is non-empty, otherwise the supplied default. */
-  def getOrElse[M, P2 <: P](default: M)(implicit shape: Shape[FlatShapeLevel, M, ?, P2], ol: OptionLift[P2, O]): ShapedValue.Unconst[P, P2] = {
+  def getOrElse[M, P2 <: P](default: M)(implicit shape: Shape[FlatShapeLevel, M, ?, P2], ol: OptionLift[P2, O]): ShapedValue.Unconst[P] = {
     // P2 != P can only happen if M contains plain values, which pack to ConstColumn instead of Rep.
     // Both have the same packedShape (RepShape), so we can safely cast here:
     val r = fold[P, P](shape.pack(default): P)(identity)(shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, P, ?, P]])
-    r.asInstanceOf[ShapedValue.Unconst[P, P2]]
+    ShapedValue.Unconst(r)
   }
 
   /** Check if this Option is empty. */


### PR DESCRIPTION
Note: I have no idea what `Unconst` is doing but this fixes the issue