### PR TITLE
Fix scala-steward config: change prefix to suffix for SQL Server versions

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,5 @@
 updatePullRequests = "always"
 updates.pin = [
-    { groupId = "com.microsoft.sqlserver", version = { prefix = "jre11" } },
+    { groupId = "com.microsoft.sqlserver", version = { suffix = "jre11" } },
     { groupId = "org.apache.derby", version = "10.14."}
 ]


### PR DESCRIPTION
This PR fixes a mistake in .scala-steward.conf where 'prefix' was used instead of 'suffix' for SQL Server package versions. Since 'jre11' appears at the end of version strings (e.g., '9.4.1.jre11'), it should be configured as a suffix, not a prefix. This ensures scala-steward correctly identifies and handles SQL Server package versions with the jre11 suffix.