### PR TITLE
upgrade.md: fix sections

### DIFF
--- a/doc/paradox/upgrade.md
+++ b/doc/paradox/upgrade.md
@@ -48,6 +48,17 @@ your codebase away from `scala-collection-compat`, otherwise if this is not poss
 
 dependency manually.
 
+### ResultConverter
+
+``ResultConverter`` is an internal interface for converting between values handled in JDBC and values handled in
+application code (case classes, etc.). While you most likely aren't using it directly, you may need to call methods
+of this interface if you are override behavior of a profile or writing a new one.
+
+In order to support a single insert statement with multiple rows, the `set` method now takes an `offset` parameter.
+If you have extended a profile and used the `set` method of this interface, you may need to specify 0 for the offset
+(unless the number of variable placeholders in the SQL dynamically changes).
+
+
 Upgrade from 3.3.x to 3.4.0
 -----------------------
 
@@ -82,20 +93,7 @@ columns in PostgreSQL:
 - changes to handling of timezone part of `java.time.Instant` in PostgreSQL profile
   ([#2005](https://github.com/slick/slick/issues/2005))
 
-Upgrade from 3.4 to 3.5
------------------------
-
-### ResultConverter
-
-``ResultConverter`` is an internal interface for converting between values handled in JDBC and values handled in
-application code (case classes, etc.). While you most likely aren't using it directly, you may need to call methods
-of this interface if you are override behavior of a profile or writing a new one.
-
-In order to support a single insert statement with multiple rows, the `set` method now takes an `offset` parameter.
-If you have extended a profile and used the `set` method of this interface, you may need to specify 0 for the offset
-(unless the number of variable placeholders in the SQL dynamically changes).
-
-Upgrade from 3.2 to 3.3
+Upgrade from 3.2.x to 3.3.0
 -----------------------
 
 ### Create / Drop If Not Exists
@@ -252,8 +250,7 @@ these mappings.
 | `java.time.OffsetDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z'` |
 | `java.time.ZonedDateTime` | `VARCHAR(254)` | `'2019-02-03T18:20:28.661Z[Europe/London]'` |
 
-
-Upgrade from 3.1 to 3.2
+Upgrade from 3.1.x to 3.2.0
 -----------------------
 
 This section describes the changes that are needed when upgrading from Slick 3.1 to 3.2. If you are


### PR DESCRIPTION
There were two sections for upgrading to 3.5.0; they have been combined.

Also, made headings consistent.