### PR TITLE
Data source test

### DIFF
--- a/common-test-resources/application.conf
+++ b/common-test-resources/application.conf
@@ -26,7 +26,7 @@ ds1 {
       driver = "org.h2.Driver"
       url = "jdbc:h2:mem:test_ds1"
       properties = {
-        LOCK_MODE = 1
+        MODE = MySQL
       }
     }
   }
@@ -40,7 +40,7 @@ ds2 {
     driver = "org.h2.Driver"
     url = "jdbc:h2:mem:test_ds2"
     properties = {
-      LOCK_MODE = 2
+      MODE = PostgreSQL
     }
   }
 }
@@ -48,6 +48,7 @@ ds2 {
 // HikariCP with DATABASE_URL parsing
 databaseUrl {
   dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  connectionTimeout = 250
   properties = {
     driver = "slick.test.jdbc.MockDriver"
     url = "postgres://user:pass@host/dbname"
@@ -60,6 +61,7 @@ databaseUrl {
 // HikariCP with DATABASE_URL parsing, no password
 databaseUrlNoPassword {
   dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  connectionTimeout = 250
   properties = {
     driver = "slick.test.jdbc.MockDriver"
     url = "postgres://user@host/dbname"
@@ -72,6 +74,7 @@ databaseUrlNoPassword {
 // HikariCP with DATABASE_URL parsing, MySQL
 databaseUrlMySQL {
   dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  connectionTimeout = 250
   properties = {
     driver = "slick.test.jdbc.MockDriver"
     url = "mysql://user:pass@host/dbname"
@@ -84,6 +87,7 @@ databaseUrlMySQL {
 // HikariCP with DATABASE_URL parsing, MySQL and no password
 databaseUrlMySQLNoPassword {
   dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  connectionTimeout = 250
   properties = {
     driver = "slick.test.jdbc.MockDriver"
     url = "mysql://user@host/dbname"
@@ -96,6 +100,7 @@ databaseUrlMySQLNoPassword {
 // Test alternative dsn for postgres
 altDatabaseUrl {
   dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  connectionTimeout = 250
   properties = {
     driver = "slick.test.jdbc.MockDriver"
     url = "postgresql://user:pass@host/dbname"

--- a/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/jdbc/DataSourceTest.scala
@@ -5,7 +5,7 @@ import java.util.Properties
 import java.util.logging.Logger
 
 import com.typesafe.config.ConfigFactory
-import org.junit.{Ignore, Test}
+import org.junit.Test
 import org.junit.Assert._
 import slick.basic.DatabaseConfig
 import slick.jdbc.{JdbcBackend, JdbcProfile}
@@ -13,13 +13,12 @@ import slick.jdbc.{JdbcBackend, JdbcProfile}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-@Ignore
 class DataSourceTest {
   @Test def testDataSourceJdbcDataSource: Unit = {
     val dc = DatabaseConfig.forConfig[JdbcProfile]("ds1")
     import dc.profile.api._
     try {
-      assertEquals(1, Await.result(dc.db.run(sql"select lock_mode()".as[Int].head), Duration.Inf))
+      assertEquals("MySQL", Await.result(dc.db.run(sql"select setting_value from information_schema.settings where setting_name = 'MODE'".as[String].head), Duration.Inf))
     } finally dc.db.close
   }
 
@@ -27,7 +26,7 @@ class DataSourceTest {
     val dc = DatabaseConfig.forConfig[JdbcProfile]("ds2")
     import dc.profile.api._
     try {
-      assertEquals(2, Await.result(dc.db.run(sql"select lock_mode()".as[Int].head), Duration.Inf))
+      assertEquals("PostgreSQL", Await.result(dc.db.run(sql"select setting_value from information_schema.settings where setting_name = 'MODE'".as[String].head), Duration.Inf))
     } finally dc.db.close
   }
 
@@ -173,4 +172,3 @@ class MockDriver extends Driver {
   }
   def getMajorVersion: Int = 0
 }
-


### PR DESCRIPTION
Fixes the previously commented out data source tests.

The old test relied on H2 `LOCK_MODE` semantics that had changed.