### PR TITLE
Replace filter on aggregates with CASE, closes #2235

### DIFF
--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -380,6 +380,13 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         case ProductType(_) => coll
         case _ => coll.iterator.filter(v => v != null && v != None)
       }).size
+    case Library.CountDistinct =>
+      val CollectionType(_, elType) = args(0)._1: @unchecked
+      val coll = args(0)._2.asInstanceOf[Coll]
+      (elType match {
+        case ProductType(_) => coll.toSeq.distinct
+        case _ => coll.toSeq.filter(v => v != null && v != None).distinct
+      }).size
     case Library.Database => ""
     case Library.Degrees =>
       val t = args(0)._1.asInstanceOf[ScalaNumericType[Any]]


### PR DESCRIPTION
Fix a case when filtered aggregate produces runtime exception by interpreting it with CASE expressions.

Closes #2235