### PR TITLE
Fix SQL Server 2025 docker-compose.yml container crashes on Intel hybrid CPUs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       MSSQL_SA_PASSWORD: Freeslick18
     ports:
       - "1401:1433"
+    cpus: "8"
   db2:
     image: ibmcom/db2:11.5.8.0
     ports:


### PR DESCRIPTION
## Summary

- Fix SQL Server 2025 container crashes on Intel 12th Gen hybrid CPUs
- Specify `cpus: "8"` in docker-compose.yml
- Allows flexible CPU usage up to 8 cores instead of rigid core pinning

## Problem

SQL Server 2025 containers crash with processor assertion errors on Intel 12th Gen hybrid CPUs (performance + efficiency cores). Microsoft has documented this as a known issue.

See https://learn.microsoft.com/en-us/sql/sql-server/sql-server-2025-release-notes?view=sql-server-ver17#sql-server-on-linux-fails-to-start-on-machines-with-hybrid-cpu-architecture

## Solution

Use `cpus: "8"` which:
- Avoids the 24-core hybrid CPU bug
- Works on machines with fewer than 8 cores (uses available cores)
- Provides better cross-environment compatibility
- Still limits resource usage appropriately for CI

## Test plan

- [ ] Verify SQL Server container starts successfully on Intel hybrid CPUs
- [ ] Confirm container works on machines with < 8 cores
- [ ] Test CI compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)