### PR TITLE
Refactor Shape.primitiveShape to use Rep.TypedRep instead of ConstColumn

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
@@ -159,7 +159,7 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q1dt: Query[Rep[Option[Int]], ?, Seq] = q1d
     val q1d2t: Query[Rep[Option[(Rep[Int], Rep[String], Rep[Option[Int]])]], ?, Seq] = q1d2
     val q2dt: Query[Rep[Option[Int]], ?, Seq] = q2d
-    val q3dt: Query[Rep[Option[(Rep[Int], Rep[Int], ConstColumn[Int])]], ?, Seq] = q3d
+    val q3dt: Query[Rep[Option[(Rep[Int], Rep[Int], Rep[Int])]], ?, Seq] = q3d
     val q4dt: Query[Rep[Option[Int]], ?, Seq] = q4d
 
     lazy val t4 = seq(

--- a/slick-testkit/src/test/scala/slick/test/compile/NestedShapesTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/compile/NestedShapesTest.scala
@@ -17,14 +17,14 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), ?, ?]]
 
     // Flat and Nested alike, fully specified
-    implicitly[Shape[FlatShapeLevel, Int, Int, ConstColumn[Int]]]
-    implicitly[Shape[FlatShapeLevel, (Int, String), (Int, String), (ConstColumn[Int], ConstColumn[String])]]
-    implicitly[Shape[FlatShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], ConstColumn[Int])]]
-    implicitly[Shape[FlatShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (ConstColumn[Int], Rep[String]))]]
-    implicitly[Shape[NestedShapeLevel, Int, Int, ConstColumn[Int]]]
-    implicitly[Shape[NestedShapeLevel, (Int, String), (Int, String), (ConstColumn[Int], ConstColumn[String])]]
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], ConstColumn[Int])]]
-    implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (ConstColumn[Int], Rep[String]))]]
+    implicitly[Shape[FlatShapeLevel, Int, Int, Rep.TypedRep[Int]]]
+    implicitly[Shape[FlatShapeLevel, (Int, String), (Int, String), (Rep.TypedRep[Int], Rep.TypedRep[String])]]
+    implicitly[Shape[FlatShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], Rep.TypedRep[Int])]]
+    implicitly[Shape[FlatShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (Rep.TypedRep[Int], Rep[String]))]]
+    implicitly[Shape[NestedShapeLevel, Int, Int, Rep.TypedRep[Int]]]
+    implicitly[Shape[NestedShapeLevel, (Int, String), (Int, String), (Rep.TypedRep[Int], Rep.TypedRep[String])]]
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], Int), (Int, Int), (Rep[Int], Rep.TypedRep[Int])]]
+    implicitly[Shape[NestedShapeLevel, (Rep[Int], (Int, Rep[String])), (Int, (Int, String)), (Rep[Int], (Rep.TypedRep[Int], Rep[String]))]]
 
     // Only Nested, only Mixed specified
     implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], ?, ?]] // 1
@@ -36,7 +36,7 @@ class NestedShapesTest {
     implicitly[Shape[NestedShapeLevel, Query[Rep[Int], Int, Seq], Seq[Int], Query[Rep[Int], Int, Seq]]] // 5
     implicitly[Shape[NestedShapeLevel, Query[(Rep[Int], Rep[String]), (Int, String), Seq], Seq[(Int, String)], Query[(Rep[Int], Rep[String]), (Int, String), Seq]]] // 6
     implicitly[Shape[NestedShapeLevel, (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Rep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 7
-    implicitly[Shape[NestedShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (ConstColumn[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 8
+    implicitly[Shape[NestedShapeLevel, (Int, Query[(Rep[Int], Rep[String]), (Int, String), Seq]), (Int, Seq[(Int, String)]), (Rep.TypedRep[Int], Query[(Rep[Int], Rep[String]), (Int, String), Seq])]] // 8
   }
 
   def illegal1 = ShouldNotTypecheck("""

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -62,8 +62,8 @@ abstract class Shape[Level <: ShapeLevel, -Mixed_, Unpacked_, Packed_] {
 
 object Shape extends ConstColumnShapeImplicits with AbstractTableShapeImplicits with TupleShapeImplicits {
   implicit final def primitiveShape[T, Level <: ShapeLevel](implicit tm: TypedType[T]
-                                                           ): Shape[Level, T, T, ConstColumn[T]] =
-    new Shape[Level, T, T, ConstColumn[T]] {
+                                                           ): Shape[Level, T, T, Rep.TypedRep[T]] =
+    new Shape[Level, T, T, Rep.TypedRep[T]] {
       def pack(value: Any): Packed = LiteralColumn(value.asInstanceOf[T])
       def packedShape = RepShape[Level, Packed, Unpacked]
       def buildParams(extract: Any => Unpacked): Packed = new ConstColumn[T](new QueryParameter(extract, tm))(tm)


### PR DESCRIPTION
This fixes a ClassCastException that is a result of overpromising ConstColumn and not always producing one.

For example, in `table.map(_.*).flatMap { t => ...`, `t` may be a tuple with elements that are the result of Rep.TypedRep.encodeRef, not ConstColumn.