### PR TITLE
Strip null chars from postgres string jdbc type on setValue

### DIFF
--- a/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/PostgresProfile.scala
@@ -296,6 +296,14 @@ trait PostgresProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsP
     override val instantType: PostgresInstantJdbcType = new PostgresInstantJdbcType
     override val localDateTimeType: PostgresLocalDateTimeJdbcType = new PostgresLocalDateTimeJdbcType
 
+    protected val nullCharReplacement: String = ""
+
+    override val stringJdbcType = new StringJdbcType {
+      override def setValue(v: String, p: PreparedStatement, idx: Int) = {
+        super.setValue(v.replace("\u0000", nullCharReplacement), p, idx)
+      }
+    }
+
     class PostgresByteArrayJdbcType extends ByteArrayJdbcType {
       override val sqlType = java.sql.Types.BINARY
       override def sqlTypeName(sym: Option[FieldSymbol]) = "BYTEA"


### PR DESCRIPTION
`\u0000` is not a valid character to submit to postgres. It will throw if the char makes it this far.

Stripping them out of the supplied string is a very principled stance to make and would be happy to have the PR turned down if it is deemed inappropriate.

To maintain backwards compatibility I have introduced the feature under a flag people can optionally toggle in their postgres profile