### PR TITLE
Fix `insertAll` with empty collections generating invalid SQL

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -538,4 +538,40 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     )
   } else DBIO.seq()
 
+  def testInsertAllEmptyList = {
+    class A(tag: Tag) extends Table[(Int, String)](tag, "insert_all_empty") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def name = column[String]("name")
+      def * = (id, name)
+    }
+    val as = TableQuery[A]
+
+    // Test with empty List
+    val emptyList = List[(Int, String)]()
+
+    DBIO.seq(
+      as.schema.create,
+      as.insertAll(emptyList).map(_ shouldBe Some(0)),
+      as.result.map(_ shouldBe Seq.empty)
+    )
+  }
+
+  def testInsertAllEmptyVector = {
+    class A(tag: Tag) extends Table[(Int, String)](tag, "insert_all_empty_vec") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def name = column[String]("name")
+      def * = (id, name)
+    }
+    val as = TableQuery[A]
+
+    // Test with empty Vector
+    val emptyVector = Vector[(Int, String)]()
+
+    DBIO.seq(
+      as.schema.create,
+      as.insertAll(emptyVector).map(_ shouldBe Some(0)),
+      as.result.map(_ shouldBe Seq.empty)
+    )
+  }
+
 }

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -624,7 +624,8 @@ trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>
         }
 
       def run(ctx: JdbcBackend#JdbcActionContext, sql: Vector[String]): MultiInsertResult =
-        rowsPerStatement match {
+        if(values.isEmpty) retMany(values, Vector.empty)
+        else rowsPerStatement match {
           case RowsPerStatement.One =>
             values match {
               case seq: IndexedSeq[?] if seq.length < 2 => doUnbatched(ctx, sql)


### PR DESCRIPTION
## PR Summary
When calling `insertAll()` with an empty List, Slick generated invalid SQL (`INSERT INTO table VALUES `) causing a database error. This fix adds an early return for empty collections, treating them as a no-op that returns `Some(0)`, consistent with the behavior for empty Vector/IndexedSeq.

Fixes #3311.