### PR TITLE
Speed up CI by disabling Scaladoc diagrams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,6 @@ jobs:
       - name: Start MySQL
         run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mysql --disable-log-bin
 
-      - uses: ts-graphviz/setup-graphviz@v2
-
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -89,6 +87,7 @@ jobs:
         env:
           SLICK_TESTKIT_CONFIG: test-dbs/testkit.github-actions.conf
           TZ: Asia/Kamchatka
+          SLICK_SKIP_DIAGRAMS: "true"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/build.sbt
+++ b/build.sbt
@@ -94,14 +94,18 @@ def slickGeneralSettings =
       _.withConfigurations(Vector(Compile, Runtime, Optional))
     },
     sonatypeProfileName := "com.typesafe.slick",
-    Compile / doc / scalacOptions ++= Seq(
-      "-doc-title", name.value,
-      "-doc-version", version.value,
-      "-doc-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
-      "-implicits",
-      "-diagrams", // requires graphviz
-      "-groups"
-    ),
+    Compile / doc / scalacOptions ++= {
+      val baseOptions = Seq(
+        "-doc-title", name.value,
+        "-doc-version", version.value,
+        "-doc-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
+        "-implicits",
+        "-groups"
+      )
+      // Skip diagrams to avoid graphviz dependency
+      if (sys.env.get("SLICK_SKIP_DIAGRAMS").contains("true")) baseOptions
+      else baseOptions :+ "-diagrams" // requires graphviz
+    },
     logBuffered := false
   ) ++ slickScalacOptions
 


### PR DESCRIPTION
## Summary
- Add `SLICK_SKIP_DIAGRAMS` environment variable to conditionally disable Scaladoc diagrams
- Remove graphviz dependency from main CI build job for faster builds
- Keep diagrams enabled for documentation deployment and release jobs

## Performance Impact
- Eliminates `ts-graphviz/setup-graphviz@v2` step from main CI builds
- Reduces build time by avoiding graphviz installation and diagram generation
- No impact on final documentation quality (diagrams still generated for releases)

## Implementation
- Build system respects `SLICK_SKIP_DIAGRAMS=true` environment variable
- Main CI job sets this flag and skips graphviz setup
- Documentation deployment and release jobs continue to generate full diagrams

## Test plan
- [ ] Verify main CI build completes without graphviz
- [ ] Confirm documentation deployment still generates diagrams
- [ ] Check that release artifacts include proper documentation

🤖 Generated with [Claude Code](https://claude.ai/code)