### PR TITLE
Fix testInsertOrUpdateAll #3251 

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -235,7 +235,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     if (tdb.capabilities.contains(JdbcCapabilities.insertOrUpdate)) {
       for {
         _ <- prepare
-        _ <- ts.insertOrUpdateAll(Seq((3, "c"), (1, "d"))).map(_.foreach(_ shouldBe 3))
+        _ <- ts.insertOrUpdateAll(Seq((3, "c"), (1, "d"))).map(_.foreach(_ shouldBe 2))
         _ <- ts.sortBy(_.id).result.map(_ shouldBe Seq((1, "d"), (2, "b"), (3, "c")))
       } yield ()
     } else {


### PR DESCRIPTION
I was implementing a custom driver for a database and noticed this test failing.

The Scaladoc of `JdbcActionComponent.insertOrUpdateAll` says:

> Insert multiple rows if its primary key does not exist in the table, otherwise update the existing record. Returns Some(rowsAffected), or None if the database returned no row count for some part of the batch. If any part of the batch fails, an exception is thrown. The option parameter specifies how the operation is to be performed.(default is RowsPerStatement.All) Note unlike insertOrUpdate, client-side emulation is not supported.

Since in:
`_ <- ts.insertOrUpdateAll(Seq((3, "c"), (1, "d"))).map(_.foreach(_ shouldBe 3))`
we are inserting two records (one updates an existing one, and the other is inserted), it think it should be `_ shouldBe 2`.

Maybe I am misunderstanding something; in this case, I would appreciate if someone could point out the error in my thinking :) 

Thanks!