### PR TITLE
Update renovate configuration for SQL Server and Derby packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,19 +7,14 @@
       "matchPackagePatterns": [
         "^com\\.microsoft\\.sqlserver:.*"
       ],
-      "excludePackagePatterns": [
-        "^.*jre11.*"
-      ],
-      "branchName": "renovate/sqlserver-java17",
+      "allowedVersions": ".*jre11",
       "baseBranch": "java17"
     },
     {
       "matchPackagePatterns": [
         "^org\\.apache\\.derby:.*"
       ],
-      "allowedVersions": ">=10.15.0",
-      "branchName": "renovate/derby-java17",
-      "baseBranch": "java17"
+      "allowedVersions": "<10.15.0"
     }
   ]
 }


### PR DESCRIPTION
This PR updates the renovate.json configuration: For SQL Server packages - Changed from excludePackagePatterns to allowedVersions with '.*jre11' pattern, removed custom branchName. For Apache Derby packages - Changed allowedVersions from '>=10.15.0' to '<10.15.0', removed custom branchName and baseBranch. These changes simplify the renovate configuration while maintaining the desired version constraints.