### PR TITLE
Fix Renovate configuration: replace invalid versionPattern with allowedVersions regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "matchPackagePatterns": [
         "^com\\.microsoft\\.sqlserver:.*"
       ],
-      "versionPattern": ".*jre11$",
+      "allowedVersions": "/.*jre11$/",
       "baseBranch": "java17"
     },
     {


### PR DESCRIPTION
This PR fixes the Renovate configuration issues #3222 and #3221 by replacing the invalid 'versionPattern' option with the correct 'allowedVersions' regex syntax. Changed versionPattern to allowedVersions with regex format for SQL Server packages to filter versions ending with 'jre11'.