### PR TITLE
chore: use -Xsource:3-cross instead of -Xsource:3 for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ def slickScalacOptions = Seq(
         List("-Ywarn-unused:imports", "-language:higherKinds", "-Xsource:3") ++ scala2InlineSettings.value
       case Some((2, 13)) =>
         List(
-          "-Xsource:3",
+          "-Xsource:3-cross",
           "-Wunused:imports",
           "-Wconf:cat=unused-imports&origin=scala\\.collection\\.compat\\._:s",
           "-Wconf:cat=deprecation&origin=scala\\.math\\.Numeric\\.signum:s"


### PR DESCRIPTION
## Summary

Switch from `-Xsource:3` to `-Xsource:3-cross` in Scala 2.13 build configuration.

## Changes

- Modified `build.sbt` line 76 to use `-Xsource:3-cross` instead of `-Xsource:3` for Scala 2.13 builds

## Rationale

Since we already cross-compile with Scala 3, we don't need migration warnings. The `-Xsource:3-cross` flag:

- **Eliminates migration warnings**: Adopts Scala 3 behavior instead of warning about it
- **Improves consistency**: Scala 2.13 builds behave more like Scala 3
- **Reduces maintenance**: No need to suppress individual migration warnings with `@nowarn` or `-Wconf`

The `-Xsource:3-cross` flag was introduced in Scala 2.13.13 and is shorthand for `-Xsource:3 -Xsource-features:_`.

## Testing

Tested cross-compilation across all supported Scala versions:

```bash
sbt +compile
```

All versions compile successfully:
- Scala 2.12.20 ✓
- Scala 2.13.16 ✓  
- Scala 3.3.7 ✓