### PR TITLE
Add slick-compat-collection to MiMa exclude filter

### DIFF
--- a/slick/src/main/mima-filters/3.5.x.backwards.excludes/slick-compat.backwards.excludes
+++ b/slick/src/main/mima-filters/3.5.x.backwards.excludes/slick-compat.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[MissingClassProblem]("slick.compat.*")


### PR DESCRIPTION
Meant to solve https://github.com/slick/slick/pull/2912#issuecomment-1987418910

In order to generate the necessary includes you have to set `mimaPreviousArtifacts` and run `sbt +mimaReportBinaryIssues`. This project doesn't set `mimaPreviousArtifacts` it directly so instead I locally added this setting

```sbt
mimaPreviousArtifacts := {
  val toIgnore = Set("root", "codegen", "testkit")

  val n = name.value

  if (toIgnore.exists(n.toLowerCase.contains))
    Set.empty
  else
    Set(organization.value %% n % "3.5.0")
},
```

To `slickGeneralSettings` (there are probably far smarter ways to do this however its temporarily to get the command working).

Then when you run `sbt +mimaReportBinaryIssues` you get

```
[error] Slick: Failed binary compatibility check against com.typesafe.slick:Slick_2.12:3.5.0! Found 22 potential problems
[error]  * class slick.compat.IterableExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.IterableExtensionMethods")
[error]  * object slick.compat.IterableExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.IterableExtensionMethods$")
[error]  * class slick.compat.MapViewExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.MapViewExtensionMethods")
[error]  * object slick.compat.MapViewExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.MapViewExtensionMethods$")
[error]  * class slick.compat.TraversableOnceExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.TraversableOnceExtensionMethods")
[error]  * object slick.compat.TraversableOnceExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.TraversableOnceExtensionMethods$")
[error]  * class slick.compat.collection.CompatImpl does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.CompatImpl")
[error]  * object slick.compat.collection.CompatImpl does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.CompatImpl$")
[error]  * class slick.compat.collection.package does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package")
[error]  * object slick.compat.collection.package does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$")
[error]  * class slick.compat.collection.package#FactoryOps does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$FactoryOps")
[error]  * class slick.compat.collection.package#ImmutableSortedMapExtensions does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedMapExtensions")
[error]  * object slick.compat.collection.package#ImmutableSortedMapExtensions does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedMapExtensions$")
[error]  * class slick.compat.collection.package#ImmutableSortedSetOps does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedSetOps")
[error]  * object slick.compat.collection.package#ImmutableSortedSetOps does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedSetOps$")
[error]  * class slick.compat.collection.package#ImmutableTreeMapExtensions does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableTreeMapExtensions")
[error]  * object slick.compat.collection.package#ImmutableTreeMapExtensions does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableTreeMapExtensions$")
[error]  * class slick.compat.collection.package#IterableExtensions does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$IterableExtensions")
[error]  * object slick.compat.collection.package#IterableExtensions does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$IterableExtensions$")
[error]  * class slick.compat.collection.package#IterableFactoryExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$IterableFactoryExtensionMethods")
[error]  * object slick.compat.collection.package#JavaConverters does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$JavaConverters$")
[error]  * class slick.compat.collection.package#SortedExtensionMethods does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$SortedExtensionMethods")
[error] java.lang.RuntimeException: Failed binary compatibility check against com.typesafe.slick:Slick_2.12:3.5.0! Found 22 potential problems
[error]         at scala.sys.package$.error(package.scala:30)
[error]         at com.typesafe.tools.mima.plugin.SbtMima$.reportModuleErrors(SbtMima.scala:89)
[error]         at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$2(MimaPlugin.scala:36)
[error]         at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$2$adapted(MimaPlugin.scala:26)
[error]         at scala.collection.Iterator.foreach(Iterator.scala:943)
[error]         at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error]         at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error]         at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$1(MimaPlugin.scala:26)
[error]         at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$1$adapted(MimaPlugin.scala:25)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error]         at sbt.Execute.work(Execute.scala:292)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error]         at java.lang.Thread.run(Thread.java:750)
```

With this you can generate a `slick/src/main/mima-filters/3.5.x.backwards.excludes/slick-compat.backwards.excludes` file with the following

```
ProblemFilters.exclude[MissingClassProblem]("slick.compat.IterableExtensionMethods")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.IterableExtensionMethods$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.MapViewExtensionMethods")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.MapViewExtensionMethods$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.TraversableOnceExtensionMethods")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.TraversableOnceExtensionMethods$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.CompatImpl")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.CompatImpl$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$FactoryOps")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedMapExtensions")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedMapExtensions$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedSetOps")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableSortedSetOps$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableTreeMapExtensions")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$ImmutableTreeMapExtensions$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$IterableExtensions")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$IterableExtensions$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$IterableFactoryExtensionMethods")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$JavaConverters$")
ProblemFilters.exclude[MissingClassProblem]("slick.compat.collection.package$SortedExtensionMethods")
```

This is however is excessive and we can just use

```
ProblemFilters.exclude[MissingClassProblem]("slick.compat.*")
```

Instead since the entire contents of `slick.compat.*` are designed to be private within slick only. After creation of this file `sbt +mimaReportBinaryIssues` no longer reports any problems. Ideally this ignore file should have been included in the original PR at https://github.com/slick/slick/pull/2747 but due to `mimaPreviousArtifacts` being empty be default I likely missed it (@nafg we should probably look into this, while the github bot does set `mimaPreviousArtifacts` when its run it should also be set when you run `sbt +mimaReportBinaryIssues` locally without any extra arguments).