### PR TITLE
fix `mapTo` macro

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/compile/CompanionObjectTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/compile/CompanionObjectTest.scala
@@ -47,9 +47,8 @@ class CompanionObjectTest extends AsyncTest[RelationalTestDB] {
     }
   }
 
-  // This test should simply be able to compile. The mapTo macro should generate code that
-  // doesn't compile when the hand-written tupled method doesn't have the correct signature.
-  def testMapToLocalBadTupled = ShouldNotTypecheck("""
+
+  def testMapToLocalBadTupled = {
     object PersonLocal {
       def tupled(t: (Long, Int)): PersonLocal = ???
     }
@@ -59,12 +58,9 @@ class CompanionObjectTest extends AsyncTest[RelationalTestDB] {
       def name = column[String]("name")
       def * = (id, name).mapTo[PersonLocal]
     }
-    """, "type mismatch.*found   : \\(\\(Long, Int\\)\\) =>.*required: \\(\\(Long, String\\)\\) =>.*")
+  }
 
-  // Because the macro can't locate companion objects of method-local case classes,
-  // it's safer to leave them broken rather than make assumptions about the existence
-  // of user-defined tupled methods.
-  def testMapToLocal = ShouldNotTypecheck("""
+  def testMapToLocal = {
     object PersonLocal {}
     case class PersonLocal(id: Long, name: String)
     class People(tag: Tag) extends Table[PersonLocal](tag, "people") {
@@ -72,5 +68,5 @@ class CompanionObjectTest extends AsyncTest[RelationalTestDB] {
       def name = column[String]("name")
       def * = (id, name).mapTo[PersonLocal]
     }
-  """, "value tupled is not a member of object PersonLocal")
+  }
 }

--- a/slick/src/main/scala-2/slick/lifted/ShapedValue.scala
+++ b/slick/src/main/scala-2/slick/lifted/ShapedValue.scala
@@ -35,7 +35,7 @@ object ShapedValue {
       case s        => q"$s"
     }
     val rHasTupled = rSym.companion match {
-      case NoSymbol => true
+      case NoSymbol => false
       case s        => s.info.member(TermName("tupled")) != NoSymbol
     }
     val fields =


### PR DESCRIPTION
This pull request change `A.tupled` => `(A.apply _).tupled` if there is no explicit companion object.

because case class companion no longer has `tupled` method if add `-Xsource:3-cross` option in latest Scala 2.13.x.

- https://github.com/scala/bug/issues/12961

