### PR TITLE
Fix Renovate configuration: replace allowedVersions with versionPattern for SQL Server packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "matchPackagePatterns": [
         "^com\\.microsoft\\.sqlserver:.*"
       ],
-      "allowedVersions": ".*jre11",
+      "versionPattern": ".*jre11$",
       "baseBranch": "java17"
     },
     {


### PR DESCRIPTION
This PR fixes issues #3217 and #3218 by replacing the invalid allowedVersions pattern with versionPattern for SQL Server packages. The allowedVersions field expects valid semver ranges, but '.*jre11' is a regex pattern. By using versionPattern instead, we can properly filter SQL Server package versions that end with 'jre11'. This resolves the Renovate configuration error that was preventing PRs from being created.