### PR TITLE
Use stable Java matrix names to avoid Mergify updates

### DIFF
--- a/.github/workflows/check-scaladoc-links.yml
+++ b/.github/workflows/check-scaladoc-links.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  JAVA_VERSION: "11"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,7 +29,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: ${{ env.JAVA_VERSION }}
         cache: sbt
 
     - name: Setup SBT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+env:
+  # language=json
+  JAVA_VERSIONS: '{ "javaMin": "11", "javaLatest": "23" }'
+
 jobs:
   build:
     name: Build and Test
@@ -18,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ 11, 23 ]
+        java: [ javaMin, javaLatest ]
         scala: [ 2.12.x, 2.13.x, 3.x ]
 
     services:
@@ -73,7 +77,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: ${{ matrix.java }}
+          java-version: ${{ fromJson(env.JAVA_VERSIONS)[matrix.java] }}
           cache: sbt
 
       - name: Setup SBT
@@ -88,9 +92,9 @@ jobs:
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: always()    # run this step even if previous step failed
+        if: always()    # run this step even if a previous step failed
         with:
-          name: test-results-java${{ matrix.java }}-scala${{ matrix.scala }}
+          name: test-results-${{ matrix.java }}-scala${{ matrix.scala }}
           path: '**/target/test-reports/TEST-*.xml'
 
   deploy_docs:
@@ -109,7 +113,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 11
+          java-version: ${{ fromJson(env.JAVA_VERSIONS)['javaMin'] }}
           cache: sbt
 
       - name: Setup SBT
@@ -145,7 +149,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 11
+          java-version: ${{ fromJson(env.JAVA_VERSIONS)['javaMin'] }}
           cache: sbt
 
       - name: Setup SBT

--- a/.github/workflows/pr-compat-report-generate.yml
+++ b/.github/workflows/pr-compat-report-generate.yml
@@ -4,6 +4,9 @@ on:
  pull_request:
    branches: ['**']
 
+env:
+  JAVA_VERSION: "11"
+
 jobs:
   generate-report:
     runs-on: ubuntu-latest
@@ -19,9 +22,9 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: ${{ env.JAVA_VERSION }}
         cache: sbt
-        
+
     - name: Setup SBT
       uses: sbt/setup-sbt@v1
 

--- a/.github/workflows/version-policy-check.yml
+++ b/.github/workflows/version-policy-check.yml
@@ -12,6 +12,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+env:
+  JAVA_VERSION: "11"
+
 jobs:
   build:
     name: Check conformance with version policy
@@ -30,7 +33,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 11
+          java-version: ${{ env.JAVA_VERSION }}
           cache: sbt
 
       - name: Setup SBT

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,12 +19,12 @@ pull_request_rules:
 
   - name: Automatic merge on approval
     conditions:
-      - "check-success=Build and Test (11, 2.12.x)"
-      - "check-success=Build and Test (11, 2.13.x)"
-      - "check-success=Build and Test (11, 3.x)"
-      - "check-success=Build and Test (23, 2.12.x)"
-      - "check-success=Build and Test (23, 2.13.x)"
-      - "check-success=Build and Test (23, 3.x)"
+      - "check-success=Build and Test (javaMin, 2.12.x)"
+      - "check-success=Build and Test (javaMin, 2.13.x)"
+      - "check-success=Build and Test (javaMin, 3.x)"
+      - "check-success=Build and Test (javaLatest, 2.12.x)"
+      - "check-success=Build and Test (javaLatest, 2.13.x)"
+      - "check-success=Build and Test (javaLatest, 3.x)"
       - "check-success=Check conformance with version policy (2.12.x)"
       - "check-success=Check conformance with version policy (2.13.x)"
       - "check-success=Check conformance with version policy (3.x)"


### PR DESCRIPTION
## Summary
- Replace hardcoded Java version numbers (11, 23) with stable symbolic names (javaMin, javaLatest) in GitHub Actions matrix
- Add JSON mapping in env vars to lookup actual Java versions
- Update Mergify configuration to reference stable job names

## Benefits
- No need to update Mergify configuration when changing Java versions
- Job names remain stable: "Build and Test (javaMin, 2.12.x)" instead of "Build and Test (11, 2.12.x)"
- Easy to change Java versions by just updating the JAVA_VERSIONS env variable

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Check that job names appear correctly in GitHub Actions UI
- [ ] Confirm Mergify recognizes the new stable job names
- [ ] Test Java version lookup works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)