### PR TITLE
Fix mapTo compiling when it shouldn't on Scala 3

### DIFF
--- a/slick/src/main/scala-3/slick/lifted/ShapedValue.scala
+++ b/slick/src/main/scala-3/slick/lifted/ShapedValue.scala
@@ -69,10 +69,14 @@ object ShapedValue {
         }
     }
 
-    if(elemTpes.length != targetElemTpes.length) {
+    val notMatchTypes = (elemTpes.length > 1) && (
+      !elemTpes.lazyZip(targetElemTpes).forall((x, y) => TypeRepr.of(using x) =:= TypeRepr.of(using y))
+    )
+
+    if ((elemTpes.length != targetElemTpes.length) || notMatchTypes) {
       // todo: change
-      val src = elemTpes.iterator.map(x => Type.show(using summon[Type[U]])).mkString("(", ", ", ")")
-      val target = targetElemTpes.iterator.map(x => Type.show(using summon[Type[U]])).mkString("(", ", ", ")")
+      val src = elemTpes.iterator.map(x => Type.show(using x)).mkString("(", ", ", ")")
+      val target = targetElemTpes.iterator.map(x => Type.show(using x)).mkString("(", ", ", ")")
       report.errorAndAbort(s"Source and target product decomposition do not match.\n  Source: $src\n  Target: $target")
     }
 


### PR DESCRIPTION
- fix https://github.com/slick/slick/issues/3142

```
Welcome to Scala 3.3.1 (21.0.7, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                             
scala> import slick.jdbc.PostgresProfile.api._
     | 
     | case class Coffee(name: String, price: Double)
     | 
     | class Coffees(tag: Tag) extends Table[Coffee](tag, "COFFEES") {
     |   def name = column[String]("NAME")
     |   def price = column[Double]("PRICE")
     |   def * = (price, name).mapTo[Coffee]
     | }
-- Error: ----------------------------------------------------------------------
8 |  def * = (price, name).mapTo[Coffee]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |          Source and target product decomposition do not match.
  |            Source: (scala.Double, java.lang.String)
  |            Target: (java.lang.String, scala.Double)
1 error found
```