### PR TITLE
MySQLProfile: quote column names in `insertOrUpdate` statement

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -297,13 +297,14 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     } else {
       case class A(id1: Int, id2: Int)
       class ATable(tag: Tag) extends Table[A](tag, "ATABLE") {
-        def id1 = column[Int]("id1")
+        // using keyword for checking they are quoted
+        def select = column[Int]("select")
 
-        def id2 = column[Int]("id2")
+        def from = column[Int]("from")
 
-        val pk = primaryKey("pk_for_atable", (id1, id2))
+        val pk = primaryKey("pk_for_atable", (select, from))
 
-        def * = (id1, id2) <> ((A.apply _).tupled, A.unapply)
+        def * = (select, from) <> ((A.apply _).tupled, A.unapply)
       }
       case class B(id1: Int, id2: Int, v: Int)
       class BTable(tag: Tag) extends Table[B](tag, "BTABLE") {

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -282,7 +282,7 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
   class MySQLUpsertBuilder(ins: Insert) extends UpsertBuilder(ins) {
     override def buildInsert: InsertBuilderResult = {
       val start = buildInsertStart
-      val names = syms.filter(!_.existsColumnOption[ColumnOption.AutoInc.type]).map(_.name)
+      val names = syms.filter(!_.existsColumnOption[ColumnOption.AutoInc.type]).map(s => quoteIdentifier(s.name))
       val update =
         if (names.isEmpty) ""
         else s"on duplicate key update ${names.map(n => s"$n=VALUES($n)").mkString(", ")}"


### PR DESCRIPTION
Closes #2910.

It would be nice to write a test for this functionality. I'm unfamiliar with Slick's codebase, so where is the best place to add a test?