### PR TITLE
Re-implement `stripMargin` for plain sql interpolator

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/jdbc/SqlActionBuilderTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/SqlActionBuilderTest.scala
@@ -1,0 +1,33 @@
+package slick.test.jdbc
+
+import org.junit.Test
+import slick.jdbc.{JdbcActionComponent, JdbcProfile}
+
+import org.junit.Assert.*
+
+class SqlActionBuilderTest {
+
+  @Test
+  def testStripMargin: Unit = {
+    val driver = new JdbcProfile with JdbcActionComponent.MultipleRowsPerStatementSupport {}
+    import driver.api.actionBasedSQLInterpolation
+
+    val id = 0
+    val s1 = sql"select * from SUPPLIERS where SUP_ID = ${id}"
+    val s2 = sql"""select *
+                  |from SUPPLIERS
+                  |where SUP_ID = ${id}""".stripMargin
+    val s3 = sql"""select *
+                  !from SUPPLIERS
+                  !where SUP_ID = ${id}""".stripMargin('!')
+    val s4 = sql"""select *
+                  #from SUPPLIERS
+                  #where SUP_ID = ${id}""".stripMargin('#')
+
+    def dropNewLineChars(sql: String): String = sql.replace('\n', ' ').replaceAll("\r", "")
+
+    assertEquals(s1.sql, dropNewLineChars(s2.sql))
+    assertEquals(s1.sql, dropNewLineChars(s3.sql))
+    assertEquals(s1.sql, dropNewLineChars(s4.sql))
+  }
+}

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -77,4 +77,6 @@ case class SQLActionBuilder(sql: String, setParameter: SetParameter[Unit]) {
       b.setParameter(p, pp)
     })
   }
+  def stripMargin(marginChar: Char): SQLActionBuilder = copy(sql.stripMargin(marginChar))
+  def stripMargin: SQLActionBuilder = copy(sql.stripMargin)
 }


### PR DESCRIPTION
#2696 removed `stripMargin`. This PR adds it back.