### PR TITLE
use new wildcard syntax

### DIFF
--- a/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/AbstractGenerator.scala
@@ -238,7 +238,7 @@ abstract class AbstractGenerator[Code,TermName,TypeName](model: m.Model)
       /** Indicates whether this is an auto increment column */
       final def autoInc = model.options.contains(ColumnOption.AutoInc)
       /** Generates code for a columnOption */
-      def columnOptionCode: ColumnOption[_] => Option[Code]
+      def columnOptionCode: ColumnOption[?] => Option[Code]
       /** Generates code for the ColumnOptions (DBType, AutoInc, etc.) */
       def options: Iterable[Code] = model.options.filter{
         case _: SqlProfile.ColumnOption.SqlType => dbType

--- a/slick-codegen/src/main/scala/slick/codegen/SourceCodeGenerator.scala
+++ b/slick-codegen/src/main/scala/slick/codegen/SourceCodeGenerator.scala
@@ -71,7 +71,7 @@ object SourceCodeGenerator {
     try {
       val m = Await.result(db.run(profileInstance.createModel(None, ignoreInvalidDefaults)(ExecutionContext.global).withPinnedSession), Duration.Inf)
       val codeGenerator = codeGeneratorClass.getOrElse("slick.codegen.SourceCodeGenerator")
-      val sourceGeneratorClass = Class.forName(codeGenerator).asInstanceOf[Class[_ <: SourceCodeGenerator]]
+      val sourceGeneratorClass = Class.forName(codeGenerator).asInstanceOf[Class[? <: SourceCodeGenerator]]
       val generatorInstance = sourceGeneratorClass.getConstructor(classOf[Model]).newInstance(m)
       if(outputToMultipleFiles)
         generatorInstance.writeToMultipleFiles(profile, outputDir, pkg)

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -376,11 +376,11 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
     case class Pair[A, B](a: A, b: B)
 
     // A Shape that maps Pair to a ProductNode
-    final class PairShape[Level <: ShapeLevel, M <: Pair[_,_], U <: Pair[_,_] : ClassTag, P <: Pair[_,_]](val shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]) extends MappedScalaProductShape[Level, Pair[_,_], M, U, P] {
+    final class PairShape[Level <: ShapeLevel, M <: Pair[?,?], U <: Pair[?,?] : ClassTag, P <: Pair[?,?]](val shapes: Seq[Shape[? <: ShapeLevel, ?, ?, ?]]) extends MappedScalaProductShape[Level, Pair[?,?], M, U, P] {
       def buildValue(elems: IndexedSeq[Any]): Any = Pair(elems(0), elems(1))
-      def copy(shapes: Seq[Shape[_ <: ShapeLevel, _, _, _]]): Shape[Level, _, _, _] = new PairShape(shapes)
+      def copy(shapes: Seq[Shape[? <: ShapeLevel, ?, ?, ?]]): Shape[Level, ?, ?, ?] = new PairShape(shapes)
     }
-    implicit def pairShape[Level <: ShapeLevel, M1, M2, U1, U2, P1, P2](implicit s1: Shape[_ <: Level, M1, U1, P1], s2: Shape[_ <: Level, M2, U2, P2]): PairShape[Level, Pair[M1, M2], Pair[U1, U2], Pair[P1, P2]] =
+    implicit def pairShape[Level <: ShapeLevel, M1, M2, U1, U2, P1, P2](implicit s1: Shape[? <: Level, M1, U1, P1], s2: Shape[? <: Level, M2, U2, P2]): PairShape[Level, Pair[M1, M2], Pair[U1, U2], Pair[P1, P2]] =
       new PairShape[Level, Pair[M1, M2], Pair[U1, U2], Pair[P1, P2]](Seq(s1, s2))
 
     // Use it in a table definition

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/MainTest.scala
@@ -96,7 +96,7 @@ class MainTest extends AsyncTest[JdbcTestDB] { mainTest =>
       } yield (u.first, o.orderID)
       q4.result.statements.toSeq.length.should(_ >= 1)
 
-      def maxOfPer[T <: Table[_], C[_]](c: Query[T, _, C])(m: (T => Rep[Int]), p: (T => Rep[Int])) =
+      def maxOfPer[T <: Table[?], C[_]](c: Query[T, ?, C])(m: (T => Rep[Int]), p: (T => Rep[Int])) =
         c filter { o => m(o) === (for { o2 <- c if p(o) === p(o2) } yield m(o2)).max }
 
       val q4b = for (

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
@@ -81,11 +81,11 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val setup = xs.schema.create >> (xs ++= r)
 
     // Construct all kinds of Option Shapes
-    implicitly[Shape[_, Rep[Int], _, _]]
-    implicitly[Shape[_, Rep[Option[Int]], _, _]]
-    implicitly[Shape[_, Rep[Option[Option[Int]]], _, _]]
-    implicitly[Shape[_, Rep[Option[(Rep[Int], Rep[String])]], _, _]]
-    implicitly[Shape[_, Rep[Option[X]], _, _]]
+    implicitly[Shape[?, Rep[Int], ?, ?]]
+    implicitly[Shape[?, Rep[Option[Int]], ?, ?]]
+    implicitly[Shape[?, Rep[Option[Option[Int]]], ?, ?]]
+    implicitly[Shape[?, Rep[Option[(Rep[Int], Rep[String])]], ?, ?]]
+    implicitly[Shape[?, Rep[Option[X]], ?, ?]]
 
     // Construct all different kinds of Options
     val q1 = q.map(t => Rep.Some(t))
@@ -95,13 +95,13 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q3 = q.map(t => t.c)
     val q4 = q.map(t => Rep.Some(t.c))
     val q5 = q.map(t => (t.c, Rep.Some(t.b)))
-    val q1t: Query[Rep[Option[X]], _, Seq] = q1
-    val q1a2t: Query[Rep[Option[Option[X]]], _, Seq] = q1a2
-    val q2t: Query[Rep[Option[Int]], _, Seq] = q2
-    val q2a2t: Query[Rep[Option[Option[Int]]], _, Seq] = q2a2
-    val q3t: Query[Rep[Option[Int]], _, Seq] = q3
-    val q4t: Query[Rep[Option[Option[Int]]], _, Seq] = q4
-    val q5t: Query[(Rep[Option[Int]], Rep[Option[String]]), _, Seq] = q5
+    val q1t: Query[Rep[Option[X]], ?, Seq] = q1
+    val q1a2t: Query[Rep[Option[Option[X]]], ?, Seq] = q1a2
+    val q2t: Query[Rep[Option[Int]], ?, Seq] = q2
+    val q2a2t: Query[Rep[Option[Option[Int]]], ?, Seq] = q2a2
+    val q3t: Query[Rep[Option[Int]], ?, Seq] = q3
+    val q4t: Query[Rep[Option[Option[Int]]], ?, Seq] = q4
+    val q5t: Query[(Rep[Option[Int]], Rep[Option[String]]), ?, Seq] = q5
 
     lazy val t1 = seq(
       mark("q1", q1.result).map(_ shouldBe r.map(t => Some(t))),
@@ -118,10 +118,10 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q2b = q2.map(_.get)
     val q3b = q3.filter(_.isDefined).map(_.get)
     val q4b = q4.map(_.getOrElse(None: Option[Int]))
-    val q1bt: Query[(Rep[Int], Rep[String], Rep[Option[Int]]), _, Seq] = q1b
-    val q2bt: Query[Rep[Int], _, Seq] = q2b
-    val q3bt: Query[Rep[Int], _, Seq] = q3b
-    val q4bt: Query[Rep[Option[Int]], _, Seq] = q4b
+    val q1bt: Query[(Rep[Int], Rep[String], Rep[Option[Int]]), ?, Seq] = q1b
+    val q2bt: Query[Rep[Int], ?, Seq] = q2b
+    val q3bt: Query[Rep[Int], ?, Seq] = q3b
+    val q4bt: Query[Rep[Option[Int]], ?, Seq] = q4b
 
     lazy val t2 = seq(
       mark("q1b", q1b.result).map(_ shouldBe r.map(t => Some(t)).map(_.getOrElse((0, "", None: Option[String])))),
@@ -156,11 +156,11 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     }
     val q3d = q3.map(_.map(s => (s, s, 1)))
     val q4d = q4.map(_.filter(_.isDefined).map(_.getOrElse(0)))
-    val q1dt: Query[Rep[Option[Int]], _, Seq] = q1d
-    val q1d2t: Query[Rep[Option[(Rep[Int], Rep[String], Rep[Option[Int]])]], _, Seq] = q1d2
-    val q2dt: Query[Rep[Option[Int]], _, Seq] = q2d
-    val q3dt: Query[Rep[Option[(Rep[Int], Rep[Int], ConstColumn[Int])]], _, Seq] = q3d
-    val q4dt: Query[Rep[Option[Int]], _, Seq] = q4d
+    val q1dt: Query[Rep[Option[Int]], ?, Seq] = q1d
+    val q1d2t: Query[Rep[Option[(Rep[Int], Rep[String], Rep[Option[Int]])]], ?, Seq] = q1d2
+    val q2dt: Query[Rep[Option[Int]], ?, Seq] = q2d
+    val q3dt: Query[Rep[Option[(Rep[Int], Rep[Int], ConstColumn[Int])]], ?, Seq] = q3d
+    val q4dt: Query[Rep[Option[Int]], ?, Seq] = q4d
 
     lazy val t4 = seq(
       q1d.result.named("q1d").map(_ shouldBe r.map(t => Some(t)).map(_.map(_._1))),
@@ -175,9 +175,9 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q1e2 = q1.map { to => to.flatMap { t => t.c }}
     val q1e3 = q1.map(to => Rep.Some(to)).map(_.flatMap(identity))
     val q2e = q2.map { io => io.flatMap { i => Rep.Some(i) }}
-    val q1e1t: Query[Rep[Option[String]], _, Seq] = q1e1
-    val q1e2t: Query[Rep[Option[Int]], _, Seq] = q1e2
-    val q2et: Query[Rep[Option[Int]], _, Seq] = q2e
+    val q1e1t: Query[Rep[Option[String]], ?, Seq] = q1e1
+    val q1e2t: Query[Rep[Option[Int]], ?, Seq] = q1e2
+    val q2et: Query[Rep[Option[Int]], ?, Seq] = q2e
 
     lazy val t5 = seq(
       mark("q1e1", q1e1.result).map(_ shouldBe r.map(t => Some(t)).map { to => to.flatMap { t => Some(t._2) }}),
@@ -193,12 +193,12 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q2f1 = q2.map { io => Rep.Some(io) }
     val q2f2 = q2.map { io => Rep.Some(io).flatten }
     val q2f3 = q2.map { io => Rep.Some(io) }.map(_.flatten)
-    val q1f1t: Query[Rep[Option[Option[X]]], _, Seq] = q1f1
-    val q1f2t: Query[Rep[Option[X]], _, Seq] = q1f2
-    val q1f3t: Query[Rep[Option[X]], _, Seq] = q1f3
-    val q2f1t: Query[Rep[Option[Option[Int]]], _, Seq] = q2f1
-    val q2f2t: Query[Rep[Option[Int]], _, Seq] = q2f2
-    val q2f3t: Query[Rep[Option[Int]], _, Seq] = q2f3
+    val q1f1t: Query[Rep[Option[Option[X]]], ?, Seq] = q1f1
+    val q1f2t: Query[Rep[Option[X]], ?, Seq] = q1f2
+    val q1f3t: Query[Rep[Option[X]], ?, Seq] = q1f3
+    val q2f1t: Query[Rep[Option[Option[Int]]], ?, Seq] = q2f1
+    val q2f2t: Query[Rep[Option[Int]], ?, Seq] = q2f2
+    val q2f3t: Query[Rep[Option[Int]], ?, Seq] = q2f3
 
     lazy val t6 = seq(
       q1f1.result.named("q1f1").map(_ shouldBe Vector(Some(Some((1,"1",Some(1)))), Some(Some((2,"2",Some(2)))), Some(Some((3,"3",None))))),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/TemplateTest.scala
@@ -81,12 +81,12 @@ class TemplateTest extends AsyncTest[RelationalTestDB] {
     val countBelowC = Compiled(countBelow)
     val joinC = Compiled { (id: Rep[Int]) => ts.filter(_.id === id).join(ts.filter(_.id === id)) }
 
-    implicitly[slick.lifted.Executable[(Rep[Int], Rep[Int]), _]]
-    implicitly[slick.lifted.Compilable[(Rep[Int], Rep[Int]), _]]
+    implicitly[slick.lifted.Executable[(Rep[Int], Rep[Int]), ?]]
+    implicitly[slick.lifted.Compilable[(Rep[Int], Rep[Int]), ?]]
     val impShaped = (ts.length, ts.length)
     val impShapedC = Compiled(impShaped)
-    implicitly[slick.lifted.Executable[slick.lifted.ShapedValue[(Rep[Int], Rep[Int]), (Int, Int)], _]]
-    implicitly[slick.lifted.Compilable[slick.lifted.ShapedValue[(Rep[Int], Rep[Int]), (Int, Int)], _]]
+    implicitly[slick.lifted.Executable[slick.lifted.ShapedValue[(Rep[Int], Rep[Int]), (Int, Int)], ?]]
+    implicitly[slick.lifted.Compilable[slick.lifted.ShapedValue[(Rep[Int], Rep[Int]), (Int, Int)], ?]]
     val expShaped = impShaped.shaped
     val expShapedC = Compiled(expShaped)
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DelegateConnection.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DelegateConnection.scala
@@ -23,7 +23,7 @@ class DelegateConnection(conn: Connection) extends Connection {
   def getSchema: String = conn.getSchema
   def setNetworkTimeout(executor: Executor, milliseconds: Int): Unit = conn.setNetworkTimeout(executor, milliseconds)
   def getMetaData: DatabaseMetaData = conn.getMetaData
-  def getTypeMap: util.Map[String, Class[_]] = conn.getTypeMap
+  def getTypeMap: util.Map[String, Class[?]] = conn.getTypeMap
   def rollback(): Unit = conn.rollback()
   def rollback(savepoint: Savepoint): Unit = conn.rollback(savepoint)
   def createStatement(resultSetType: Int, resultSetConcurrency: Int): Statement = conn.createStatement(resultSetType, resultSetConcurrency)
@@ -33,7 +33,7 @@ class DelegateConnection(conn: Connection) extends Connection {
   def setClientInfo(name: String, value: String): Unit = conn.setClientInfo(name, value)
   def setClientInfo(properties: Properties): Unit = conn.setClientInfo(properties)
   def isReadOnly: Boolean = conn.isReadOnly
-  def setTypeMap(map: util.Map[String, Class[_]]): Unit = conn.setTypeMap(map)
+  def setTypeMap(map: util.Map[String, Class[?]]): Unit = conn.setTypeMap(map)
   def getCatalog: String = conn.getCatalog
   def createClob(): Clob = conn.createClob
   def setTransactionIsolation(level: Int): Unit = conn.setTransactionIsolation(level)
@@ -60,5 +60,5 @@ class DelegateConnection(conn: Connection) extends Connection {
   def setSchema(schema: String): Unit = conn.setSchema(schema)
   def commit(): Unit = conn.commit()
   def unwrap[T](iface: Class[T]): T = conn.unwrap[T](iface)
-  def isWrapperFor(iface: Class[_]): Boolean = conn.isWrapperFor(iface)
+  def isWrapperFor(iface: Class[?]): Boolean = conn.isWrapperFor(iface)
 }

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DelegateResultSet.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/DelegateResultSet.scala
@@ -13,7 +13,7 @@ import java.net.URL
   * JDK 7. */
 class DelegateResultSet(rs: ResultSet) extends ResultSet {
   def next(): Boolean = rs.next()
-  def isWrapperFor(iface: Class[_]): Boolean = rs.isWrapperFor(iface)
+  def isWrapperFor(iface: Class[?]): Boolean = rs.isWrapperFor(iface)
   def unwrap[T](iface: Class[T]): T = rs.unwrap(iface)
   def getObject[T](columnLabel: String, `type`: Class[T]): T = ??? // rs.getObject[T](columnLabel, `type`)
   def getObject[T](columnIndex: Int, `type`: Class[T]): T = ??? // rs.getObject[T](columnIndex, `type`)
@@ -85,12 +85,12 @@ class DelegateResultSet(rs: ResultSet) extends ResultSet {
   def getClob(columnLabel: String): Clob = rs.getClob(columnLabel)
   def getBlob(columnLabel: String): Blob = rs.getBlob(columnLabel)
   def getRef(columnLabel: String): Ref = rs.getRef(columnLabel)
-  def getObject(columnLabel: String, map: Map[String, Class[_]]): AnyRef = rs.getObject(columnLabel, map)
+  def getObject(columnLabel: String, map: Map[String, Class[?]]): AnyRef = rs.getObject(columnLabel, map)
   def getArray(columnIndex: Int): SQLArray = rs.getArray(columnIndex)
   def getClob(columnIndex: Int): Clob = rs.getClob(columnIndex)
   def getBlob(columnIndex: Int): Blob = rs.getBlob(columnIndex)
   def getRef(columnIndex: Int): Ref = rs.getRef(columnIndex)
-  def getObject(columnIndex: Int, map: Map[String, Class[_]]): AnyRef = rs.getObject(columnIndex, map)
+  def getObject(columnIndex: Int, map: Map[String, Class[?]]): AnyRef = rs.getObject(columnIndex, map)
   def getStatement: Statement = rs.getStatement
   def moveToCurrentRow(): Unit = rs.moveToCurrentRow
   def moveToInsertRow(): Unit = rs.moveToInsertRow

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
@@ -56,9 +56,9 @@ object TestkitConfig {
   lazy val testDBs = getStrings(testkitConfig, "testDBs")
 
   /** The `testkit.testClasses` setting */
-  lazy val testClasses: Seq[Class[_ <: AsyncTest[_ >: Null <: TestDB]]] =
+  lazy val testClasses: Seq[Class[? <: AsyncTest[? >: Null <: TestDB]]] =
     getStrings(testkitConfig, "testClasses").getOrElse(Nil).
-      map(n => Class.forName(n).asInstanceOf[Class[_ <: AsyncTest[_ >: Null <: TestDB]]])
+      map(n => Class.forName(n).asInstanceOf[Class[? <: AsyncTest[? >: Null <: TestDB]]])
 
   /** The duration after which asynchronous tests should be aborted and failed */
   lazy val asyncTimeout =
@@ -67,7 +67,7 @@ object TestkitConfig {
   def getStrings(config: Config, path: String): Option[Seq[String]] = {
     if(config.hasPath(path)) {
       config.getValue(path).unwrapped() match {
-        case l: java.util.List[_] => Some(l.asScala.iterator.map(_.toString).toSeq)
+        case l: java.util.List[?] => Some(l.asScala.iterator.map(_.toString).toSeq)
         case o => Some(List(o.toString))
       }
     } else None

--- a/slick-testkit/src/test/scala/slick/benchmark/CompilerBenchmark.scala
+++ b/slick-testkit/src/test/scala/slick/benchmark/CompilerBenchmark.scala
@@ -72,7 +72,7 @@ object CompilerBenchmark {
 
   def allQueries = queriesFromNewComposition ++ queriesFromAdancedFusion ++ queriesFromExpansion ++ queriesFromNewFusion
 
-  def queriesFromNewComposition: Vector[Rep[_]] = {
+  def queriesFromNewComposition: Vector[Rep[?]] = {
     class SuppliersStd(tag: Tag) extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
       def id = column[Int]("SUP_ID", O.PrimaryKey) // This is the primary key column
       def name = column[String]("SUP_NAME")
@@ -192,7 +192,7 @@ object CompilerBenchmark {
     Vector(qa, qa2, qb, qb2, qc, q0, q1, q1b_0, q1b, q2, q3, q3b, q4, q4b_0, q4b, q5_0, q5, q5b, q6, q7a, q1, q71, q7b, q8, q8b)
   }
 
-  def queriesFromAdancedFusion: Vector[Rep[_]] = {
+  def queriesFromAdancedFusion: Vector[Rep[?]] = {
     class TableA(tag: Tag) extends Table[Int](tag, "TableA") {
       def id = column[Int]("id")
       def * = id
@@ -222,7 +222,7 @@ object CompilerBenchmark {
     Vector(queryErr2)
   }
 
-  def queriesFromExpansion: Vector[Rep[_]] = {
+  def queriesFromExpansion: Vector[Rep[?]] = {
     class A(tag: Tag) extends Table[(Int, String)](tag, "A_refexp") {
       def id = column[Int]("id")
       def a = column[String]("a")
@@ -242,7 +242,7 @@ object CompilerBenchmark {
     Vector(q1, q2a, q2)
   }
 
-  def queriesFromNewFusion: Vector[Rep[_]] = {
+  def queriesFromNewFusion: Vector[Rep[?]] = {
     class A(tag: Tag) extends Table[(Int, String, String)](tag, "A_NEWFUSION") {
       def id = column[Int]("id")
       def a = column[String]("a")
@@ -277,6 +277,6 @@ object CompilerBenchmark {
     val q16 = (as.map(a => a.id.?).filter(_ < 2) unionAll as.map(a => a.id.?).filter(_ > 2)).map(_.getOrElse(-1)).to[Set].filter(_ =!= 42)
     val q17 = as.sortBy(_.id).zipWithIndex.filter(_._2 < 2L).map { case (a, i) => (a.id, i) }
 
-    Vector[Rep[_]](q1, q2, q3, q4, q5a, q5b, q5c, q6, q7, q8, q9a, q9b, q10, q11a, q11b, q11c, q11d, q11e, q11f, q12, q13, q14, /*q15,*/ q16, q17)
+    Vector[Rep[?]](q1, q2, q3, q4, q5a, q5b, q5c, q6, q7, q8, q9a, q9b, q10, q11a, q11b, q11c, q11d, q11e, q11f, q12, q13, q14, /*q15,*/ q16, q17)
   }
 }

--- a/slick-testkit/src/test/scala/slick/benchmark/UnboxedBenchmark.scala
+++ b/slick-testkit/src/test/scala/slick/benchmark/UnboxedBenchmark.scala
@@ -60,12 +60,12 @@ object UnboxedBenchmark extends App {
     TreePrinter.default.print(rsm)
     val ResultSetMapping(_, _, CompiledMapping(converter, _)) = rsm
     for(i <- 1 to 5) {
-      val pr = createFakePR(10000000, converter.asInstanceOf[ResultConverter[ResultSet, PreparedStatement, ResultSet, _]])
+      val pr = createFakePR(10000000, converter.asInstanceOf[ResultConverter[ResultSet, PreparedStatement, ResultSet, ?]])
       readPR(pr)
     }
   }
 
-  def createFakePR(len: Long, converter: ResultConverter[ResultSet, PreparedStatement, ResultSet, _]): PositionedResultIterator[Any] = {
+  def createFakePR(len: Long, converter: ResultConverter[ResultSet, PreparedStatement, ResultSet, ?]): PositionedResultIterator[Any] = {
     val fakeRS = new DelegateResultSet(null) {
       var count: Long = 0
       var lastIndex: Int = 0
@@ -85,7 +85,7 @@ object UnboxedBenchmark extends App {
     }
   }
 
-  def readPR(pr: PositionedResultIterator[_]): (Long, AnyRef) = {
+  def readPR(pr: PositionedResultIterator[?]): (Long, AnyRef) = {
     val t0 = System.currentTimeMillis()
     var count: Long = 0
     var lastRow: AnyRef = null

--- a/slick-testkit/src/test/scala/slick/test/codegen/GeneratedCodeTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/codegen/GeneratedCodeTest.scala
@@ -49,7 +49,7 @@ object GeneratedCodeTest {
         val dIdxFieldsName = convertColumnsToString(dIdx.on)
         assertTrue("Indices should refer to correct field", dIdxFieldsName sameElements List("f1", "f2"))
 
-        def optionsOfColumn(c: slick.lifted.Rep[_]) =
+        def optionsOfColumn(c: slick.lifted.Rep[?]) =
           c.toNode.asInstanceOf[Select].field.asInstanceOf[FieldSymbol].options.toList
         val k1Options = optionsOfColumn(E.baseTableRow.k1)
         val k2Options = optionsOfColumn(E.baseTableRow.k2)

--- a/slick-testkit/src/test/scala/slick/test/compile/NestedShapesTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/compile/NestedShapesTest.scala
@@ -7,14 +7,14 @@ import slick.lifted.Shape
 class NestedShapesTest {
   def legal = {
     // Flat and Nested alike, only Mixed specified
-    implicitly[Shape[FlatShapeLevel, Int, _, _]]
-    implicitly[Shape[FlatShapeLevel, (Int, String), _, _]]
-    implicitly[Shape[FlatShapeLevel, (Rep[Int], Int), _, _]]
-    implicitly[Shape[FlatShapeLevel, (Rep[Int], (Int, Rep[String])), _, _]]
-    implicitly[Shape[NestedShapeLevel, Int, _, _]]
-    implicitly[Shape[NestedShapeLevel, (Int, String), _, _]]
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], Int), _, _]]
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), _, _]]
+    implicitly[Shape[FlatShapeLevel, Int, ?, ?]]
+    implicitly[Shape[FlatShapeLevel, (Int, String), ?, ?]]
+    implicitly[Shape[FlatShapeLevel, (Rep[Int], Int), ?, ?]]
+    implicitly[Shape[FlatShapeLevel, (Rep[Int], (Int, Rep[String])), ?, ?]]
+    implicitly[Shape[NestedShapeLevel, Int, ?, ?]]
+    implicitly[Shape[NestedShapeLevel, (Int, String), ?, ?]]
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], Int), ?, ?]]
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), ?, ?]]
 
     // Flat and Nested alike, fully specified
     implicitly[Shape[FlatShapeLevel, Int, Int, ConstColumn[Int]]]
@@ -27,10 +27,10 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (ConstColumn[Int], Rep[String]))]]
 
     // Only Nested, only Mixed specified
-    implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], _, _]] // 1
-    implicitly[Shape[NestedShapeLevel, Query[(Rep[Int], Rep[String]), (Int, String), Seq], _, _]] // 2
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq]), _, _]] // 3
-    implicitly[Shape[NestedShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), _, _]] // 4
+    implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], ?, ?]] // 1
+    implicitly[Shape[NestedShapeLevel, Query[(Rep[Int], Rep[String]), (Int, String), Seq], ?, ?]] // 2
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq]), ?, ?]] // 3
+    implicitly[Shape[NestedShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), ?, ?]] // 4
 
     // Only Nested, fully specified
     implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], Seq[Int], Query[Rep[Int], Int, Seq]]] // 5

--- a/slick-testkit/src/test/scala/slick/test/jdbc/ModelBuilderTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/ModelBuilderTest.scala
@@ -24,6 +24,6 @@ class ModelBuilderTest(val tdb: JdbcTestDB) extends DBTest {
       sqlu"""create table BAZ (FOO VARCHAR(255) DEFAULT CURRENT_USER)""" >>
       tdb.profile.createModel(ignoreInvalidDefaults=false).asTry
     val mt = Await.result(db.run(a.withPinnedSession), Duration.Inf)
-    assertTrue(mt.asInstanceOf[Failure[_]].exception.asInstanceOf[SlickException].getMessage.contains("not parse default"))
+    assertTrue(mt.asInstanceOf[Failure[?]].exception.asInstanceOf[SlickException].getMessage.contains("not parse default"))
   }
 }

--- a/slick/src/main/scala-2/slick/lifted/TableQuery.scala
+++ b/slick/src/main/scala-2/slick/lifted/TableQuery.scala
@@ -9,10 +9,10 @@ import scala.reflect.macros.blackbox.Context
 /** Represents a database table. Profiles add extension methods to TableQuery
  * for operations that can be performed on tables but not on arbitrary
  * queries, e.g. getting the table DDL. */
-class TableQuery[E <: AbstractTable[_]](cons: Tag => E) extends Query[E, E#TableElementType, Seq] {
-  lazy val shaped: ShapedValue[_ <: E, E#TableElementType] = {
+class TableQuery[E <: AbstractTable[?]](cons: Tag => E) extends Query[E, E#TableElementType, Seq] {
+  lazy val shaped: ShapedValue[? <: E, E#TableElementType] = {
     val baseTable = cons(new BaseTag { base =>
-      def taggedAs(path: Node): AbstractTable[_] = cons(new RefTag(path) {
+      def taggedAs(path: Node): AbstractTable[?] = cons(new RefTag(path) {
         def taggedAs(path: Node) = base.taggedAs(path)
       })
     })
@@ -29,16 +29,16 @@ class TableQuery[E <: AbstractTable[_]](cons: Tag => E) extends Query[E, E#Table
 
 object TableQuery {
   /** Create a TableQuery for a table row class using an arbitrary constructor function. */
-  def apply[E <: AbstractTable[_]](cons: Tag => E): TableQuery[E] =
+  def apply[E <: AbstractTable[?]](cons: Tag => E): TableQuery[E] =
     new TableQuery[E](cons)
 
   /** Create a TableQuery for a table row class which has a constructor of type (Tag). */
-  def apply[E <: AbstractTable[_]]: TableQuery[E] = macro TableQueryMacroImpl.apply[E]
+  def apply[E <: AbstractTable[?]]: TableQuery[E] = macro TableQueryMacroImpl.apply[E]
 }
 
 object TableQueryMacroImpl {
 
-  def apply[E <: AbstractTable[_]](c: Context)(implicit e: c.WeakTypeTag[E]): c.Expr[TableQuery[E]] = {
+  def apply[E <: AbstractTable[?]](c: Context)(implicit e: c.WeakTypeTag[E]): c.Expr[TableQuery[E]] = {
     import c.universe._
     val cons = c.Expr[Tag => E](Function(
       List(ValDef(Modifiers(Flag.PARAM), TermName("tag"), Ident(typeOf[Tag].typeSymbol), EmptyTree)),

--- a/slick/src/main/scala-3/slick/lifted/ShapedValue.scala
+++ b/slick/src/main/scala-3/slick/lifted/ShapedValue.scala
@@ -8,13 +8,13 @@ import slick.ast.{MappedScalaType, Node}
 import slick.collection.heterogeneous.*
 
 /** A value together with its Shape */
-case class ShapedValue[T, U](value: T, shape: Shape[_ <: FlatShapeLevel, T, U, _]) extends Rep[U] {
+case class ShapedValue[T, U](value: T, shape: Shape[? <: FlatShapeLevel, T, U, ?]) extends Rep[U] {
   def encodeRef(path: Node): ShapedValue[T, U] = {
     val fv = shape.encodeRef(value, path).asInstanceOf[T]
     if(fv.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this else new ShapedValue(fv, shape)
   }
   def toNode = shape.toNode(value)
-  def packedValue[R](implicit ev: Shape[_ <: FlatShapeLevel, T, _, R]): ShapedValue[R, U] = ShapedValue(shape.pack(value).asInstanceOf[R], shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, R, U, _]])
+  def packedValue[R](implicit ev: Shape[? <: FlatShapeLevel, T, ?, R]): ShapedValue[R, U] = ShapedValue(shape.pack(value).asInstanceOf[R], shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, R, U, _]])
   def zip[T2, U2](s2: ShapedValue[T2, U2]) = new ShapedValue[(T, T2), (U, U2)]((value, s2.value), Shape.tuple2Shape(shape, s2.shape))
   def <>[R : ClassTag, T](f: (U => R), g: (R => T))(implicit tt: ToTuple[T, U]) =
     new MappedProjection[R](shape.toNode(value), MappedScalaType.Mapper(g.andThen(tt.apply).andThen(_.get).asInstanceOf[Any => Any], f.asInstanceOf[Any => Any], None), implicitly[ClassTag[R]])
@@ -32,24 +32,24 @@ object ShapedValue {
     val rct = Expr.summon[ClassTag[R]].getOrElse(report.errorAndAbort(s"No ClassTag available for ${Type.show[R]}"))
     val rpm = Expr.summon[Mirror.ProductOf[R]].getOrElse(report.errorAndAbort(s"${Type.show[R]} is not a product type"))
 
-    def decomposeTuple(tpe: Type[_ <: Tuple]): List[Type[_]] = tpe match {
+    def decomposeTuple(tpe: Type[? <: Tuple]): List[Type[_]] = tpe match {
       case '[ t *: ts ] => Type.of[t] :: decomposeTuple(Type.of[ts])
       case '[ EmptyTuple ] => Nil
     }
 
-    def decomposeHList(tpe: Type[_ <: HList]): List[Type[_]] = tpe match {
+    def decomposeHList(tpe: Type[? <: HList]): List[Type[_]] = tpe match {
       case '[ HCons[t, ts] ] => Type.of[t] :: decomposeHList(Type.of[ts])
       case '[ HNil.type ] => Nil
     }
 
     val targetElemTpes = rpm match {
       case '{ $m: Mirror.ProductOf[R] { type MirroredElemTypes = ts }} =>
-        decomposeTuple(Type.of[ts].asInstanceOf[Type[_ <: Tuple]])
+        decomposeTuple(Type.of[ts].asInstanceOf[Type[? <: Tuple]])
     }
 
     val (f, g, elemTpes) = Expr.summon[Mirror.ProductOf[U]] match {
       case Some(upm @ '{ $m: Mirror.ProductOf[U] { type MirroredElemTypes = elementTypes }}) =>
-        val elemTpes = decomposeTuple(Type.of[elementTypes].asInstanceOf[Type[_ <: Tuple]])
+        val elemTpes = decomposeTuple(Type.of[elementTypes].asInstanceOf[Type[? <: Tuple]])
         val f = '{ ((u: U) => $rpm.fromProduct(u.asInstanceOf[Product])).asInstanceOf[Any => Any] }
         val g = '{ ((r: R) => $upm.fromProduct(r.asInstanceOf[Product])).asInstanceOf[Any => Any] }
         (f, g, elemTpes)

--- a/slick/src/main/scala-3/slick/lifted/TableQuery.scala
+++ b/slick/src/main/scala-3/slick/lifted/TableQuery.scala
@@ -10,7 +10,7 @@ import slick.ast.Node
 class TableQuery[E <: AbstractTable[_]](cons: Tag => E) extends Query[E, TableQuery.Extract[E], Seq] {
   lazy val shaped = {
     val baseTable = cons(new BaseTag { base =>
-      def taggedAs(path: Node): AbstractTable[_] = cons(new RefTag(path) {
+      def taggedAs(path: Node): AbstractTable[?] = cons(new RefTag(path) {
         def taggedAs(path: Node) = base.taggedAs(path)
       })
     })

--- a/slick/src/main/scala/slick/ast/Symbol.scala
+++ b/slick/src/main/scala/slick/ast/Symbol.scala
@@ -18,10 +18,10 @@ trait TypeSymbol extends Symbol
 trait TermSymbol extends Symbol
 
 /** A named symbol which refers to an (aliased or unaliased) field. */
-case class FieldSymbol(name: String)(val options: Seq[ColumnOption[_]], val tpe: Type) extends TermSymbol {
-  def findColumnOption[T <: ColumnOption[_]](implicit ct: ClassTag[T]): Option[T] =
+case class FieldSymbol(name: String)(val options: Seq[ColumnOption[?]], val tpe: Type) extends TermSymbol {
+  def findColumnOption[T <: ColumnOption[?]](implicit ct: ClassTag[T]): Option[T] =
     options.find(ct.runtimeClass.isInstance _).asInstanceOf[Option[T]]
-  def existsColumnOption[T <: ColumnOption[_]](implicit ct: ClassTag[T]): Boolean =
+  def existsColumnOption[T <: ColumnOption[?]](implicit ct: ClassTag[T]): Boolean =
     findColumnOption[T].nonEmpty
 }
 

--- a/slick/src/main/scala/slick/basic/BasicProfile.scala
+++ b/slick/src/main/scala/slick/basic/BasicProfile.scala
@@ -43,19 +43,19 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
 
     implicit val slickProfile: self.type = self
 
-    implicit final def anyToShapedValue[T, U](value: T)(implicit shape: Shape[_ <: FlatShapeLevel, T, U, _]): ShapedValue[T, U] =
+    implicit final def anyToShapedValue[T, U](value: T)(implicit shape: Shape[? <: FlatShapeLevel, T, U, ?]): ShapedValue[T, U] =
       new ShapedValue[T, U](value, shape)
 
-    implicit def streamableQueryActionExtensionMethods[U, C[_]](q: Query[_,U, C]): StreamingQueryActionExtensionMethods[C[U], U] =
+    implicit def streamableQueryActionExtensionMethods[U, C[_]](q: Query[?,U, C]): StreamingQueryActionExtensionMethods[C[U], U] =
       createStreamingQueryActionExtensionMethods[C[U], U](queryCompiler.run(q.toNode).tree, ())
-    implicit def runnableCompiledQueryActionExtensionMethods[RU](c: RunnableCompiled[_, RU]): QueryActionExtensionMethods[RU, NoStream] =
+    implicit def runnableCompiledQueryActionExtensionMethods[RU](c: RunnableCompiled[?, RU]): QueryActionExtensionMethods[RU, NoStream] =
       createQueryActionExtensionMethods[RU, NoStream](c.compiledQuery, c.param)
-    implicit def streamableCompiledQueryActionExtensionMethods[RU, EU](c: StreamableCompiled[_, RU, EU]): StreamingQueryActionExtensionMethods[RU, EU] =
+    implicit def streamableCompiledQueryActionExtensionMethods[RU, EU](c: StreamableCompiled[?, RU, EU]): StreamingQueryActionExtensionMethods[RU, EU] =
       createStreamingQueryActionExtensionMethods[RU, EU](c.compiledQuery, c.param)
     // Applying a CompiledFunction always results in only a RunnableCompiled, not a StreamableCompiled, so we need this:
-    implicit def streamableAppliedCompiledFunctionActionExtensionMethods[R, RU, EU, C[_]](c: AppliedCompiledFunction[_, Query[R, EU, C], RU]): StreamingQueryActionExtensionMethods[RU, EU] =
+    implicit def streamableAppliedCompiledFunctionActionExtensionMethods[R, RU, EU, C[_]](c: AppliedCompiledFunction[?, Query[R, EU, C], RU]): StreamingQueryActionExtensionMethods[RU, EU] =
       createStreamingQueryActionExtensionMethods[RU, EU](c.compiledQuery, c.param)
-    implicit def recordQueryActionExtensionMethods[M, R](q: M)(implicit shape: Shape[_ <: FlatShapeLevel, M, R, _]): QueryActionExtensionMethods[R, NoStream] =
+    implicit def recordQueryActionExtensionMethods[M, R](q: M)(implicit shape: Shape[? <: FlatShapeLevel, M, R, ?]): QueryActionExtensionMethods[R, NoStream] =
       createQueryActionExtensionMethods[R, NoStream](queryCompiler.run(shape.toNode(q)).tree, ())
   }
 
@@ -97,7 +97,7 @@ trait BasicProfile extends BasicActionComponent { self: BasicProfile =>
     * and then returns uses this name as a path in the application config. If no configuration
     * exists at this path, an empty Config object is returned. */
   protected[this] def loadProfileConfig: Config = {
-    def findConfigName(classes: Vector[Class[_]]): Option[String] =
+    def findConfigName(classes: Vector[Class[?]]): Option[String] =
       classes.iterator.map { cl =>
         val n = cl.getName
         if(n.startsWith("slick.") && n.endsWith("Profile")) Some(n) else None

--- a/slick/src/main/scala/slick/basic/DatabasePublisher.scala
+++ b/slick/src/main/scala/slick/basic/DatabasePublisher.scala
@@ -12,7 +12,7 @@ abstract class DatabasePublisher[T] extends Publisher[T] { self =>
   /** Create a Publisher that runs a synchronous mapping function on this Publisher. This
     * can be used to materialize LOB values in a convenient way. */
   def mapResult[U](f: T => U): DatabasePublisher[U] = new DatabasePublisher[U] {
-    def subscribe(s: Subscriber[_ >: U]) = self.subscribe(new Subscriber[T] {
+    def subscribe(s: Subscriber[? >: U]) = self.subscribe(new Subscriber[T] {
       def onSubscribe(sn: Subscription): Unit = s.onSubscribe(sn)
       def onComplete(): Unit = s.onComplete()
       def onError(t: Throwable): Unit = s.onError(t)

--- a/slick/src/main/scala/slick/compiler/FixRowNumberOrdering.scala
+++ b/slick/src/main/scala/slick/compiler/FixRowNumberOrdering.scala
@@ -14,7 +14,7 @@ class FixRowNumberOrdering extends Phase {
   def fix(n: Node, parent: Option[Comprehension[Option[Node]]] = None): Node = (n, parent) match {
     case (r @ RowNumber(_), Some(c)) if !c.orderBy.isEmpty =>
       RowNumber(c.orderBy) :@ r.nodeType
-    case (c: Comprehension[_], _) => c.mapScopedChildren {
+    case (c: Comprehension[?], _) => c.mapScopedChildren {
       case (Some(_), ch) => fix(ch, None)
       case (None, ch)    => fix(ch, Some(c))
     }.infer()

--- a/slick/src/main/scala/slick/compiler/RewriteBooleans.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteBooleans.scala
@@ -62,7 +62,7 @@ class RewriteBooleans extends Phase {
   /** Check if a type is equivalent to the Scala Boolean type or a (possibly
     * nested) Option of that type. */
   def isBooleanLike(t: Type): Boolean = t match {
-    case t: TypedType[_] if t.scalaType == ScalaBaseType.booleanType => true
+    case t: TypedType[?] if t.scalaType == ScalaBaseType.booleanType => true
     case t: OptionType => isBooleanLike(t.elementType)
     case _ => false
   }

--- a/slick/src/main/scala/slick/jdbc/DB2Profile.scala
+++ b/slick/src/main/scala/slick/jdbc/DB2Profile.scala
@@ -60,15 +60,15 @@ trait DB2Profile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerSta
       Phase.rewriteBooleans
   override val columnTypes: DB2JdbcTypes = new DB2JdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new DB2QueryBuilder(n, state)
-  override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new DB2TableDDLBuilder(table)
-  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder =
+  override def createTableDDLBuilder(table: Table[?]): TableDDLBuilder = new DB2TableDDLBuilder(table)
+  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[?]): ColumnDDLBuilder =
     new DB2ColumnDDLBuilder(column)
-  override def createSequenceDDLBuilder(seq: Sequence[_]): SequenceDDLBuilder = new DB2SequenceDDLBuilder(seq)
+  override def createSequenceDDLBuilder(seq: Sequence[?]): SequenceDDLBuilder = new DB2SequenceDDLBuilder(seq)
 
   override def defaultTables(implicit ec: ExecutionContext): DBIO[Seq[MTable]] =
     MTable.getTables(None, None, None, Some(Seq("TABLE"))).map(_.filter(!_.name.schema.exists(_ == "SYSTOOLS")))
 
-  override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
+  override def defaultSqlTypeName(tmd: JdbcType[?], sym: Option[FieldSymbol]): String = tmd.sqlType match {
     case java.sql.Types.TINYINT => "SMALLINT" // DB2 has no smaller binary integer type
     case _ => super.defaultSqlTypeName(tmd, sym)
   }
@@ -126,7 +126,7 @@ trait DB2Profile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerSta
     }
   }
 
-  class DB2TableDDLBuilder(table: Table[_]) extends TableDDLBuilder(table) {
+  class DB2TableDDLBuilder(table: Table[?]) extends TableDDLBuilder(table) {
     override protected def createIndex(idx: Index) = {
       if(idx.unique) {
         /* Create a UNIQUE CONSTRAINT (with an automatically generated backing
@@ -182,7 +182,7 @@ trait DB2Profile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerSta
     }
   }
 
-  class DB2SequenceDDLBuilder(seq: Sequence[_]) extends SequenceDDLBuilder(seq) {
+  class DB2SequenceDDLBuilder(seq: Sequence[?]) extends SequenceDDLBuilder(seq) {
     override def buildDDL: DDL = {
       val b = new StringBuilder append "create sequence " append quoteIdentifier(seq.name)
       b append " as " append jdbcTypeFor(seq.tpe).sqlTypeName(None)

--- a/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/DerbyProfile.scala
@@ -150,12 +150,12 @@ trait DerbyProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
     super.computeQueryCompiler + Phase.rewriteBooleans + Phase.specializeParameters
   override val columnTypes: DerbyJdbcTypes = new DerbyJdbcTypes
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new DerbyQueryBuilder(n, state)
-  override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new DerbyTableDDLBuilder(table)
-  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder =
+  override def createTableDDLBuilder(table: Table[?]): TableDDLBuilder = new DerbyTableDDLBuilder(table)
+  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[?]): ColumnDDLBuilder =
     new DerbyColumnDDLBuilder(column)
-  override def createSequenceDDLBuilder(seq: Sequence[_]): SequenceDDLBuilder = new DerbySequenceDDLBuilder(seq)
+  override def createSequenceDDLBuilder(seq: Sequence[?]): SequenceDDLBuilder = new DerbySequenceDDLBuilder(seq)
 
-  override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
+  override def defaultSqlTypeName(tmd: JdbcType[?], sym: Option[FieldSymbol]): String = tmd.sqlType match {
     case java.sql.Types.BOOLEAN => "SMALLINT"
     /* Derby does not have a TINYINT type, so we use SMALLINT instead. */
     case java.sql.Types.TINYINT => "SMALLINT"
@@ -234,7 +234,7 @@ trait DerbyProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
     }
   }
 
-  class DerbyTableDDLBuilder(table: Table[_]) extends TableDDLBuilder(table) {
+  class DerbyTableDDLBuilder(table: Table[?]) extends TableDDLBuilder(table) {
     override protected def createIndex(idx: Index) = {
       if(idx.unique) {
         /* Create a UNIQUE CONSTRAINT (with an automatically generated backing

--- a/slick/src/main/scala/slick/jdbc/DriverDataSource.scala
+++ b/slick/src/main/scala/slick/jdbc/DriverDataSource.scala
@@ -141,7 +141,7 @@ class DriverDataSource(
     driver.getParentLogger
   }
 
-  def isWrapperFor(iface: Class[_]): Boolean = iface.isInstance(this)
+  def isWrapperFor(iface: Class[?]): Boolean = iface.isInstance(this)
 
   def unwrap[T](iface: Class[T]): T =
     if(iface.isInstance(this)) this.asInstanceOf[T]

--- a/slick/src/main/scala/slick/jdbc/H2Profile.scala
+++ b/slick/src/main/scala/slick/jdbc/H2Profile.scala
@@ -93,12 +93,12 @@ trait H2Profile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerStat
     super.computeQueryCompiler.replace(Phase.resolveZipJoinsRownumStyle) - Phase.fixRowNumberOrdering
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new H2QueryBuilder(n, state)
   override def createUpsertBuilder(node: Insert): InsertBuilder = new H2UpsertBuilder(node)
-  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder =
+  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[?]): ColumnDDLBuilder =
     new H2ColumnDDLBuilder(column)
   override def createInsertActionExtensionMethods[T](compiled: CompiledInsert): InsertActionExtensionMethods[T] =
     new H2CountingInsertActionComposerImpl[T](compiled)
 
-  override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
+  override def defaultSqlTypeName(tmd: JdbcType[?], sym: Option[FieldSymbol]): String = tmd.sqlType match {
     case java.sql.Types.VARCHAR =>
       val size = sym.flatMap(_.findColumnOption[RelationalProfile.ColumnOption.Length])
       size.fold("VARCHAR")(l => if(l.varying) s"VARCHAR(${l.length})" else s"CHAR(${l.length})")

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -53,13 +53,13 @@ trait JdbcBackend extends RelationalBackend {
       * `request()` more data. This allows you to process LOBs asynchronously by requesting only
       * one single element at a time after processing the current one, so that the proper
       * sequencing is preserved even though processing may happen on a different thread. */
-    final def stream[T](a: StreamingDBIO[_, T], bufferNext: Boolean): DatabasePublisher[T] =
+    final def stream[T](a: StreamingDBIO[?, T], bufferNext: Boolean): DatabasePublisher[T] =
       createPublisher(a, s => new JdbcStreamingActionContext(s, false, this, bufferNext))
 
     override protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean): Context =
       new JdbcActionContext { val useSameThread = _useSameThread }
 
-    override protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[_ >: T], useSameThread: Boolean): StreamingContext =
+    override protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[? >: T], useSameThread: Boolean): StreamingContext =
       new JdbcStreamingActionContext(s, useSameThread, this, true)
 
     protected[this] def synchronousExecutionContext = executor.executionContext
@@ -589,7 +589,7 @@ trait JdbcBackend extends RelationalBackend {
     def connection: Connection = session.conn
   }
 
-  class JdbcStreamingActionContext(subscriber: Subscriber[_], useSameThread: Boolean, database: Database, val bufferNext: Boolean) extends BasicStreamingActionContext(subscriber, useSameThread, database) with JdbcActionContext
+  class JdbcStreamingActionContext(subscriber: Subscriber[?], useSameThread: Boolean, database: Database, val bufferNext: Boolean) extends BasicStreamingActionContext(subscriber, useSameThread, database) with JdbcActionContext
 }
 
 object JdbcBackend extends JdbcBackend {

--- a/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
@@ -98,7 +98,7 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
   class Builders(val tablesByQName: Map[MQName, TableBuilder])
 
   /** Converts from java.sql.Types w/ type name to the corresponding Java class name (with fully qualified path). */
-  def jdbcTypeToScala(jdbcType: Int, typeName: String = ""): ClassTag[_] = {
+  def jdbcTypeToScala(jdbcType: Int, typeName: String = ""): ClassTag[?] = {
     import java.sql.Types.*
 
     import scala.reflect.classTag
@@ -247,7 +247,7 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
       *
       * If `ignoreInvalidDefaults = true`, Slick catches scala.MatchError and java.lang.NumberFormatException thrown by
       * this method, logs the message and treats it as no default value for convenience. */
-    def defaultColumnOption: Option[RelationalProfile.ColumnOption.Default[_]] = rawDefault.map(v => (v,tpe)).collect {
+    def defaultColumnOption: Option[RelationalProfile.ColumnOption.Default[?]] = rawDefault.map(v => (v,tpe)).collect {
       case (v,_) if Seq("NOW","CURRENT_TIMESTAMP","CURRENT_DATE","CURRENT_TIME").contains(v.stripSuffix("()").toUpperCase) =>
         logger.debug(s"Ignoring"+formatDefault(v))
         None
@@ -260,7 +260,7 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
       )
     }
 
-    private def convenientDefault: Option[RelationalProfile.ColumnOption.Default[_]] =
+    private def convenientDefault: Option[RelationalProfile.ColumnOption.Default[?]] =
       try defaultColumnOption catch {
         case e: java.lang.NumberFormatException if ignoreInvalidDefaults =>
           logger.debug(s"NumberFormatException: Could not parse"+formatDefault(rawDefault))

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -160,7 +160,7 @@ class LoggingStatement(st: Statement) extends Statement {
   override def setFetchDirection(direction: Int) = st.setFetchDirection(direction)
   override def getFetchDirection: Int = st.getFetchDirection
   override def getResultSetConcurrency: Int = st.getResultSetConcurrency
-  override def isWrapperFor(iface: Class[_]): Boolean = st.isWrapperFor(iface)
+  override def isWrapperFor(iface: Class[?]): Boolean = st.isWrapperFor(iface)
   override def clearBatch() = st.clearBatch()
   override def close() = st.close()
   override def isClosed: Boolean = st.isClosed

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -119,7 +119,7 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
 
     //https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html
     import scala.reflect.{classTag, ClassTag}
-    override def jdbcTypeToScala(jdbcType: Int, typeName: String = ""): ClassTag[_] = {
+    override def jdbcTypeToScala(jdbcType: Int, typeName: String = ""): ClassTag[?] = {
       import java.sql.Types.*
       jdbcType match{
         case TINYINT if typeName.contains("UNSIGNED")  =>  classTag[Short]
@@ -150,14 +150,14 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
     super.computeQueryCompiler.replace(new MySQLResolveZipJoins) - Phase.fixRowNumberOrdering
   override def createQueryBuilder(n: Node, state: CompilerState): QueryBuilder = new MySQLQueryBuilder(n, state)
   override def createUpsertBuilder(node: Insert): InsertBuilder = new MySQLUpsertBuilder(node)
-  override def createTableDDLBuilder(table: Table[_]): TableDDLBuilder = new MySQLTableDDLBuilder(table)
-  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[_]): ColumnDDLBuilder =
+  override def createTableDDLBuilder(table: Table[?]): TableDDLBuilder = new MySQLTableDDLBuilder(table)
+  override def createColumnDDLBuilder(column: FieldSymbol, table: Table[?]): ColumnDDLBuilder =
     new MySQLColumnDDLBuilder(column)
-  override def createSequenceDDLBuilder(seq: Sequence[_]): SequenceDDLBuilder = new MySQLSequenceDDLBuilder(seq)
+  override def createSequenceDDLBuilder(seq: Sequence[?]): SequenceDDLBuilder = new MySQLSequenceDDLBuilder(seq)
 
   override def quoteIdentifier(id: String) = s"`$id`"
 
-  override def defaultSqlTypeName(tmd: JdbcType[_], sym: Option[FieldSymbol]): String = tmd.sqlType match {
+  override def defaultSqlTypeName(tmd: JdbcType[?], sym: Option[FieldSymbol]): String = tmd.sqlType match {
     case java.sql.Types.VARCHAR =>
       sym.flatMap(_.findColumnOption[RelationalProfile.ColumnOption.Length]) match {
         case Some(l) => if(l.varying){
@@ -169,7 +169,7 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
         case None => defaultStringType match {
           case Some(s) => s
           case None =>
-            if(sym.flatMap(_.findColumnOption[RelationalProfile.ColumnOption.Default[_]]).isDefined ||
+            if(sym.flatMap(_.findColumnOption[RelationalProfile.ColumnOption.Default[?]]).isDefined ||
                sym.flatMap(_.findColumnOption[ColumnOption.PrimaryKey.type]).isDefined)
               "VARCHAR(254)" else "TEXT"
         }
@@ -295,7 +295,7 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
     }
   }
 
-  class MySQLTableDDLBuilder(table: Table[_]) extends TableDDLBuilder(table) {
+  class MySQLTableDDLBuilder(table: Table[?]) extends TableDDLBuilder(table) {
     override protected def dropForeignKey(fk: ForeignKey) = {
       "ALTER TABLE " + quoteTableName(table.tableNode) + " DROP FOREIGN KEY " + quoteIdentifier(fk.name)
     }

--- a/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
+++ b/slick/src/main/scala/slick/jdbc/StatementInvoker.scala
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 private[jdbc] object StatementInvoker {
   val maxLogResults = 5
   lazy val tableDump = new TableDump(20)
-  lazy val resultLogger = new SlickLogger(LoggerFactory.getLogger(classOf[StatementInvoker[_]].getName+".result"))
+  lazy val resultLogger = new SlickLogger(LoggerFactory.getLogger(classOf[StatementInvoker[?]].getName+".result"))
 }
 
 /** An invoker which executes an SQL statement through JDBC. */

--- a/slick/src/main/scala/slick/lifted/Case.scala
+++ b/slick/src/main/scala/slick/lifted/Case.scala
@@ -14,7 +14,7 @@ import slick.util.ConstArray
   * missing, the result is also an `Option`.  */
 object Case {
 
-  def If[C <: Rep[_] : CanBeQueryCondition](cond: C) = new UntypedWhen(cond.toNode)
+  def If[C <: Rep[?] : CanBeQueryCondition](cond: C) = new UntypedWhen(cond.toNode)
 
   final class UntypedWhen(cond: Node) {
     def Then[P, B](res: Rep[P])(implicit om: OptionMapperDSL.arg[B, P]#to[B, P], bType: BaseTypedType[B]) =
@@ -28,7 +28,7 @@ object Case {
         else clauses.zipWithIndex.map { case (n, i) => if(i % 2 == 0) n else OptionApply(n) }
       IfThenElse(cl :+ LiteralNode(null))
     }
-    def If[C <: Rep[_] : CanBeQueryCondition](cond: C) = new TypedWhen[B,T](cond.toNode, clauses)
+    def If[C <: Rep[?] : CanBeQueryCondition](cond: C) = new TypedWhen[B,T](cond.toNode, clauses)
     def Else(res: Rep[T]): Rep[T] = Rep.forNode(IfThenElse(clauses :+ res.toNode))
   }
 

--- a/slick/src/main/scala/slick/lifted/Constraint.scala
+++ b/slick/src/main/scala/slick/lifted/Constraint.scala
@@ -24,15 +24,15 @@ final class ForeignKey( //TODO Simplify this mess!
     val linearizedTargetColumns: IndexedSeq[Node],
     val linearizedTargetColumnsForOriginalTargetTable: IndexedSeq[Node],
     val targetTable: TableNode,
-    val columnsShape: Shape[_ <: FlatShapeLevel, _, _, _])
+    val columnsShape: Shape[? <: FlatShapeLevel, ?, ?, ?])
 
 object ForeignKey {
-  def apply[TT <: AbstractTable[_], P](
+  def apply[TT <: AbstractTable[?], P](
       name: String,
       sourceTable: Node,
-      targetTableShaped: ShapedValue[TT, _],
+      targetTableShaped: ShapedValue[TT, ?],
       originalTargetTable: TT,
-      pShape: Shape[_ <: FlatShapeLevel, P, _, _],
+      pShape: Shape[? <: FlatShapeLevel, P, ?, ?],
       originalSourceColumns: P,
       originalTargetColumns: TT => P,
       onUpdate: model.ForeignKeyAction,
@@ -64,9 +64,9 @@ object ForeignKey {
 }
 
 /** A query that selects data linked by a foreign key. */
-class ForeignKeyQuery[E <: AbstractTable[_], U](
+class ForeignKeyQuery[E <: AbstractTable[?], U](
     nodeDelegate: Node,
-    base: ShapedValue[_ <: E, U],
+    base: ShapedValue[? <: E, U],
     val fks: IndexedSeq[ForeignKey],
     targetBaseQuery: Query[E, U, Seq],
     generator: AnonSymbol,
@@ -92,4 +92,4 @@ class ForeignKeyQuery[E <: AbstractTable[_], U](
 case class PrimaryKey(name: String, columns: IndexedSeq[Node]) extends Constraint
 
 /** An index (or foreign key constraint with an implicit index). */
-class Index(val name: String, val table: AbstractTable[_], val on: IndexedSeq[Node], val unique: Boolean)
+class Index(val name: String, val table: AbstractTable[?], val on: IndexedSeq[Node], val unique: Boolean)

--- a/slick/src/main/scala/slick/lifted/OptionMapper.scala
+++ b/slick/src/main/scala/slick/lifted/OptionMapper.scala
@@ -79,12 +79,12 @@ sealed trait OptionLift[M, O] {
 }
 
 object OptionLift extends OptionLiftLowPriority {
-  final implicit def repOptionLift[M <: Rep[_], P](implicit shape: Shape[_ <: FlatShapeLevel, M, _, Rep[P]]): OptionLift[M, Rep[Option[P]]] = new OptionLift[M, Rep[Option[P]]] {
+  final implicit def repOptionLift[M <: Rep[?], P](implicit shape: Shape[? <: FlatShapeLevel, M, ?, Rep[P]]): OptionLift[M, Rep[Option[P]]] = new OptionLift[M, Rep[Option[P]]] {
     def lift(v: M): Rep[Option[P]] = {
       val n = OptionApply(v.toNode)
       val packed = shape.pack(v)
       packed match {
-        case r: Rep.TypedRep[_] if !r.tpe.isInstanceOf[OptionType] /* An primitive column */ =>
+        case r: Rep.TypedRep[?] if !r.tpe.isInstanceOf[OptionType] /* An primitive column */ =>
           Rep.forNode[Option[P]](n)(r.tpe.asInstanceOf[TypedType[P]].optionType)
         case _ =>
           RepOption[P](ShapedValue(packed, shape.packedShape), n)
@@ -95,7 +95,7 @@ object OptionLift extends OptionLiftLowPriority {
 }
 
 sealed trait OptionLiftLowPriority {
-  final implicit def anyOptionLift[M, P](implicit shape: Shape[_ <: FlatShapeLevel, M, _, P]): OptionLift[M, Rep[Option[P]]] = new OptionLift[M, Rep[Option[P]]] {
+  final implicit def anyOptionLift[M, P](implicit shape: Shape[? <: FlatShapeLevel, M, ?, P]): OptionLift[M, Rep[Option[P]]] = new OptionLift[M, Rep[Option[P]]] {
     def lift(v: M): Rep[Option[P]] =
       RepOption[P](ShapedValue(shape.pack(v), shape.packedShape), OptionApply(shape.toNode(v)))
     override def toString = s"AnyOptionLift($shape)"
@@ -103,8 +103,8 @@ sealed trait OptionLiftLowPriority {
 
   /** Get a suitably typed base value for a `Rep[Option[_]]` */
   def baseValue[M, O](v: O, path: Node): M = v match {
-    case RepOption(base, _) => base.asInstanceOf[ShapedValue[M, _]].encodeRef(path).value
-    case r: Rep.TypedRep[_] /* An Option column */ =>
+    case RepOption(base, _) => base.asInstanceOf[ShapedValue[M, ?]].encodeRef(path).value
+    case r: Rep.TypedRep[?] /* An Option column */ =>
       Rep.columnPlaceholder[Any](r.tpe.asInstanceOf[OptionType].elementType.asInstanceOf[TypedType[Any]]).encodeRef(path).asInstanceOf[M]
   }
 }

--- a/slick/src/main/scala/slick/lifted/Rep.scala
+++ b/slick/src/main/scala/slick/lifted/Rep.scala
@@ -76,6 +76,6 @@ final case class LiteralColumn[T](value: T)(implicit tt: TypedType[T]) extends C
   * representation is necessary so that a non-Option `Rep` value can be retrieved for encoding
   * Option-based operations. This base value is of type `T` if `T <: Rep[_]`, otherwise of
   * type `Rep[T]`. */
-final case class RepOption[T](base: ShapedValue[_, _], toNode: Node) extends Rep[Option[T]] {
+final case class RepOption[T](base: ShapedValue[?, ?], toNode: Node) extends Rep[Option[T]] {
   def encodeRef(path: Node): Rep[Option[T]] = copy(toNode = path)
 }

--- a/slick/src/main/scala/slick/lifted/SimpleFunction.scala
+++ b/slick/src/main/scala/slick/lifted/SimpleFunction.scala
@@ -18,7 +18,7 @@ trait SimpleFunction extends Node {
 }
 
 object SimpleFunction {
-  def apply[T : TypedType](fname: String, fn: Boolean = false): (Seq[Rep[_]] => Rep[T]) = {
+  def apply[T : TypedType](fname: String, fn: Boolean = false): (Seq[Rep[?]] => Rep[T]) = {
     def build(params: IndexedSeq[Node]): SimpleFeatureNode[T] = new SimpleFeatureNode[T] with SimpleFunction {
       override def self: Self = this
       val name = fname
@@ -26,7 +26,7 @@ object SimpleFunction {
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]): Self = build(ch.toSeq)
     }
-    { (paramsC: Seq[Rep[_]]) => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
+    { (paramsC: Seq[Rep[?]]) => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
   def nullary[R : TypedType](fname: String, fn: Boolean = false): Rep[R] =
     apply(fname, fn).apply(Seq())
@@ -50,7 +50,7 @@ trait SimpleBinaryOperator extends BinaryNode {
 }
 
 object SimpleBinaryOperator {
-  def apply[T : TypedType](fname: String): ((Rep[_], Rep[_]) => Rep[T]) = {
+  def apply[T : TypedType](fname: String): ((Rep[?], Rep[?]) => Rep[T]) = {
     def build(leftN: Node, rightN: Node): SimpleFeatureNode[T] = new SimpleFeatureNode[T] with SimpleBinaryOperator {
       override def self: Self = this
       val name = fname
@@ -58,7 +58,7 @@ object SimpleBinaryOperator {
       val right = rightN
       protected[this] def rebuild(left: Node, right: Node): Self = build(left, right)
     }
-    { (leftC: Rep[_], rightC: Rep[_]) => Rep.forNode[T](build(leftC.toNode, rightC.toNode)) }
+    { (leftC: Rep[?], rightC: Rep[?]) => Rep.forNode[T](build(leftC.toNode, rightC.toNode)) }
   }
 }
 
@@ -79,14 +79,14 @@ trait SimpleExpression extends Node {
 }
 
 object SimpleExpression {
-  def apply[T : TypedType](f: (Seq[Node], JdbcStatementBuilderComponent#QueryBuilder) => Unit): (Seq[Rep[_]] => Rep[T]) = {
+  def apply[T : TypedType](f: (Seq[Node], JdbcStatementBuilderComponent#QueryBuilder) => Unit): (Seq[Rep[?]] => Rep[T]) = {
     def build(params: IndexedSeq[Node]): SimpleFeatureNode[T] = new SimpleFeatureNode[T] with SimpleExpression {
       override def self: Self = this
       def toSQL(qb: JdbcStatementBuilderComponent#QueryBuilder) = f(children.toSeq, qb)
       def children = ConstArray.from(params)
       protected[this] def rebuild(ch: ConstArray[Node]) = build(ch.toSeq)
     }
-    { (paramsC: Seq[Rep[_]]) => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
+    { (paramsC: Seq[Rep[?]]) => Rep.forNode(build(paramsC.iterator.map(_.toNode).toIndexedSeq)) }
   }
 
   def nullary[R : TypedType](f: JdbcStatementBuilderComponent#QueryBuilder => Unit): Rep[R] = {

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -33,7 +33,7 @@ trait DistributedBackend extends RelationalBackend with Logging {
     protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean): Context =
       new BasicActionContext { val useSameThread = _useSameThread }
 
-    protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[_ >: T],
+    protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[? >: T],
                                                                 useSameThread: Boolean): StreamingContext =
       new BasicStreamingActionContext(s, useSameThread, this)
 

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -32,7 +32,7 @@ trait HeapBackend extends RelationalBackend with Logging {
     protected[this] def createDatabaseActionContext[T](_useSameThread: Boolean): Context =
       new BasicActionContext { val useSameThread = _useSameThread }
 
-    protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[_ >: T],
+    protected[this] def createStreamingDatabaseActionContext[T](s: Subscriber[? >: T],
                                                                 useSameThread: Boolean): StreamingContext =
       new BasicStreamingActionContext(s, useSameThread, this)
 

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -284,7 +284,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         val coll = run(ch).asInstanceOf[Coll]
         val (it, itType) = unwrapSingleColumn(coll, ch.nodeType)
         val (num, opt) = itType match {
-          case t: ScalaOptionType[_] => (t.elementType.asInstanceOf[ScalaNumericType[Any]].numeric, true)
+          case t: ScalaOptionType[?] => (t.elementType.asInstanceOf[ScalaNumericType[Any]].numeric, true)
           case t => (t.asInstanceOf[ScalaNumericType[Any]].numeric, false)
         }
         reduceOptionIt[Any](it, opt, identity, (a, b) => num.plus(a, b))
@@ -292,7 +292,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         val coll = run(ch).asInstanceOf[Coll]
         val (it, itType) = unwrapSingleColumn(coll, ch.nodeType)
         val (num, opt) = itType match {
-          case t: ScalaOptionType[_] => (t.elementType.asInstanceOf[ScalaNumericType[Any]].numeric, true)
+          case t: ScalaOptionType[?] => (t.elementType.asInstanceOf[ScalaNumericType[Any]].numeric, true)
           case t => (t.asInstanceOf[ScalaNumericType[Any]].numeric, false)
         }
         reduceOptionIt[(Int, Any)](it, opt, (1, _), { case ((ai, a), (bi, b)) => (ai + bi, num.plus(a, b)) }).map { case (count, sum) =>
@@ -303,7 +303,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         val coll = run(ch).asInstanceOf[Coll]
         val (it, itType) = unwrapSingleColumn(coll, ch.nodeType)
         val (ord, opt) = itType match {
-          case t: ScalaOptionType[_] => (t.elementType.asInstanceOf[ScalaBaseType[Any]].ordering, true)
+          case t: ScalaOptionType[?] => (t.elementType.asInstanceOf[ScalaBaseType[Any]].ordering, true)
           case t => (t.asInstanceOf[ScalaBaseType[Any]].ordering, false)
         }
         reduceOptionIt[Any](it, opt, identity, (a, b) => if(ord.lt(b, a)) b else a)
@@ -311,7 +311,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         val coll = run(ch).asInstanceOf[Coll]
         val (it, itType) = unwrapSingleColumn(coll, ch.nodeType)
         val (ord, opt) = itType match {
-          case t: ScalaOptionType[_] => (t.elementType.asInstanceOf[ScalaBaseType[Any]].ordering, true)
+          case t: ScalaOptionType[?] => (t.elementType.asInstanceOf[ScalaBaseType[Any]].ordering, true)
           case t => (t.asInstanceOf[ScalaBaseType[Any]].ordering, false)
         }
         reduceOptionIt[Any](it, opt, identity, (a, b) => if(ord.gt(b, a)) b else a)
@@ -458,7 +458,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
   }
 
   def createNullRow(tpe: Type): Any = tpe match {
-    case t: ScalaType[_] => if(t.nullable) None else null
+    case t: ScalaType[?] => if(t.nullable) None else null
     case StructType(el) =>
       new StructValue(el.toSeq.map{ case (_, tpe) => createNullRow(tpe) },
         el.toSeq.zipWithIndex.iterator.map{ case ((sym, _), idx) => (sym, idx) }.toMap)

--- a/slick/src/main/scala/slick/model/Model.scala
+++ b/slick/src/main/scala/slick/model/Model.scala
@@ -21,7 +21,7 @@ case class Table(
   primaryKey: Option[PrimaryKey],
   foreignKeys: Seq[ForeignKey],
   indices: Seq[Index],
-  options: Set[TableOption[_]] = Set()
+  options: Set[TableOption[?]] = Set()
 ){
   require( name.table != "", "name cannot be empty string" )
 }
@@ -32,7 +32,7 @@ case class Column(
   table: QualifiedName,
   tpe: String,
   nullable: Boolean,
-  options: Set[ColumnOption[_]] = Set()
+  options: Set[ColumnOption[?]] = Set()
 ){
   require( name != "", "name cannot be empty string" )
 }
@@ -41,7 +41,7 @@ case class PrimaryKey(
   name: Option[String],
   table: QualifiedName,
   columns: Seq[Column],
-  options: Set[PrimaryKeyOption[_]] = Set()
+  options: Set[PrimaryKeyOption[?]] = Set()
 ){
   require( !name.contains(""), "name cannot be empty string" )
 }
@@ -54,7 +54,7 @@ case class ForeignKey(
   referencedColumns: Seq[Column],
   onUpdate: ForeignKeyAction,
   onDelete: ForeignKeyAction,
-  options: Set[ForeignKeyOption[_]] = Set()
+  options: Set[ForeignKeyOption[?]] = Set()
 ){
   require( !name.contains(""), "name cannot be empty string" )
 }
@@ -75,7 +75,7 @@ case class Index(
   table: QualifiedName,
   columns: Seq[Column],
   unique: Boolean,
-  options: Set[IndexOption[_]] = Set()
+  options: Set[IndexOption[?]] = Set()
 ){
   require( !name.contains(""), "name cannot be empty string" )
 }
@@ -88,7 +88,7 @@ case class Index(
  */
 case class Model(
   tables: Seq[Table],
-  options: Set[ModelOption[_]] = Set()
+  options: Set[ModelOption[?]] = Set()
 ){
   lazy val tablesByName = tables.map(t => t.name->t).toMap
   /**

--- a/slick/src/main/scala/slick/relational/RelationalProfile.scala
+++ b/slick/src/main/scala/slick/relational/RelationalProfile.scala
@@ -80,7 +80,7 @@ trait RelationalProfile extends BasicProfile with RelationalTableComponent
   class FastPathExtensionMethods[R, W, U, T](val mp: MappedProjection[T]) {
     def fastPath(fpf: TypeMappingResultConverter[R, W, U, T, ?] => SimpleFastPathResultConverter[R, W, U, T]
                 ): MappedProjection[T] = mp.genericFastPath {
-      case tm @ TypeMappingResultConverter(_: ProductResultConverter[_, _, _, _], _, _) =>
+      case tm @ TypeMappingResultConverter(_: ProductResultConverter[?, ?, ?, ?], _, _) =>
         fpf(tm.asInstanceOf[TypeMappingResultConverter[R, W, U, T, ?]])
       case tm                                                                           =>
         tm

--- a/slick/src/main/scala/slick/util/ClassLoaderUtil.scala
+++ b/slick/src/main/scala/slick/util/ClassLoaderUtil.scala
@@ -8,7 +8,7 @@ object ClassLoaderUtil {
   /** Get the default classloader to use to dynamically load classes. */
   val defaultClassLoader: ClassLoader = {
     new ClassLoader(this.getClass.getClassLoader) {
-      override def loadClass(name: String): Class[_] = {
+      override def loadClass(name: String): Class[?] = {
         try {
           // Try the context classloader first. But, during macro compilation, it's probably wrong, so fallback to this
           // classloader.

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -93,7 +93,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
     var len = 0
     var i = 0
     while(i < length) {
-      len += a(i).asInstanceOf[ConstArray[_]].length
+      len += a(i).asInstanceOf[ConstArray[?]].length
       i += 1
     }
     if(len == 0) ConstArray.empty
@@ -102,7 +102,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
       i = 0
       var j = 0
       while(i < length) {
-        val r = a(i).asInstanceOf[ConstArray[_]]
+        val r = a(i).asInstanceOf[ConstArray[?]]
         val l = r.length
         r.copySliceTo(ar, 0, j, l)
         j += l
@@ -361,7 +361,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
 
   ///////////////////////////////////////////////////////// Equals
 
-  def canEqual(that: Any): Boolean = that.isInstanceOf[ConstArray[_]]
+  def canEqual(that: Any): Boolean = that.isInstanceOf[ConstArray[?]]
 
   private[this] var _hashCode: Int = 0
 
@@ -375,7 +375,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
   }
 
   override def equals(o: Any): Boolean = o match {
-    case o: ConstArray[_] =>
+    case o: ConstArray[?] =>
       if(length != o.length) false
       else {
         var i = 0
@@ -502,7 +502,7 @@ final class ConstArrayBuilder[T](initialCapacity: Int = 16, growFactor: Double =
   }
 
   def ++= (vs: IterableOnce[T]): Unit = {
-    if(vs.isInstanceOf[scala.collection.IndexedSeq[_]]) ensure(vs.asInstanceOf[scala.collection.IndexedSeq[_]].size)
+    if(vs.isInstanceOf[scala.collection.IndexedSeq[?]]) ensure(vs.asInstanceOf[scala.collection.IndexedSeq[?]].size)
     vs.iterator.foreach(self += _)
   }
 

--- a/slick/src/main/scala/slick/util/InternalArrayQueue.scala
+++ b/slick/src/main/scala/slick/util/InternalArrayQueue.scala
@@ -105,7 +105,7 @@ private[util] final class InternalArrayQueue[E >: Null <: AnyRef](capacity: Int)
     takeIndex = 0
   }
 
-  private[util] def drainTo(c: util.Collection[_ >: E]): Int = {
+  private[util] def drainTo(c: util.Collection[? >: E]): Int = {
     checkNotNull(c)
     val items = this.items
     var i = takeIndex
@@ -125,7 +125,7 @@ private[util] final class InternalArrayQueue[E >: Null <: AnyRef](capacity: Int)
     n
   }
 
-  private[util] def drainTo(c: util.Collection[_ >: E], maxElements: Int): Int = {
+  private[util] def drainTo(c: util.Collection[? >: E], maxElements: Int): Int = {
     checkNotNull(c)
     if (maxElements <= 0) return 0
     val items = this.items

--- a/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
+++ b/slick/src/main/scala/slick/util/ManagedArrayBlockingQueue.scala
@@ -194,7 +194,7 @@ class ManagedArrayBlockingQueue(maximumInUse: Int, capacity: Int, fair: Boolean 
     itemQueueNotFull.signalAll()
   }
 
-  def drainTo(c: util.Collection[_ >: PrioritizedRunnable]): Int = locked {
+  def drainTo(c: util.Collection[? >: PrioritizedRunnable]): Int = locked {
     val n = highPriorityItemQueue.drainTo(c) + itemQueue.drainTo(c)
     if (remainingCapacity != 0) {
       itemQueueNotFull.signalAll()
@@ -202,7 +202,7 @@ class ManagedArrayBlockingQueue(maximumInUse: Int, capacity: Int, fair: Boolean 
     n
   }
 
-  def drainTo(c: util.Collection[_ >: PrioritizedRunnable], maxElements: Int): Int = locked {
+  def drainTo(c: util.Collection[? >: PrioritizedRunnable], maxElements: Int): Int = locked {
     var n = highPriorityItemQueue.drainTo(c, maxElements)
     if (n < maxElements) {
       n += itemQueue.drainTo(c, maxElements - n)

--- a/slick/src/main/scala/slick/util/TreePrinter.scala
+++ b/slick/src/main/scala/slick/util/TreePrinter.scala
@@ -83,7 +83,7 @@ case class DumpInfo(name: String, mainInfo: String = "", attrInfo: String = "", 
 }
 
 object DumpInfo {
-  def simpleNameFor(cl: Class[_]): String = cl.getName.replaceFirst(".*\\.", "")
+  def simpleNameFor(cl: Class[?]): String = cl.getName.replaceFirst(".*\\.", "")
 
   def highlight(s: String) = cGreen + s + cNormal
 }


### PR DESCRIPTION
`[_]` is deprecated in latest Scala 3.

```
Welcome to Scala 3.6.3 (21.0.5, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                           
scala> val a: List[_] = Nil
1 warning found
-- Warning: --------------------------------------------------------------------
1 |val a: List[_] = Nil
  |            ^
  |        `_` is deprecated for wildcard arguments of types: use `?` instead
val a: List[?] = List()
                                                                                                                                           
scala> val b: List[?] = Nil
val b: List[?] = List()
```