### PR TITLE
Bring back `MappedTo` class for both Scala 2 and 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,8 +78,6 @@ def slickScalacOptions = Seq(
           "-Wconf:cat=unused-imports&origin=scala\\.collection\\.compat\\._:s",
           "-Wconf:cat=deprecation&origin=scala\\.math\\.Numeric\\.signum:s"
         ) ++ scala2InlineSettings.value
-      case Some((3, _)) =>
-        List("-source:3.0-migration")
       case _ =>
         Nil
     })

--- a/slick-testkit/src/test/scala/slick/test/lifted/MappedToStringExtensionMethodSupportTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/MappedToStringExtensionMethodSupportTest.scala
@@ -1,0 +1,167 @@
+package slick.test.lifted
+
+import org.junit.Assert._
+import org.junit.Test
+
+/** Test cases for MappedTo[String] getting access to String extension methods */
+class MappedToStringExtensionMethodSupportTest {
+
+  @Test def testMappedToStringExtensionMethodSupport = {
+    import slick.jdbc.H2Profile.api._
+
+    class T(tag: Tag) extends Table[(Int, MyString, Option[MyString])](tag, Some("myschema"), "mytable") {
+      def id = column[Int]("id")
+      def myString = column[MyString]("myString")
+      def optString = column[Option[MyString]]("optString")
+      def * = (id, myString, optString)
+    }
+
+    val ts = TableQuery[T]
+
+    val s1 = ts.map(_.myString.length).result.statements.head
+    println(s1)
+    assertTrue("MappedTo[String] can use String ExtensionMethod length", s1 contains """select length("myString")""")
+
+    val s2 = ts.filter(_.myString like "foo%").result.statements.head
+    println(s2)
+    assertTrue("MappedTo[String] can use String ExtensionMethod like", s2 contains """where "myString" like 'foo%'""")
+
+    val s3 = ts.map(_.myString ++ "!").result.statements.head
+    println(s3)
+    assertTrue("MappedTo[String] can use String ExtensionMethod ++", s3 contains """select "myString"||'!'""")
+
+    val s4 = ts.filter(_.myString startsWith "foo").result.statements.head
+    println(s4)
+    assertTrue("MappedTo[String] can use String ExtensionMethod startsWith", s4 contains """where "myString" like 'foo%'""")
+
+    val s5 = ts.filter(_.myString endsWith "foo").result.statements.head
+    println(s5)
+    assertTrue("MappedTo[String] can use String ExtensionMethod endsWith", s5 contains """where "myString" like '%foo'""")
+
+    val s6 = ts.map(_.myString.toUpperCase).result.statements.head
+    println(s6)
+    assertTrue("MappedTo[String] can use String ExtensionMethod toUpperCase", s6 contains """select ucase("myString")""")
+
+    val s7 = ts.map(_.myString.toLowerCase).result.statements.head
+    println(s7)
+    assertTrue("MappedTo[String] can use String ExtensionMethod toLowerCase", s7 contains """select lcase("myString")""")
+
+    val s8 = ts.map(_.myString.ltrim).result.statements.head
+    println(s8)
+    assertTrue("MappedTo[String] can use String ExtensionMethod endsWith", s8 contains """select ltrim("myString")""")
+
+    val s9 = ts.map(_.myString.rtrim).result.statements.head
+    println(s9)
+    assertTrue("MappedTo[String] can use String ExtensionMethod toUpperCase", s9 contains """select rtrim("myString")""")
+
+    val s10 = ts.map(_.myString.trim).result.statements.head
+    println(s10)
+    assertTrue("MappedTo[String] can use String ExtensionMethod toLowerCase", s10 contains """select ltrim(rtrim("myString"))""")
+
+    val s11 = ts.map(_.myString.reverseString).result.statements.head
+    println(s11)
+    assertTrue("MappedTo[String] can use String ExtensionMethod reverse", s11 contains """select reverse("myString")""")
+
+    val s12 = ts.map(_.myString.substring(1)).result.statements.head
+    println(s12)
+    assertTrue("MappedTo[String] can use String ExtensionMethod substring start", s12 contains """select {fn substring("myString", 2)}""")
+
+    val s13 = ts.map(_.myString.substring(1, 2)).result.statements.head
+    println(s13)
+    assertTrue("MappedTo[String] can use String ExtensionMethod substring start end", s13 contains """select {fn substring("myString", 2, 1)}""")
+
+    val s14 = ts.map(_.myString.take(2)).result.statements.head
+    println(s14)
+    assertTrue("MappedTo[String] can use String ExtensionMethod take", s14 contains """select {fn substring("myString", 1, 2)}""")
+
+    val s15 = ts.map(_.myString.drop(1)).result.statements.head
+    println(s15)
+    assertTrue("MappedTo[String] can use String ExtensionMethod drop", s15 contains """select {fn substring("myString", 2)}""")
+
+    val s16 = ts.map(_.myString.replace("my", "your")).result.statements.head
+    println(s16)
+    assertTrue("MappedTo[String] can use String ExtensionMethod replace", s16 contains """select replace("myString",'my','your')""")
+
+    val s17 = ts.map(_.myString.indexOf("my")).result.statements.head
+    println(s17)
+    assertTrue("MappedTo[String] can use String ExtensionMethod indexOf", s17 contains """select {fn locate('my', "myString")} - 1""")
+
+    val s18 = ts.map(_.myString.*(2)).result.statements.head
+    println(s18)
+    assertTrue("MappedTo[String] can use String ExtensionMethod *", s18 contains """select repeat("myString",2)""")
+
+    val s19 = ts.map(_.optString.length).result.statements.head
+    println(s19)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod length", s19 contains """select length("optString")""")
+
+    val s20 = ts.filter(_.optString like "foo%").result.statements.head
+    println(s20)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod like", s20 contains """where "optString" like 'foo%'""")
+
+    val s21 = ts.map(_.optString ++ "!").result.statements.head
+    println(s21)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod ++", s21 contains """select "optString"||'!'""")
+
+    val s22 = ts.filter(_.optString startsWith "foo").result.statements.head
+    println(s22)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod startsWith", s22 contains """where "optString" like 'foo%'""")
+
+    val s23 = ts.filter(_.optString endsWith "foo").result.statements.head
+    println(s23)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod endsWith", s23 contains """where "optString" like '%foo'""")
+
+    val s24 = ts.map(_.optString.toUpperCase).result.statements.head
+    println(s24)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod toUpperCase", s24 contains """select ucase("optString")""")
+
+    val s25 = ts.map(_.optString.toLowerCase).result.statements.head
+    println(s25)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod toLowerCase", s25 contains """select lcase("optString")""")
+
+    val s26 = ts.map(_.optString.ltrim).result.statements.head
+    println(s26)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod endsWith", s26 contains """select ltrim("optString")""")
+
+    val s27 = ts.map(_.optString.rtrim).result.statements.head
+    println(s27)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod toUpperCase", s27 contains """select rtrim("optString")""")
+
+    val s28 = ts.map(_.optString.trim).result.statements.head
+    println(s28)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod toLowerCase", s28 contains """select ltrim(rtrim("optString"))""")
+
+    val s29 = ts.map(_.optString.reverseString).result.statements.head
+    println(s29)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod reverse", s29 contains """select reverse("optString")""")
+
+    val s30 = ts.map(_.optString.substring(1)).result.statements.head
+    println(s30)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod substring start", s30 contains """select {fn substring("optString", 2)}""")
+
+    val s31 = ts.map(_.optString.substring(1, 2)).result.statements.head
+    println(s31)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod substring start end", s31 contains """select {fn substring("optString", 2, 1)}""")
+
+    val s32 = ts.map(_.optString.take(2)).result.statements.head
+    println(s32)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod take", s32 contains """select {fn substring("optString", 1, 2)}""")
+
+    val s33 = ts.map(_.optString.drop(1)).result.statements.head
+    println(s33)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod drop", s33 contains """select {fn substring("optString", 2)}""")
+
+    val s34 = ts.map(_.optString.replace("my", "your")).result.statements.head
+    println(s34)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod replace", s34 contains """select replace("optString",'my','your')""")
+
+    val s35 = ts.map(_.optString.indexOf("my")).result.statements.head
+    println(s35)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod indexOf", s35 contains """select {fn locate('my', "optString")} - 1""")
+
+    val s36 = ts.map(_.optString.*(2)).result.statements.head
+    println(s36)
+    assertTrue("Option[MappedTo[String]] can use String ExtensionMethod *", s36 contains """select repeat("optString",2)""")
+
+  }
+}
+final case class MyString(value: String) extends AnyVal with slick.lifted.MappedTo[String]

--- a/slick/src/main/scala-2/slick/lifted/MappedTo.scala
+++ b/slick/src/main/scala-2/slick/lifted/MappedTo.scala
@@ -1,0 +1,54 @@
+package slick.lifted
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+import scala.util.control.NonFatal
+
+/** An isomorphism between two types that can be used for mapped column types. */
+class Isomorphism[A, B](val map: A => B, val comap: B => A)
+
+trait MappedToBase extends Any {
+  type Underlying
+  def value: Underlying
+}
+
+object MappedToBase {
+  implicit def mappedToIsomorphism[E <: MappedToBase]: Isomorphism[E, E#Underlying] =
+    macro mappedToIsomorphismMacroImpl[E]
+
+  def mappedToIsomorphismMacroImpl[E <: MappedToBase](c: Context)(implicit e: c.WeakTypeTag[E]): c.Expr[Isomorphism[E, E#Underlying]] = {
+    import c.universe._
+    // Check that E <: MappedToBase. Due to SI-8351 the macro can be expanded before scalac has
+    // checked this. The error message here will never be seen because scalac's subsequent bounds
+    // check fails, overriding our error (or backtracking in implicit search).
+    if(!(e.tpe <:< c.typeOf[MappedToBase]))
+      c.abort(c.enclosingPosition, "Work-around for SI-8351 leading to illegal macro-invocation -- You should not see this message")
+    implicit val eutag = c.TypeTag[E#Underlying](e.tpe.member(TypeName("Underlying")).typeSignatureIn(e.tpe))
+    val cons = c.Expr[E#Underlying => E](Function(
+      List(ValDef(Modifiers(Flag.PARAM), TermName("v"), /*Ident(eu.tpe.typeSymbol)*/TypeTree(), EmptyTree)),
+      Apply(
+        Select(New(TypeTree(e.tpe)), termNames.CONSTRUCTOR),
+        List(Ident(TermName("v")))
+      )
+    ))
+    val res = reify { new Isomorphism[E, E#Underlying](_.value, cons.splice) }
+    try c.typecheck(res.tree) catch { case NonFatal(ex) =>
+      val p = c.enclosingPosition
+      val msg = "Error typechecking MappedTo expansion: " + ex.getMessage
+      println(p.source.path + ":" + p.line + ": " + msg)
+      c.error(c.enclosingPosition, msg)
+    }
+    res
+  }
+}
+
+/** The base type for automatically mapped column types.
+  * Extending this type (with a type parameter ``T`` which is already a
+  * supported column type) lets you use your custom type as a column
+  * type in the Lifted Embedding. You must provide a constructor that
+  * takes a single value of the underlying type (same restriction as
+  * for value classes). */
+trait MappedTo[T] extends Any with MappedToBase {
+  type Underlying = T
+  def value: T
+}

--- a/slick/src/main/scala-3/slick/lifted/MappedTo.scala
+++ b/slick/src/main/scala-3/slick/lifted/MappedTo.scala
@@ -1,0 +1,41 @@
+package slick.lifted
+
+import scala.quoted._
+import scala.util.control.NonFatal
+
+/** An isomorphism between two types that can be used for mapped column types. */
+class Isomorphism[A, B](val map: A => B, val comap: B => A)
+
+trait MappedToBase extends Any {
+  type Underlying
+  def value: Underlying
+}
+
+object MappedToBase {
+  inline implicit def mappedToIsomorphism[T, E <: MappedTo[T]]: Isomorphism[E, T] =
+    ${mappedToIsomorphismMacroImpl[T, E]}
+
+  def mappedToIsomorphismMacroImpl[T: Type, E <: MappedTo[T]: Type](using Quotes): Expr[Isomorphism[E, T]] = {
+    import quotes.reflect._    
+    def makeApply(v: Expr[T])(using Quotes): Expr[E] = {
+      import quotes.reflect._
+      val sym = TypeRepr.of[E].typeSymbol
+      Apply(Select(New(TypeTree.of[E]), sym.primaryConstructor), List(v.asTerm)).asExprOf[E]
+    }
+    val cons = '{(v: T) => ${ makeApply('v)}}
+
+    val res = '{ new Isomorphism[E, T](_.value, $cons) }
+    res
+  }
+}
+
+/** The base type for automatically mapped column types.
+  * Extending this type (with a type parameter ``T`` which is already a
+  * supported column type) lets you use your custom type as a column
+  * type in the Lifted Embedding. You must provide a constructor that
+  * takes a single value of the underlying type (same restriction as
+  * for value classes). */
+trait MappedTo[T] extends Any with MappedToBase {
+  type Underlying = T
+  def value: T
+}

--- a/slick/src/main/scala/slick/compiler/CreateAggregates.scala
+++ b/slick/src/main/scala/slick/compiler/CreateAggregates.scala
@@ -15,7 +15,7 @@ class CreateAggregates extends Phase {
       state.map(_.replace({
         case n @ Apply(f: AggregateFunctionSymbol, ConstArray(from)) =>
           logger.debug("Converting aggregation function application", n)
-          val CollectionType(_, elType @ Type.Structural(StructType(els))) = from.nodeType
+          val CollectionType(_, elType @ Type.Structural(StructType(els))) = from.nodeType: @unchecked
           val s = new AnonSymbol
           val a = Aggregate(s, from, Apply(f, ConstArray(f match {
             case Library.CountAll => LiteralNode(1)

--- a/slick/src/main/scala/slick/compiler/ExpandSums.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandSums.scala
@@ -110,7 +110,7 @@ class ExpandSums extends Phase {
   /** Translate an Option-extended left outer, right outer or full outer join */
   def translateJoin(bind: Bind, discCandidates: Set[(TypeSymbol, List[TermSymbol])]): Bind = {
     logger.debug("translateJoin", bind)
-    val Bind(bsym, (join @ Join(lsym, rsym, left :@ CollectionType(_, leftElemType), right :@ CollectionType(_, rightElemType), jt, on)) :@ CollectionType(cons, elemType), pure) = bind
+    val Bind(bsym, (join @ Join(lsym, rsym, left :@ CollectionType(_, leftElemType), right :@ CollectionType(_, rightElemType), jt, on)) :@ CollectionType(cons, elemType), pure) = bind: @unchecked
     val lComplex = !leftElemType.structural.isInstanceOf[AtomicType]
     val rComplex = !rightElemType.structural.isInstanceOf[AtomicType]
     logger.debug(s"Translating join ($jt, complex: $lComplex, $rComplex):", bind)
@@ -154,7 +154,7 @@ class ExpandSums extends Phase {
           logger.debug("No suitable discriminator column found in "+elemType)
           (Disc1, false)
       }
-      val extend :@ CollectionType(_, extendedElementType) = Bind(extendGen, side, Pure(ProductNode(ConstArray(disc, Ref(extendGen))))).infer()
+      val extend :@ CollectionType(_, extendedElementType) = Bind(extendGen, side, Pure(ProductNode(ConstArray(disc, Ref(extendGen))))).infer(): @unchecked
       val sideInCondition = Select(Ref(sym) :@ extendedElementType, ElementSymbol(2)).infer()
       val on2 = on.replace({
         case Ref(s) if s == sym => sideInCondition
@@ -177,7 +177,7 @@ class ExpandSums extends Phase {
     }
 
     // Cast to translated Option type in outer bind
-    val join2 :@ CollectionType(_, elemType2) = Join(lsym, rsym, left2, right2, jt2, on2).infer()
+    val join2 :@ CollectionType(_, elemType2) = Join(lsym, rsym, left2, right2, jt2, on2).infer(): @unchecked
     def optionCast(idx: Int, createDisc: Boolean): Node = {
       val ref = Select(Ref(bsym) :@ elemType2, ElementSymbol(idx+1))
       val v = if(createDisc) {

--- a/slick/src/main/scala/slick/compiler/HoistClientOps.scala
+++ b/slick/src/main/scala/slick/compiler/HoistClientOps.scala
@@ -50,7 +50,7 @@ class HoistClientOps extends Phase {
                                     br @ Bind(bsr, rfrom, Pure(StructNode(rdefs), tsr)),
                           jt, on1) if jt != JoinType.Outer =>
           logger.debug("Hoisting operations from Join:", Ellipsis(from2, List(0, 0), List(1, 0)))
-          val (bl2: Bind, lrepl: Map[TermSymbol, (Node => Node, AnonSymbol)] @unchecked) = if(jt != JoinType.Right) {
+          val (bl2: Bind, lrepl: Map[TermSymbol, (Node => Node, AnonSymbol)] @unchecked) = (if(jt != JoinType.Right) {
             val hoisted = ldefs.map { case (ts, n) => (ts, n, unwrap(n, false)) }
             logger.debug("Hoisting operations from defs in left side of Join: " + hoisted.iterator.filter(t => t._2 ne t._3._1).map(_._1).mkString(", "))
             val newDefsM = hoisted.iterator.map { case (ts, n, (n2, wrap)) => (n2, new AnonSymbol) }.toMap
@@ -59,8 +59,8 @@ class HoistClientOps extends Phase {
             logger.debug("Translated left join side:", Ellipsis(bl2, List(0)))
             val repl = hoisted.iterator.map { case (s, _, (n2, wrap)) => (s, (wrap, newDefsM(n2))) }.toMap
             (bl2, repl)
-          } else (bl, Map.empty)
-          val (br2: Bind, rrepl: Map[TermSymbol, (Node => Node, AnonSymbol)] @unchecked) = if(jt != JoinType.Left) {
+          } else (bl, Map.empty)): @unchecked
+          val (br2: Bind, rrepl: Map[TermSymbol, (Node => Node, AnonSymbol)] @unchecked) = (if(jt != JoinType.Left) {
             val hoisted = rdefs.map { case (ts, n) => (ts, n, unwrap(n, false)) }
             logger.debug("Hoisting operations from defs in right side of Join: " + hoisted.iterator.filter(t => t._2 ne t._3._1).map(_._1).mkString(", "))
             val newDefsM = hoisted.iterator.map { case (ts, n, (n2, wrap)) => (n2, new AnonSymbol) }.toMap
@@ -69,7 +69,7 @@ class HoistClientOps extends Phase {
             logger.debug("Translated right join side:", Ellipsis(br2, List(0)))
             val repl = hoisted.iterator.map { case (s, _, (n2, wrap)) => (s, (wrap, newDefsM(n2))) }.toMap
             (br2, repl)
-          } else (br, Map.empty)
+          } else (br, Map.empty)): @unchecked
           if((bl2 ne bl) || (br2 ne br)) {
             val from3 = from2.copy(left = bl2, right = br2, on = on1.replace {
               case Select(Ref(s), f) if s == sl1 && (bl2 ne bl) =>

--- a/slick/src/main/scala/slick/compiler/MergeToComprehensions.scala
+++ b/slick/src/main/scala/slick/compiler/MergeToComprehensions.scala
@@ -167,7 +167,7 @@ class MergeToComprehensions extends Phase {
         }
         val c2 = c1a.copy(groupBy = Some(ProductNode(ConstArray(b2a)).flatten), select = Pure(str2, ts2)).infer()
         logger.debug("Merged GroupBy into Comprehension:", c2)
-        val StructNode(defs2) = str2
+        val StructNode(defs2) = str2: @unchecked
         val replacements = defs2.iterator.map { case (f, _) => (ts2, f) -> f }.toMap
         logger.debug("Replacements are: "+replacements)
         (c2, replacements)
@@ -183,7 +183,7 @@ class MergeToComprehensions extends Phase {
         val str2 = applyReplacements(str1, replacements1, c1)
         val c2 = c1.copy(select = Pure(str2, ts)).infer()
         logger.debug("Merged Aggregate source into Comprehension:", c2)
-        val StructNode(defs) = str2
+        val StructNode(defs) = str2: @unchecked
         val repl = defs.iterator.map { case (f, _) => ((ts, f), f) }.toMap
         logger.debug("Replacements are: "+repl)
         (c2, repl)
@@ -223,8 +223,8 @@ class MergeToComprehensions extends Phase {
         Some((p, mappings))
       case j @ Join(ls, rs, l1, r1, _, on1) =>
         logger.debug(s"Creating source from Join $ls/$rs:", j)
-        val (l2 @ _ :@ CollectionType(_, _), leftMappings) = dealias(l1)(createSourceOrTopLevel)
-        val (r2 @ _ :@ CollectionType(_, _), rightMappings) = dealias(r1)(createSourceOrTopLevel)
+        val (l2 @ _ :@ CollectionType(_, _), leftMappings) = dealias(l1)(createSourceOrTopLevel): @unchecked
+        val (r2 @ _ :@ CollectionType(_, _), rightMappings) = dealias(r1)(createSourceOrTopLevel): @unchecked
         logger.debug(s"Converted left side of Join $ls/$rs:", l2)
         logger.debug(s"Converted right side of Join $ls/$rs:", r2)
         // Detect and remove empty join sides
@@ -324,7 +324,7 @@ class MergeToComprehensions extends Phase {
       case n => convert1(n)
     }
 
-    val tree2 :@ CollectionType(cons2, _) = convert1(tree)
+    val tree2 :@ CollectionType(cons2, _) = convert1(tree): @unchecked
     val cons1 = tree.nodeType.asCollectionType.cons
     if(cons2 != cons1) CollectionCast(tree2, cons1).infer()
     else tree2
@@ -410,7 +410,7 @@ class MergeToComprehensions extends Phase {
             case Select(_ :@ NominalType(_, _), _) => true
             case _ => false
           }.getOrElse(throw new SlickTreeException("Missing path on top of TypeSymbol in:", p))
-          val Select(_ :@ NominalType(ts2, _), f2) = sel
+          val Select(_ :@ NominalType(ts2, _), f2) = sel: @unchecked
           (ts1, f1) -> map1M((ts2, f2))
         }
         (n2, map2)
@@ -421,7 +421,7 @@ class MergeToComprehensions extends Phase {
   /** Apply the replacements and current selection of a Comprehension to a new Node that
     * will be merged into the Comprehension. */
   def applyReplacements(n1: Node, r: Replacements, c: Comprehension[Option[Node]]): Node = {
-    val Pure(StructNode(base), _) = c.select
+    val Pure(StructNode(base), _) = c.select: @unchecked
     val baseM = base.iterator.toMap
     n1.replace({ case n @ Select(_ :@ NominalType(ts, _), s) =>
       r.get((ts, s)) match {

--- a/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
+++ b/slick/src/main/scala/slick/compiler/RemoveFieldNames.scala
@@ -11,7 +11,7 @@ class RemoveFieldNames(val alwaysKeepSubqueryNames: Boolean = false) extends Pha
   val name = "removeFieldNames"
 
   def apply(state: CompilerState) = state.map { n => ClientSideOp.mapResultSetMapping(n, true) { rsm =>
-    val CollectionType(_, NominalType(top, StructType(fdefs))) = rsm.from.nodeType
+    val CollectionType(_, NominalType(top, StructType(fdefs))) = rsm.from.nodeType: @unchecked
     val requiredSyms = rsm.map.collect[TermSymbol]({
       case Select(Ref(s), f) if s == rsm.generator => f
     }, stopOnMatch = true).toSeq.distinct.zipWithIndex.toMap
@@ -41,7 +41,7 @@ class RemoveFieldNames(val alwaysKeepSubqueryNames: Boolean = false) extends Pha
       }.infer()
     })
     logger.debug("Transformed RSM: ", rsm2)
-    val CollectionType(_, fType) = rsm2.from.nodeType
+    val CollectionType(_, fType) = rsm2.from.nodeType: @unchecked
     val baseRef = Ref(rsm.generator) :@ fType
     rsm2.copy(map = rsm2.map.replace({
       case Select(Ref(s), f) if s == rsm.generator =>

--- a/slick/src/main/scala/slick/compiler/ReorderOperations.scala
+++ b/slick/src/main/scala/slick/compiler/ReorderOperations.scala
@@ -101,7 +101,7 @@ class ReorderOperations extends Phase {
     val usedFields = defs.flatMap(_._2.collect[TermSymbol] {
       case Select(Ref(s), f) if s == base => f
     })
-    val StructType(tDefs) = tpe.structural
+    val StructType(tDefs) = tpe.structural: @unchecked
     (tDefs.map(_._1).toSet -- usedFields.toSeq).isEmpty
   }
 

--- a/slick/src/main/scala/slick/compiler/RewriteJoins.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteJoins.scala
@@ -131,7 +131,7 @@ class RewriteJoins extends Phase {
       case (Filter(fs1, from1, pred1), tss1) =>
         logger.debug("Hoisting Filter out of Bind from:", b)
         val sRefs = pred1.collect({ case p @ FwdPath(s :: rest) if s == fs1 => (p, FwdPath(b.generator :: rest)) }, stopOnMatch = true)
-        val Bind(_, _, Pure(StructNode(struct1), pts)) = b
+        val Bind(_, _, Pure(StructNode(struct1), pts)) = b: @unchecked
         val foundRefs = sRefs.map { case (p, pOnBGen) =>
           (p, (pOnBGen, /*None: Option[Symbol]*/ struct1.find { case (s, n) => pOnBGen == n }.map(_._1) ))
         }.toMap

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -332,7 +332,7 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
   class UpdateActionExtensionMethodsImpl[T](tree: Node, param: Any) {
     protected[this] val ResultSetMapping(_,
       CompiledStatement(_, sres: SQLBuilder.Result, _),
-      CompiledMapping(_converter, _)) = tree
+      CompiledMapping(_converter, _)) = tree: @unchecked
     protected[this] val converter = _converter.asInstanceOf[ResultConverter[ResultSet, PreparedStatement, ResultSet, T]]
 
     /** An Action that updates the data selected by this query. */

--- a/slick/src/main/scala/slick/jdbc/JdbcInvokerComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcInvokerComponent.scala
@@ -25,7 +25,7 @@ trait JdbcInvokerComponent { self: JdbcProfile =>
   class QueryInvokerImpl[R](tree: Node, param: Any, overrideSql: String) extends QueryInvoker[R] {
     protected[this] val ResultSetMapping(_, compiled, CompiledMapping(_converter, _)) = tree: @unchecked
     protected[this] val converter = _converter.asInstanceOf[ResultConverter[ResultSet, PreparedStatement, ResultSet, R]]
-    protected[this] val CompiledStatement(_, sres: SQLBuilder.Result, _) = findCompiledStatement(compiled)
+    protected[this] val CompiledStatement(_, sres: SQLBuilder.Result, _) = findCompiledStatement(compiled): @unchecked
 
     protected[this] def findCompiledStatement(n: Node): CompiledStatement = n match {
       case c: CompiledStatement => c

--- a/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcStatementBuilderComponent.scala
@@ -64,7 +64,7 @@ trait JdbcStatementBuilderComponent { self: JdbcProfile =>
       if(!capabilities.contains(JdbcCapabilities.returnInsertKey))
         throw new SlickException("This DBMS does not allow returning columns from INSERT statements")
       val ResultSetMapping(_, CompiledStatement(_, ibr: InsertBuilderResult, _), CompiledMapping(rconv, _)) =
-        forceInsertCompiler.run(node).tree
+        forceInsertCompiler.run(node).tree: @unchecked
       if(ibr.table.baseIdentity != standardInsert.table.baseIdentity)
         throw new SlickException("Returned key columns must be from same table as inserted columns ("+
           ibr.table.baseIdentity+" != "+standardInsert.table.baseIdentity+")")

--- a/slick/src/main/scala/slick/lifted/Aliases.scala
+++ b/slick/src/main/scala/slick/lifted/Aliases.scala
@@ -38,6 +38,8 @@ trait Aliases {
   type NestedShapeLevel = lifted.NestedShapeLevel
   type FlatShapeLevel = lifted.FlatShapeLevel
   type ColumnsShapeLevel = lifted.ColumnsShapeLevel
+  type Isomorphism[A, B] = lifted.Isomorphism[A, B]
+  type MappedTo[T] = lifted.MappedTo[T]
   val ForeignKeyAction = slick.model.ForeignKeyAction
   type ForeignKeyAction = slick.model.ForeignKeyAction
 

--- a/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
+++ b/slick/src/main/scala/slick/lifted/ExtensionMethods.scala
@@ -244,6 +244,8 @@ trait ExtensionMethodConversions {
   implicit def numericOptionColumnExtensionMethods[B1](c: Rep[Option[B1]])(implicit tm: BaseTypedType[B1] & NumericTypedType): OptionNumericColumnExtensionMethods[B1] = new OptionNumericColumnExtensionMethods[B1](c)
   implicit def stringColumnExtensionMethods(c: Rep[String]): StringColumnExtensionMethods[String] = new StringColumnExtensionMethods[String](c)
   implicit def stringOptionColumnExtensionMethods(c: Rep[Option[String]]): StringColumnExtensionMethods[Option[String]] = new StringColumnExtensionMethods[Option[String]](c)
+  implicit def mappedToStringColumnExtensionMethods[B1 <: MappedTo[String]](c: Rep[B1]): StringColumnExtensionMethods[String] = new StringColumnExtensionMethods[String](c.asInstanceOf[Rep[String]])
+  implicit def mappedToOptionStringColumnExtensionMethods[B1 <: MappedTo[String]](c: Rep[Option[B1]]): StringColumnExtensionMethods[Option[String]] = new StringColumnExtensionMethods[Option[String]](c.asInstanceOf[Rep[Option[String]]])
   implicit def booleanColumnExtensionMethods(c: Rep[Boolean]): BooleanColumnExtensionMethods[Boolean] = new BooleanColumnExtensionMethods[Boolean](c)
   implicit def booleanOptionColumnExtensionMethods(c: Rep[Option[Boolean]]): BooleanColumnExtensionMethods[Option[Boolean]] = new BooleanColumnExtensionMethods[Option[Boolean]](c)
 

--- a/slick/src/main/scala/slick/lifted/Shape.scala
+++ b/slick/src/main/scala/slick/lifted/Shape.scala
@@ -70,8 +70,8 @@ object Shape extends ConstColumnShapeImplicits with AbstractTableShapeImplicits 
       def encodeRef(value: Any, path: Node): Any =
         throw new SlickException("Shape does not have the same Mixed and Packed type")
       def toNode(value: Any): Node = pack(value).toNode
-    override def toString = s"PrimitiveShape($tm)"
-  }
+      override def toString = s"PrimitiveShape($tm)"
+    }
 
   @inline implicit final def unitShape[Level <: ShapeLevel]: Shape[Level, Unit, Unit, Unit] =
     unitShapePrototype.asInstanceOf[Shape[Level, Unit, Unit, Unit]]
@@ -366,24 +366,24 @@ object ProvenShape {
     new Shape[FlatShapeLevel, ProvenShape[T], T, P] {
       def pack(value: Any): Packed = {
         val v = value.asInstanceOf[ProvenShape[T]]
-      v.shape.pack(v.value).asInstanceOf[Packed]
-    }
-
-    def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] =
-      shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, Packed, Unpacked, Packed]]
-    def buildParams(extract: Any => Unpacked): Packed =
-      shape.buildParams(extract)
-      def encodeRef(value: Any, path: Node) = {
-        val v = value.asInstanceOf[ProvenShape[T]]
-      v.shape.encodeRef(v.value, path)
+        v.shape.pack(v.value).asInstanceOf[Packed]
       }
 
-    def toNode(value: Any): Node = {
+      def packedShape: Shape[FlatShapeLevel, Packed, Unpacked, Packed] =
+        shape.packedShape.asInstanceOf[Shape[FlatShapeLevel, Packed, Unpacked, Packed]]
+      def buildParams(extract: Any => Unpacked): Packed =
+        shape.buildParams(extract)
+      def encodeRef(value: Any, path: Node) = {
         val v = value.asInstanceOf[ProvenShape[T]]
-      v.shape.toNode(v.value)
-    }
+        v.shape.encodeRef(v.value, path)
+      }
 
-    override def toString = s"ProvenShapeShape($shape)"
+      def toNode(value: Any): Node = {
+        val v = value.asInstanceOf[ProvenShape[T]]
+        v.shape.toNode(v.value)
+      }
+
+      override def toString = s"ProvenShapeShape($shape)"
     }
 }
 

--- a/slick/src/main/scala/slick/memory/DistributedProfile.scala
+++ b/slick/src/main/scala/slick/memory/DistributedProfile.scala
@@ -124,7 +124,7 @@ class DistributedProfile(val profiles: RelationalProfile*) extends MemoryQueryin
       val needed = new mutable.HashMap[RefId[Node], Set[RelationalProfile]]
       val taints = new mutable.HashMap[RefId[Node], Set[RelationalProfile]]
       def collect(n: Node, scope: Scope): (Set[RelationalProfile], Set[RelationalProfile]) = {
-        val (dr: Set[RelationalProfile] @unchecked, tt: Set[RelationalProfile] @unchecked) = n match {
+        val (dr: Set[RelationalProfile] @unchecked, tt: Set[RelationalProfile] @unchecked) = (n match {
           case t: TableNode => (Set(t.profileTable.asInstanceOf[RelationalProfile#Table[?]].tableProvider), Set.empty)
           case Ref(sym) =>
             scope.get(sym) match {
@@ -144,7 +144,7 @@ class DistributedProfile(val profiles: RelationalProfile*) extends MemoryQueryin
               n
             }, scope)
             (nnd, ntt)
-        }
+        }): @unchecked
         needed += RefId(n) -> dr
         taints += RefId(n) -> tt
         (dr, tt)

--- a/slick/src/main/scala/slick/relational/RelationalProfile.scala
+++ b/slick/src/main/scala/slick/relational/RelationalProfile.scala
@@ -200,6 +200,8 @@ trait RelationalTypesComponent { self: RelationalProfile =>
   }
 
   trait RelationalImplicitColumnTypes {
+    implicit def isomorphicType[A, B](implicit iso: Isomorphism[A, B], ct: ClassTag[A], jt: BaseColumnType[B]): BaseColumnType[A] =
+      MappedColumnType.base[A, B](iso.map, iso.comap)
     implicit def booleanColumnType: BaseColumnType[Boolean]
     implicit def bigDecimalColumnType: BaseColumnType[BigDecimal] & NumericTypedType
     implicit def byteColumnType: BaseColumnType[Byte] & NumericTypedType


### PR DESCRIPTION
Includes scala-2 and scala-3 versions of the macros. For scala-2, the old one was brought back, but for scala-3, the api had to be adjusted to comply with the new type projection rules. This difference in API should not matter that much, as this is an implicit method. The test were brought back from https://github.com/slick/slick/pull/2698
The -source 3.0-migration option had to be removed as it caused the added macro to not compile. This in turn caused more warnings to be thrown, most of them being a variation of `pattern's type (...) is more specialized than the right hand side expression's type (...)` (which were suppressed in the second commit).
