### PR TITLE
Sonatype snapshot resolvers warning correction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ inThisBuild(
   Seq(
     organizationName := "Typesafe",
     organization := "com.typesafe.slick",
-    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
     homepage := Some(url("https://scala-slick.org")),
     startYear := Some(2008),
     licenses += ("Two-clause BSD-style license", url("https://github.com/slick/slick/blob/main/LICENSE.txt")),


### PR DESCRIPTION
If I understood the warning correctly this change is a solution because there are no snapshot dependencies.

```
warning: method sonatypeOssRepos in class ResolverFunctions is deprecated (since 1.11.2): Sonatype OSS Repository Hosting (OSSRH) will be sunset on 2025-06-30; use the following instead:
  resolvers += Resolver.sonatypeCentralSnapshots
    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
```

Please let me know if I misunderstand anything.