### PR TITLE
Make Versioning settings take precedence over CiReleasePlugin (by "requiring" it)

### DIFF
--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -2,6 +2,7 @@ import java.io.File
 import java.util.Date
 
 import Versioning.VersionInfo.VersionType
+import com.geirsson.CiReleasePlugin
 import com.github.sbt.git.DefaultReadableGit
 import coursier.version.Version
 import sbt.Keys.version
@@ -98,6 +99,7 @@ object Versioning extends AutoPlugin {
       .map(VersionInfo(compat, _).shortVersionString)
 
   override def trigger = allRequirements
+  override def requires = CiReleasePlugin
 
   override def projectSettings =
     List(


### PR DESCRIPTION


Our setting was ignored since sbt-ci-release 1.9.2, due to https://github.com/sbt/sbt-ci-release/pull/339

This caused our versionPolicyIgnoredInternalDependencyVersions not to match, which resulted in noise in the compatibility report PR comments.