### PR TITLE
Add scala 3.8 support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ This is Slick, a functional relational mapping (FRM) library for Scala that prov
 - Use `sbt` for all build operations
 - Main build command: `sbt clean compile`
 - Test command: `sbt testAll` (includes testkit, doctests, and reactive-streams tests)
-- Cross-compile testing: `sbt ++2.12.20 compile`, `sbt ++2.13.16 compile`, `sbt ++3.3.4 compile`
+- Cross-compile testing: `sbt ++2.13.16 compile`, `sbt ++3.3.4 compile`
 - For database-specific testing, use the testkit with appropriate configuration
 
 ### Database Support

--- a/.github/workflows/check-scaladoc-links.yml
+++ b/.github/workflows/check-scaladoc-links.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  JAVA_VERSION: "11"
+  JAVA_VERSION: "17"
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ concurrency:
 
 env:
   # language=json
-  JAVA_VERSIONS: '{ "javaMin": "11", "javaLatest": "23" }'
+  # javaMinScala2 is the minimum Java version for Scala 2.x builds.
+  # javaMinScala3 is the minimum Java version for Scala 3.x builds (Scala 3.8+ requires Java 17+).
+  JAVA_VERSIONS: '{ "javaMinScala2": "11", "javaMinScala3": "17", "javaLatest": "23" }'
 
 jobs:
   build:
@@ -22,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ javaMin, javaLatest ]
+        java: [ javaMinScala2, javaLatest ]
         scala: [ 2.12.x, 2.13.x, 3.x ]
 
     services:
@@ -75,7 +77,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: adopt
-          java-version: ${{ fromJson(env.JAVA_VERSIONS)[matrix.java] }}
+          java-version: ${{ matrix.java == 'javaMinScala2' && matrix.scala == '3.x' && fromJson(env.JAVA_VERSIONS)['javaMinScala3'] || fromJson(env.JAVA_VERSIONS)[matrix.java] }}
           cache: sbt
 
       - name: Setup SBT
@@ -112,7 +114,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: adopt
-          java-version: ${{ fromJson(env.JAVA_VERSIONS)['javaMin'] }}
+          java-version: ${{ fromJson(env.JAVA_VERSIONS)['javaMinScala2'] }}
           cache: sbt
 
       - name: Setup SBT
@@ -148,7 +150,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: adopt
-          java-version: ${{ fromJson(env.JAVA_VERSIONS)['javaMin'] }}
+          java-version: ${{ fromJson(env.JAVA_VERSIONS)['javaMinScala2'] }}
           cache: sbt
 
       - name: Setup SBT

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,13 +19,10 @@ pull_request_rules:
 
   - name: Automatic merge on approval
     conditions:
-      - "check-success=Build and Test (javaMin, 2.12.x)"
       - "check-success=Build and Test (javaMin, 2.13.x)"
       - "check-success=Build and Test (javaMin, 3.x)"
-      - "check-success=Build and Test (javaLatest, 2.12.x)"
       - "check-success=Build and Test (javaLatest, 2.13.x)"
       - "check-success=Build and Test (javaLatest, 3.x)"
-      - "check-success=Check conformance with version policy (2.12.x)"
       - "check-success=Check conformance with version policy (2.13.x)"
       - "check-success=Check conformance with version policy (3.x)"
       - "#changes-requested-reviews-by=0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,12 @@ It's a multi-module SBT project with the following key modules:
 sbt clean compile
 
 # Cross-compile for all supported Scala versions
-sbt ++2.12.20 compile
-sbt ++2.13.16 compile
-sbt ++3.3.4 compile
+sbt ++2.12.21 compile
+sbt ++2.13.18 compile
+sbt ++3.8.3 compile
 
 # Force specific Scala version for testing
-sbt ++3.3.4! compile
+sbt ++3.8.3! compile
 
 # Generate API documentation
 sbt doc
@@ -60,8 +60,9 @@ sbt "testkit/testOnly *MainTest* -- -z insertTest"
 sbt -Dslick.ansiDump=true testkit/test
 
 # Cross-version testing
-sbt ++2.13.16 testkit/test
-sbt ++3.3.4! testkit/test
+sbt ++2.12.21 testkit/test
+sbt ++2.13.18 testkit/test
+sbt ++3.8.3! testkit/test
 
 # Codegen tests (requires cleaning managed sources first)
 rm -rf slick-testkit/target/scala-2.13/src_managed && sbt 'testOnly slick.test.codegen.*'

--- a/build.sbt
+++ b/build.sbt
@@ -39,16 +39,24 @@ inThisBuild(
 def scaladocSourceUrl(dir: String) =
   Compile / doc / scalacOptions ++= {
     val ref = Versioning.currentRef(baseDirectory.value)
-    Seq(
-      "-sourcepath",
-      (ThisBuild / baseDirectory).value.getAbsolutePath,
-      "-doc-source-url",
-      s"https://github.com/slick/slick/blob/${ref}€{FILE_PATH}.scala"
-    )
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((3, _)) =>
+        Seq(
+          s"-source-links:github://slick/slick/${ref}"
+        )
+      case _ =>
+        Seq(
+          "-sourcepath",
+          (ThisBuild / baseDirectory).value.getAbsolutePath,
+          "-doc-source-url",
+          s"https://github.com/slick/slick/blob/${ref}€{FILE_PATH}.scala"
+        )
+    }
   }
 
 val scala2InlineSettings = Def.setting {
-  if (insideCI.value) {
+  val isScala2 = CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 2)
+  if (insideCI.value && isScala2) {
     val log = sLog.value
     log.info(s"Running in CI, enabling Scala2 optimizer for module: ${name.value}")
     List(
@@ -66,17 +74,22 @@ def slickScalacOptions = Seq(
     List(
       "-deprecation",
       "-feature",
-      "-unchecked",
-      "-Wconf:cat=unused-imports&src=src_managed/.*:silent"
+      "-unchecked"
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 12)) =>
-        List("-Ywarn-unused:imports", "-language:higherKinds", "-Xsource:3") ++ scala2InlineSettings.value
+        List(
+          "-Ywarn-unused:imports",
+          "-language:higherKinds",
+          "-Xsource:3",
+          "-Wconf:cat=unused-imports&src=src_managed/.*:silent",
+          "-Wconf:cat=unused-imports&origin=slick\\.compat\\.collection\\..*:s"
+        ) ++ scala2InlineSettings.value
       case Some((2, 13)) =>
         List(
           "-Xsource:3-cross",
           "-Wunused:imports",
-          "-Wconf:cat=unused-imports&origin=scala\\.collection\\.compat\\._:s",
-          "-Wconf:cat=deprecation&origin=scala\\.math\\.Numeric\\.signum:s"
+          "-Wconf:cat=unused-imports&src=src_managed/.*:silent",
+          "-Wconf:cat=unused-imports&origin=slick\\.compat\\.collection\\..*:s"
         ) ++ scala2InlineSettings.value
       case Some((3, _)) =>
         List("-source:3.0-migration")
@@ -95,16 +108,26 @@ def slickGeneralSettings =
     },
     sonatypeProfileName := "com.typesafe.slick",
     Compile / doc / scalacOptions ++= {
-      val baseOptions = Seq(
-        "-doc-title", name.value,
-        "-doc-version", version.value,
-        "-doc-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
-        "-implicits",
-        "-groups"
-      )
-      // Skip diagrams to avoid graphviz dependency
-      if (sys.env.get("SLICK_SKIP_DIAGRAMS").contains("true")) baseOptions
-      else baseOptions :+ "-diagrams" // requires graphviz
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) =>
+          val baseOptions = Seq(
+            "-project-version", version.value,
+            "-project-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
+            "-groups"
+          )
+          baseOptions
+        case _ =>
+          val baseOptions = Seq(
+            "-doc-title", name.value,
+            "-doc-version", version.value,
+            "-doc-footer", "Slick is developed by Typesafe and EPFL Lausanne.",
+            "-implicits",
+            "-groups"
+          )
+          // Skip diagrams to avoid graphviz dependency
+          if (sys.env.get("SLICK_SKIP_DIAGRAMS").contains("true")) baseOptions
+          else baseOptions :+ "-diagrams" // requires graphviz
+      }
     },
     logBuffered := false
   ) ++ slickScalacOptions

--- a/doc/code/CodeGenerator.scala
+++ b/doc/code/CodeGenerator.scala
@@ -8,69 +8,71 @@ import slick.jdbc.H2Profile
 import slick.jdbc.H2Profile.api.*
 //#imports
 
-object CodeGenerator extends App {
-  val uri = "#slick.db.default"
-  val profile = "slick.jdbc.H2Profile"
-  val jdbcDriver = "org.h2.Driver"
-  val url = "jdbc:postgresql://localhost/test"
-  val outputFolder = ""
-  val pkg = "demo"
-  val user = ""
-  val password = ""
-  if(false){
-    val db = Database.forURL("jdbc:h2:mem:test1;DB_CLOSE_DELAY=-1", driver="org.h2.Driver")
-    //#default-runner-uri
-    slick.codegen.SourceCodeGenerator.main(
-      Array(uri, outputFolder)
-    )
-    //#default-runner-uri
-    //#default-runner
-    slick.codegen.SourceCodeGenerator.main(
-      Array(profile, jdbcDriver, url, outputFolder, pkg)
-    )
-    //#default-runner
-    //#default-runner-with-auth
-    slick.codegen.SourceCodeGenerator.main(
-      Array(profile, jdbcDriver, url, outputFolder, pkg, user, password)
-    )
-    //#default-runner-with-auth
-    //#customization
-    import slick.codegen.SourceCodeGenerator
-    // fetch data model
-    val modelAction = H2Profile.createModel(Some(H2Profile.defaultTables)) // you can filter specific tables here
-    val modelFuture = db.run(modelAction)
-    // customize code generator
-    val codegenFuture = modelFuture.map(model => new SourceCodeGenerator(model) {
-      // override mapped table and class name
-      override def entityName =
-        dbTableName => dbTableName.dropRight(1).toLowerCase.toCamelCase
-      override def tableName =
-        dbTableName => dbTableName.toLowerCase.toCamelCase
+object CodeGenerator {
+  def main(args: Array[String]): Unit = {
+    val uri = "#slick.db.default"
+    val profile = "slick.jdbc.H2Profile"
+    val jdbcDriver = "org.h2.Driver"
+    val url = "jdbc:postgresql://localhost/test"
+    val outputFolder = ""
+    val pkg = "demo"
+    val user = ""
+    val password = ""
+    if(false){
+      val db = Database.forURL("jdbc:h2:mem:test1;DB_CLOSE_DELAY=-1", driver="org.h2.Driver")
+      //#default-runner-uri
+      slick.codegen.SourceCodeGenerator.main(
+        Array(uri, outputFolder)
+      )
+      //#default-runner-uri
+      //#default-runner
+      slick.codegen.SourceCodeGenerator.main(
+        Array(profile, jdbcDriver, url, outputFolder, pkg)
+      )
+      //#default-runner
+      //#default-runner-with-auth
+      slick.codegen.SourceCodeGenerator.main(
+        Array(profile, jdbcDriver, url, outputFolder, pkg, user, password)
+      )
+      //#default-runner-with-auth
+      //#customization
+      import slick.codegen.SourceCodeGenerator
+      // fetch data model
+      val modelAction = H2Profile.createModel(Some(H2Profile.defaultTables)) // you can filter specific tables here
+      val modelFuture = db.run(modelAction)
+      // customize code generator
+      val codegenFuture = modelFuture.map(model => new SourceCodeGenerator(model) {
+                                            // override mapped table and class name
+                                            override def entityName =
+                                              dbTableName => dbTableName.dropRight(1).toLowerCase.toCamelCase
+                                            override def tableName =
+                                              dbTableName => dbTableName.toLowerCase.toCamelCase
 
-      // add some custom import
-      override def code = "import foo.{MyCustomType,MyCustomTypeMapper}" + "\n" + super.code
+                                            // add some custom import
+                                            override def code = "import foo.{MyCustomType,MyCustomTypeMapper}" + "\n" + super.code
 
-      // override table generator
-      override def Table = new Table(_){
-        // disable entity class generation for tables with more than 22 columns
-        override def hugeClassEnabled = false
+                                            // override table generator
+                                            override def Table = new Table(_){
+                                              // disable entity class generation for tables with more than 22 columns
+                                              override def hugeClassEnabled = false
 
-        // override contained column generator
-        override def Column = new Column(_){
-          // use the data model member of this column to change the Scala type,
-          // e.g. to a custom enum or anything else
-          override def rawType =
-            if(this.model.name == "SOME_SPECIAL_COLUMN_NAME") "MyCustomType" else super.rawType
-        }
+                                              // override contained column generator
+                                              override def Column = new Column(_){
+                                                // use the data model member of this column to change the Scala type,
+                                                // e.g. to a custom enum or anything else
+                                                override def rawType =
+                                                  if(this.model.name == "SOME_SPECIAL_COLUMN_NAME") "MyCustomType" else super.rawType
+                                              }
+                                            }
+                                          })
+      codegenFuture.onComplete {
+        case Success(codegen) =>
+          codegen.writeToFile(
+            "slick.jdbc.H2Profile","some/folder/","some.packag","Tables","Tables.scala"
+          )
+        case Failure(_) =>
       }
-    })
-    codegenFuture.onComplete {
-      case Success(codegen) =>
-        codegen.writeToFile(
-          "slick.jdbc.H2Profile","some/folder/","some.packag","Tables","Tables.scala"
-        )
-      case Failure(_) =>
+      //#customization
     }
-    //#customization
   }
 }

--- a/doc/code/Connection.scala
+++ b/doc/code/Connection.scala
@@ -13,138 +13,140 @@ import slick.basic.DatabasePublisher
 import slick.jdbc.H2Profile.api._
 //#imports
 
-object Connection extends App {
-  class Coffees(tag: Tag) extends Table[(String, Blob)](tag, "COFFEES") {
-    def name = column[String]("COF_NAME", O.PrimaryKey)
-    def image = column[Blob]("IMAGE")
-    def * = (name, image)
-  }
-  val coffees = TableQuery[Coffees]
-  if (false){
-    val dataSource = null.asInstanceOf[javax.sql.DataSource]
-    val size = 42
-    //#forDataSource
-    val db = Database.forDataSource(dataSource: javax.sql.DataSource,
-      Some(size: Int))
-    //#forDataSource
-  }
-  if (false){
-    val dataSource = null.asInstanceOf[slick.jdbc.DatabaseUrlDataSource]
-    //#forDatabaseURL
-    val db = Database.forDataSource(dataSource: slick.jdbc.DatabaseUrlDataSource,
-      None)
-    //#forDatabaseURL
-  }
-  if(false) {
-    val jndiName = ""
-    val size = 42
-    //#forName
-    val db = Database.forName(jndiName: String, Some(size: Int))
-    //#forName
-  }
-  ;{
-    //#forConfig
-    val db = Database.forConfig("mydb")
-    //#forConfig
-    db.close
-  }
-  ;{
-    //#forURL
-    val db = Database.forURL("jdbc:h2:mem:test1;DB_CLOSE_DELAY=-1",
-      driver="org.h2.Driver")
-    //#forURL
-    db.close
-  }
-  ;{
-    //#forURL2
-    val db = Database.forURL("jdbc:h2:mem:test1;DB_CLOSE_DELAY=-1",
-      driver="org.h2.Driver",
-      executor = AsyncExecutor("test1", numThreads=10, queueSize=1000))
-    //#forURL2
-    db.close
-  }
-  val db = Database.forURL("jdbc:h2:mem:test2;INIT="+coffees.schema.createStatements.mkString("\\;"), driver="org.h2.Driver")
-  try {
-    val lines = new ArrayBuffer[Any]()
-    def println(s: Any) = lines += s
-    ;{
-      //#materialize
-      val q = for (c <- coffees) yield c.name
-      val a = q.result
-      val f: Future[Seq[String]] = db.run(a)
-
-      f.onComplete {
-        case Success(s) => println(s"Result: $s")
-        case Failure(t) => t.printStackTrace()
-      }
-      //#materialize
-      Await.result(f, Duration.Inf)
-    };{
-      //#stream
-      val q = for (c <- coffees) yield c.name
-      val a = q.result
-      val p: DatabasePublisher[String] = db.stream(a)
-
-      // .foreach is a convenience method on DatabasePublisher.
-      // Use Akka Streams for more elaborate stream processing.
-      //#stream
-      val f =
-      //#stream
-      p.foreach { s => println(s"Element: $s") }
-      //#stream
-      Await.result(f, Duration.Inf)
-    };{
-      //#streamblob
-      val q = for (c <- coffees) yield c.image
-      val a = q.result
-      val p1: DatabasePublisher[Blob] = db.stream(a)
-      val p2: DatabasePublisher[Array[Byte]] = p1.mapResult { b =>
-        // Executed synchronously on the database thread
-        b.getBytes(0, b.length().toInt)
-      }
-      //#streamblob
-    };{
-      //#transaction
-      val a = (for {
-        ns <- coffees.filter(_.name.startsWith("ESPRESSO")).map(_.name).result
-        _ <- DBIO.seq(ns.map(n => coffees.filter(_.name === n).delete): _*)
-      } yield ()).transactionally
-
-      val f: Future[Unit] = db.run(a)
-      //#transaction
-      Await.result(f, Duration.Inf)
-    };{
-      //#rollback
-      val countAction = coffees.length.result
-
-      val rollbackAction = (coffees ++= Seq(
-        ("Cold_Drip", new SerialBlob(Array[Byte](101))),
-        ("Dutch_Coffee", new SerialBlob(Array[Byte](49)))
-      )).flatMap { _ =>
-        DBIO.failed(new Exception("Roll it back"))
-      }.transactionally
-
-      val errorHandleAction = rollbackAction.asTry.flatMap {
-        case Failure(e: Throwable) => DBIO.successful(e.getMessage)
-        case Success(_) => DBIO.successful("never reached")
-      }
-
-      // Here we show that that coffee count is the same before and after the attempted insert.
-      // We also show that the result of the action is filled in with the exception's message.
-      val f = db.run(countAction zip errorHandleAction zip countAction).map {
-        case ((initialCount, result), finalCount) =>
-          // init: 5, final: 5, result: Roll it back
-          println(s"init: ${initialCount}, final: ${finalCount}, result: ${result}")
-          result
-      }
-
-      //#rollback
-      assert(Await.result(f, Duration.Inf) == "Roll it back")
+object Connection {
+  def main(args: Array[String]): Unit = {
+    class Coffees(tag: Tag) extends Table[(String, Blob)](tag, "COFFEES") {
+      def name = column[String]("COF_NAME", O.PrimaryKey)
+      def image = column[Blob]("IMAGE")
+      def * = (name, image)
     }
-    lines.foreach(Predef.println _)
-  } finally db.close
+    val coffees = TableQuery[Coffees]
+    if (false){
+      val dataSource = null.asInstanceOf[javax.sql.DataSource]
+      val size = 42
+      //#forDataSource
+      val db = Database.forDataSource(dataSource: javax.sql.DataSource,
+                                      Some(size: Int))
+      //#forDataSource
+    }
+    if (false){
+      val dataSource = null.asInstanceOf[slick.jdbc.DatabaseUrlDataSource]
+      //#forDatabaseURL
+      val db = Database.forDataSource(dataSource: slick.jdbc.DatabaseUrlDataSource,
+                                      None)
+      //#forDatabaseURL
+    }
+    if(false) {
+      val jndiName = ""
+      val size = 42
+      //#forName
+      val db = Database.forName(jndiName: String, Some(size: Int))
+      //#forName
+    }
+    ;{
+      //#forConfig
+      val db = Database.forConfig("mydb")
+      //#forConfig
+      db.close
+    }
+    ;{
+      //#forURL
+      val db = Database.forURL("jdbc:h2:mem:test1;DB_CLOSE_DELAY=-1",
+                               driver="org.h2.Driver")
+      //#forURL
+      db.close
+    }
+    ;{
+      //#forURL2
+      val db = Database.forURL("jdbc:h2:mem:test1;DB_CLOSE_DELAY=-1",
+                               driver="org.h2.Driver",
+                               executor = AsyncExecutor("test1", numThreads=10, queueSize=1000))
+      //#forURL2
+      db.close
+    }
+    val db = Database.forURL("jdbc:h2:mem:test2;INIT="+coffees.schema.createStatements.mkString("\\;"), driver="org.h2.Driver")
+    try {
+      val lines = new ArrayBuffer[Any]()
+      def println(s: Any) = lines += s
+      ;{
+        //#materialize
+        val q = for (c <- coffees) yield c.name
+        val a = q.result
+        val f: Future[Seq[String]] = db.run(a)
 
-  //#simpleaction
-  val getAutoCommit = SimpleDBIO[Boolean](_.connection.getAutoCommit)
-  //#simpleaction
+        f.onComplete {
+          case Success(s) => println(s"Result: $s")
+          case Failure(t) => t.printStackTrace()
+        }
+        //#materialize
+        Await.result(f, Duration.Inf)
+      };{
+        //#stream
+        val q = for (c <- coffees) yield c.name
+        val a = q.result
+        val p: DatabasePublisher[String] = db.stream(a)
+
+        // .foreach is a convenience method on DatabasePublisher.
+        // Use Akka Streams for more elaborate stream processing.
+        //#stream
+        val f =
+          //#stream
+          p.foreach { s => println(s"Element: $s") }
+        //#stream
+        Await.result(f, Duration.Inf)
+      };{
+        //#streamblob
+        val q = for (c <- coffees) yield c.image
+        val a = q.result
+        val p1: DatabasePublisher[Blob] = db.stream(a)
+        val p2: DatabasePublisher[Array[Byte]] = p1.mapResult { b =>
+          // Executed synchronously on the database thread
+          b.getBytes(0, b.length().toInt)
+        }
+        //#streamblob
+      };{
+        //#transaction
+        val a = (for {
+                   ns <- coffees.filter(_.name.startsWith("ESPRESSO")).map(_.name).result
+                   _ <- DBIO.seq(ns.map(n => coffees.filter(_.name === n).delete): _*)
+                 } yield ()).transactionally
+
+        val f: Future[Unit] = db.run(a)
+        //#transaction
+        Await.result(f, Duration.Inf)
+      };{
+        //#rollback
+        val countAction = coffees.length.result
+
+        val rollbackAction = (coffees ++= Seq(
+                                ("Cold_Drip", new SerialBlob(Array[Byte](101))),
+                                ("Dutch_Coffee", new SerialBlob(Array[Byte](49)))
+                              )).flatMap { _ =>
+          DBIO.failed(new Exception("Roll it back"))
+        }.transactionally
+
+        val errorHandleAction = rollbackAction.asTry.flatMap {
+          case Failure(e: Throwable) => DBIO.successful(e.getMessage)
+          case Success(_) => DBIO.successful("never reached")
+        }
+
+        // Here we show that that coffee count is the same before and after the attempted insert.
+        // We also show that the result of the action is filled in with the exception's message.
+        val f = db.run(countAction zip errorHandleAction zip countAction).map {
+          case ((initialCount, result), finalCount) =>
+            // init: 5, final: 5, result: Roll it back
+            println(s"init: ${initialCount}, final: ${finalCount}, result: ${result}")
+            result
+        }
+
+        //#rollback
+        assert(Await.result(f, Duration.Inf) == "Roll it back")
+      }
+      lines.foreach(Predef.println _)
+    } finally db.close
+
+    //#simpleaction
+    val getAutoCommit = SimpleDBIO[Boolean](_.connection.getAutoCommit)
+    //#simpleaction
+  }
 }

--- a/doc/code/Cookbook.scala
+++ b/doc/code/Cookbook.scala
@@ -8,7 +8,6 @@ object Cookbook {
    
     //#imports22
     import slick.collection.heterogeneous._
-    import slick.collection.heterogeneous.syntax._
     //#imports22
     
     //#example22
@@ -57,74 +56,76 @@ object Cookbook {
     //#exampleTrackNumberOfQueryCompilations
   }
 
-  object DistinguishDBIOActionsByEffectTypeAtRuntime extends App {
+  object DistinguishDBIOActionsByEffectTypeAtRuntime {
+    def main(args: Array[String]): Unit = {
 
-    //#exampleDistinguishDBIOActionsByEffectTypeAtRuntime
-    import slick.dbio._
+      //#exampleDistinguishDBIOActionsByEffectTypeAtRuntime
+      import slick.dbio._
 
-    object EffectInfo {
+      object EffectInfo {
 
-      /**
-       * Type class which can be summoned to determine if a given DBIOAction is read-only,
-       * e.g., to let us determine whether to run the DBIOAction on the primary or the secondary.
-       */
-      sealed trait ReadOnly[E <: Effect] {
-        def isReadOnly: Boolean
-      }
+        /**
+          * Type class which can be summoned to determine if a given DBIOAction is read-only,
+          * e.g., to let us determine whether to run the DBIOAction on the primary or the secondary.
+          */
+        sealed trait ReadOnly[E <: Effect] {
+          def isReadOnly: Boolean
+        }
 
-      /**
-       * Base trait provides an instance of ReadOnly where isReadOnly = false.
-       * This is extended below by the ReadOnly companion object, which overrides the instance of ReadOnly for effect
-       * types where isReadOnly should be true.
-       */
-      sealed trait ReadOnlyFalse {
+        /**
+          * Base trait provides an instance of ReadOnly where isReadOnly = false.
+          * This is extended below by the ReadOnly companion object, which overrides the instance of ReadOnly for effect
+          * types where isReadOnly should be true.
+          */
+        sealed trait ReadOnlyFalse {
 
-        implicit def readOnlyFalse[E <: Effect]: ReadOnly[E] = new ReadOnly[E] {
-          val isReadOnly: Boolean = false
+          implicit def readOnlyFalse[E <: Effect]: ReadOnly[E] = new ReadOnly[E] {
+            val isReadOnly: Boolean = false
+          }
+        }
+
+        /**
+          * Companion object providing implementations of ReadOnly for specific types where isReadOnly = true.
+          */
+        object ReadOnly extends ReadOnlyFalse {
+
+          // When Effect.Read is used by itself, isReadOnly is true.
+          implicit object Read extends ReadOnly[Effect.Read] {
+            val isReadOnly: Boolean = true
+          }
+
+          // When Effect.Read is used with Effect.Transactional, isReadOnly is true,
+          // as a transactional read is still a read.
+          implicit object ReadWithTransactional extends ReadOnly[Effect.Read with Effect.Transactional] {
+            val isReadOnly: Boolean = true
+          }
         }
       }
 
-      /**
-       * Companion object providing implementations of ReadOnly for specific types where isReadOnly = true.
-       */
-      object ReadOnly extends ReadOnlyFalse {
+      // For brevity, this run method just demonstrates that we can distinguish the effect type at runtime.
+      // In a real application, we could place this method in a class that contains a handle to the primary and a handle
+      // to the secondary. Then the callers just call `run(action)` and don't worry about distinguishing the two handles.
+      def run[A, E <: Effect: EffectInfo.ReadOnly](action: DBIOAction[A, NoStream, E]): Unit =
+        if (implicitly[EffectInfo.ReadOnly[E]].isReadOnly) println("Action is read-only, run it on the secondary")
+        else println("Action is not read-only, run it on the primary")
 
-        // When Effect.Read is used by itself, isReadOnly is true.
-        implicit object Read extends ReadOnly[Effect.Read] {
-          val isReadOnly: Boolean = true
-        }
+      // We define a generic action and narrow it to specific effect types below.
+      val action = DBIO.successful(42)
 
-        // When Effect.Read is used with Effect.Transactional, isReadOnly is true,
-        // as a transactional read is still a read.
-        implicit object ReadWithTransactional extends ReadOnly[Effect.Read with Effect.Transactional] {
-          val isReadOnly: Boolean = true
-        }
-      }
+      // Read-only actions.
+      // Each of these prints "Action is read-only, run it on the secondary"
+      run(action: DBIOAction[Int, NoStream, Effect.Read])
+      run(action: DBIOAction[Int, NoStream, Effect.Read with Effect.Transactional])
+      run(action: DBIOAction[Int, NoStream, Effect with Effect.Read with Effect.Transactional])
+      run(action: DBIOAction[Int, NoStream, Effect.Transactional with Effect.Read with Effect])
+
+      // Other actions.
+      // "Action is not read-only, run it on the primary"
+      run(action: DBIOAction[Int, NoStream, Effect])
+      run(action: DBIOAction[Int, NoStream, Effect.Write])
+      run(action: DBIOAction[Int, NoStream, Effect.Schema])
+      run(action: DBIOAction[Int, NoStream, Effect.All])
+      //#exampleDistinguishDBIOActionsByEffectTypeAtRuntime
     }
-
-    // For brevity, this run method just demonstrates that we can distinguish the effect type at runtime.
-    // In a real application, we could place this method in a class that contains a handle to the primary and a handle
-    // to the secondary. Then the callers just call `run(action)` and don't worry about distinguishing the two handles.
-    def run[A, E <: Effect: EffectInfo.ReadOnly](action: DBIOAction[A, NoStream, E]): Unit =
-      if (implicitly[EffectInfo.ReadOnly[E]].isReadOnly) println("Action is read-only, run it on the secondary")
-      else println("Action is not read-only, run it on the primary")
-
-    // We define a generic action and narrow it to specific effect types below.
-    val action = DBIO.successful(42)
-
-    // Read-only actions.
-    // Each of these prints "Action is read-only, run it on the secondary"
-    run(action: DBIOAction[Int, NoStream, Effect.Read])
-    run(action: DBIOAction[Int, NoStream, Effect.Read with Effect.Transactional])
-    run(action: DBIOAction[Int, NoStream, Effect with Effect.Read with Effect.Transactional])
-    run(action: DBIOAction[Int, NoStream, Effect.Transactional with Effect.Read with Effect])
-
-    // Other actions.
-    // "Action is not read-only, run it on the primary"
-    run(action: DBIOAction[Int, NoStream, Effect])
-    run(action: DBIOAction[Int, NoStream, Effect.Write])
-    run(action: DBIOAction[Int, NoStream, Effect.Schema])
-    run(action: DBIOAction[Int, NoStream, Effect.All])
-    //#exampleDistinguishDBIOActionsByEffectTypeAtRuntime
   }
 }

--- a/doc/code/DBIOCombinators.scala
+++ b/doc/code/DBIOCombinators.scala
@@ -2,27 +2,29 @@ package com.typesafe.slick.docs
 
 import slick.jdbc.H2Profile.api._
 
-object DBIOCombinators extends App {
-  class Coffees(tag: Tag) extends Table[(String, Double)](tag, "COFFEES") {
-    def name = column[String]("COF_NAME", O.PrimaryKey)
-    def price = column[Double]("PRICE")
-    def * = (name, price)
-  }
-  val coffees = TableQuery[Coffees]
-  ;{
-    //#combinators1
-    val ins1: DBIO[Int] = coffees += ("Colombian", 7.99)
-    val ins2: DBIO[Int] = coffees += ("French_Roast", 8.99)
+object DBIOCombinators extends {
+  def main(args: Array[String]): Unit = {
+    class Coffees(tag: Tag) extends Table[(String, Double)](tag, "COFFEES") {
+      def name = column[String]("COF_NAME", O.PrimaryKey)
+      def price = column[Double]("PRICE")
+      def * = (name, price)
+    }
+    val coffees = TableQuery[Coffees]
+    ;{
+      //#combinators1
+      val ins1: DBIO[Int] = coffees += ("Colombian", 7.99)
+      val ins2: DBIO[Int] = coffees += ("French_Roast", 8.99)
 
-    val a1: DBIO[Unit] = DBIO.seq(ins1, ins2)
+      val a1: DBIO[Unit] = DBIO.seq(ins1, ins2)
 
-    val a2: DBIO[Int] = ins1 andThen ins2
+      val a2: DBIO[Int] = ins1 andThen ins2
 
-    val a3: DBIO[(Int, Int)] = ins1 zip ins2
+      val a3: DBIO[(Int, Int)] = ins1 zip ins2
 
-    val a4: DBIO[Vector[Int]] = DBIO.sequence(Vector(ins1, ins2))
-    //#combinators1
+      val a4: DBIO[Vector[Int]] = DBIO.sequence(Vector(ins1, ins2))
+      //#combinators1
 
-    ()
+      ()
+    }
   }
 }

--- a/doc/code/GettingStartedOverview.scala
+++ b/doc/code/GettingStartedOverview.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.Duration
 
 //#imports
 // Use H2Profile to connect to an H2 database
-import slick.jdbc.H2Profile.api._
+import slick.jdbc.H2Profile.api.*
 //#imports
 
 /**
@@ -13,95 +13,94 @@ import slick.jdbc.H2Profile.api._
  * H2 database. The example data comes from Oracle's JDBC tutorial at
  * http://docs.oracle.com/javase/tutorial/jdbc/basics/tables.html.
  */
-object GettingStartedOverview extends App {
-  //#quick-imports
-  import slick.jdbc.H2Profile.api._
-  //#quick-imports
+object GettingStartedOverview {
+  def main(args: Array[String]): Unit = {
 
-  //#quick-schema
-  class Coffees(tag: Tag) extends Table[(String, Double)](tag, "COFFEES") {
-    def name = column[String]("COF_NAME", O.PrimaryKey)
-    def price = column[Double]("PRICE")
-    def * = (name, price)
-  }
-  val coffees = TableQuery[Coffees]
-  //#quick-schema
-
-  val f1 =
-  //#quick-query
-  Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver").run(
-  //#quick-query
-    coffees.schema.create andThen
-  //#quick-query
-    ( for( c <- coffees; if c.price < 10.0 ) yield c.name ).result
-  //#quick-query
-    andThen
-  //#quick-query
-    // or
-    coffees.filter(_.price < 10.0).map(_.name).result
-  )
-  //#quick-query
-  Await.result(f1, Duration.Inf)
-
-  val f2 = Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver").run(
-    coffees.schema.create andThen {
-      //#what-is-slick-micro-example
-      val limit = 10.0
-
-      // Your query could look like this:
-      ( for( c <- coffees; if c.price < limit ) yield c.name ).result
-
-      // Equivalent SQL: select COF_NAME from COFFEES where PRICE < 10.0
-      //#what-is-slick-micro-example
-    } andThen {
-      //#what-is-slick-micro-example-plainsql
-      val limit = 10.0
-
-      sql"select COF_NAME from COFFEES where PRICE < $limit".as[String]
-
-      // Automatically using a bind variable to be safe from SQL injection:
-      // select COF_NAME from COFFEES where PRICE < ?
-      //#what-is-slick-micro-example-plainsql
+    //#quick-schema
+    class Coffees(tag: Tag) extends Table[(String, Double)](tag, "COFFEES") {
+      def name = column[String]("COF_NAME", O.PrimaryKey)
+      def price = column[Double]("PRICE")
+      def * = (name, price)
     }
-  )
-  Await.result(f2, Duration.Inf)
+    val coffees = TableQuery[Coffees]
+    //#quick-schema
 
-  //#features-scala-collections
-  // Query that only returns the "name" column
-  // Equivalent SQL: select NAME from COFFEES
-  coffees.map(_.name)
-
-  // Query that limits results by price < 10.0
-  // Equivalent SQL: select * from COFFEES where PRICE < 10.0
-  coffees.filter(_.price < 10.0)
-  //#features-scala-collections
-
-  {
-    val db = Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver")
-    val f4 = {
-      //#features-type-safe
-      // The result of "select PRICE from COFFEES" is a Seq of Double
-      // because of the type safe column definitions
-      val coffeeNames: Future[Seq[Double]] = db.run(
-        //#features-type-safe
+    val f1 =
+      //#quick-query
+      Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver").run(
+        //#quick-query
         coffees.schema.create andThen
-        //#features-type-safe
-        coffees.map(_.price).result
+          //#quick-query
+          ( for( c <- coffees; if c.price < 10.0 ) yield c.name ).result
+          //#quick-query
+          andThen
+          //#quick-query
+          // or
+          coffees.filter(_.price < 10.0).map(_.name).result
       )
+    //#quick-query
+    Await.result(f1, Duration.Inf)
 
-      // Query builders are type safe:
-      coffees.filter(_.price < 10.0)
-      // Using a string in the filter would result in a compilation error
-      //#features-type-safe
-      coffeeNames
+    val f2 = Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver").run(
+      coffees.schema.create andThen {
+        //#what-is-slick-micro-example
+        val limit = 10.0
+
+        // Your query could look like this:
+        ( for( c <- coffees; if c.price < limit ) yield c.name ).result
+
+        // Equivalent SQL: select COF_NAME from COFFEES where PRICE < 10.0
+        //#what-is-slick-micro-example
+      } andThen {
+        //#what-is-slick-micro-example-plainsql
+        val limit = 10.0
+
+        sql"select COF_NAME from COFFEES where PRICE < $limit".as[String]
+
+        // Automatically using a bind variable to be safe from SQL injection:
+        // select COF_NAME from COFFEES where PRICE < ?
+        //#what-is-slick-micro-example-plainsql
+      }
+    )
+    Await.result(f2, Duration.Inf)
+
+    //#features-scala-collections
+    // Query that only returns the "name" column
+    // Equivalent SQL: select NAME from COFFEES
+    coffees.map(_.name)
+
+    // Query that limits results by price < 10.0
+    // Equivalent SQL: select * from COFFEES where PRICE < 10.0
+    coffees.filter(_.price < 10.0)
+    //#features-scala-collections
+
+    {
+      val db = Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver")
+      val f4 = {
+        //#features-type-safe
+        // The result of "select PRICE from COFFEES" is a Seq of Double
+        // because of the type safe column definitions
+        val coffeeNames: Future[Seq[Double]] = db.run(
+          //#features-type-safe
+          coffees.schema.create andThen
+            //#features-type-safe
+            coffees.map(_.price).result
+        )
+
+        // Query builders are type safe:
+        coffees.filter(_.price < 10.0)
+        // Using a string in the filter would result in a compilation error
+        //#features-type-safe
+        coffeeNames
+      }
+      Await.result(f4, Duration.Inf)
     }
-    Await.result(f4, Duration.Inf)
-  }
 
-  //#features-composable
-  // Create a query for coffee names with a price less than 10, sorted by name
-  coffees.filter(_.price < 10.0).sortBy(_.name).map(_.name)
-  // The generated SQL is equivalent to:
-  // select name from COFFEES where PRICE < 10.0 order by NAME
-  //#features-composable
+    //#features-composable
+    // Create a query for coffee names with a price less than 10, sorted by name
+    coffees.filter(_.price < 10.0).sortBy(_.name).map(_.name)
+    // The generated SQL is equivalent to:
+    // select name from COFFEES where PRICE < 10.0 order by NAME
+    //#features-composable
+  }
 }

--- a/doc/code/JoinsUnions.scala
+++ b/doc/code/JoinsUnions.scala
@@ -2,140 +2,141 @@ package com.typesafe.slick.docs
 
 import slick.jdbc.H2Profile.api._
 
-object JoinsUnions extends App{
+object JoinsUnions {
+  def main(args: Array[String]): Unit = {
+    class Suppliers(tag: Tag) extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
+      def id = column[Int]("SUP_ID", O.PrimaryKey)
+      def name = column[String]("SUP_NAME")
+      def street = column[String]("STREET")
+      def city = column[String]("CITY")
+      def state = column[String]("STATE")
+      def zip = column[String]("ZIP")
+      def * = (id, name, street, city, state, zip)
+    }
+    val suppliers = TableQuery[Suppliers]
 
-  class Suppliers(tag: Tag) extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
-    def id = column[Int]("SUP_ID", O.PrimaryKey)
-    def name = column[String]("SUP_NAME")
-    def street = column[String]("STREET")
-    def city = column[String]("CITY")
-    def state = column[String]("STATE")
-    def zip = column[String]("ZIP")
-    def * = (id, name, street, city, state, zip)
+    class Coffees(tag: Tag) extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
+      def name = column[String]("COF_NAME", O.PrimaryKey)
+      def supID = column[Int]("SUP_ID")
+      def price = column[Double]("PRICE")
+      def sales = column[Int]("SALES")
+      def total = column[Int]("TOTAL")
+      def * = (name, supID, price, sales, total)
+      def supplier = foreignKey("SUP_FK", supID, suppliers)(_.id)
+    }
+    val coffees = TableQuery[Coffees]
+
+    //#implicitCross
+    val monadicCrossJoin = for {
+      c <- coffees
+      s <- suppliers
+    } yield (c.name, s.name)
+    // compiles to SQL:
+    //   select x2."COF_NAME", x3."SUP_NAME"
+    //     from "COFFEES" x2, "SUPPLIERS" x3
+    //#implicitCross
+    println(monadicCrossJoin.result.statements.head)
+
+    //#implicitInner
+    val monadicInnerJoin = for {
+      c <- coffees
+      s <- suppliers if c.supID === s.id
+    } yield (c.name, s.name)
+    // compiles to SQL:
+    //   select x2."COF_NAME", x3."SUP_NAME"
+    //     from "COFFEES" x2, "SUPPLIERS" x3
+    //     where x2."SUP_ID" = x3."SUP_ID"
+    //#implicitInner
+    println(monadicInnerJoin.result.statements.head)
+
+    //#explicit
+    val crossJoin = for {
+      (c, s) <- coffees join suppliers
+    } yield (c.name, s.name)
+    // compiles to SQL (simplified):
+    //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
+    //     inner join "SUPPLIERS" x3
+
+    val innerJoin = for {
+      (c, s) <- coffees join suppliers on (_.supID === _.id)
+    } yield (c.name, s.name)
+    // compiles to SQL (simplified):
+    //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
+    //     inner join "SUPPLIERS" x3
+    //     on x2."SUP_ID" = x3."SUP_ID"
+
+    val leftOuterJoin = for {
+      (c, s) <- coffees joinLeft suppliers on (_.supID === _.id)
+    } yield (c.name, s.map(_.name))
+    // compiles to SQL (simplified):
+    //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
+    //     left outer join "SUPPLIERS" x3
+    //     on x2."SUP_ID" = x3."SUP_ID"
+
+    val rightOuterJoin = for {
+      (c, s) <- coffees joinRight suppliers on (_.supID === _.id)
+    } yield (c.map(_.name), s.name)
+    // compiles to SQL (simplified):
+    //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
+    //     right outer join "SUPPLIERS" x3
+    //     on x2."SUP_ID" = x3."SUP_ID"
+
+    val fullOuterJoin = for {
+      (c, s) <- coffees joinFull suppliers on (_.supID === _.id)
+    } yield (c.map(_.name), s.map(_.name))
+    // compiles to SQL (simplified):
+    //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
+    //     full outer join "SUPPLIERS" x3
+    //     on x2."SUP_ID" = x3."SUP_ID"
+    //#explicit
+    println(crossJoin.result.statements.head)
+    println(innerJoin.result.statements.head)
+    println(leftOuterJoin.result.statements.head)
+    println(rightOuterJoin.result.statements.head)
+    println(fullOuterJoin.result.statements.head)
+
+    //#zip
+    val zipJoinQuery = for {
+      (c, s) <- coffees zip suppliers
+    } yield (c.name, s.name)
+
+    val zipWithJoin = for {
+      res <- coffees.zipWith(suppliers, (c: Coffees, s: Suppliers) => (c.name, s.name))
+    } yield res
+    //#zip
+    //println(zipJoinQuery.result.statements.head)
+    //println(zipWithJoin.result.statements.head)
+
+    //#zipWithIndex
+    val zipWithIndexJoin = for {
+      (c, idx) <- coffees.zipWithIndex
+    } yield (c.name, idx)
+    //#zipWithIndex
+    //println(zipWithIndexJoin.result.statements.head)
+
+    //#union
+    val q1 = coffees.filter(_.price < 8.0)
+    val q2 = coffees.filter(_.price > 9.0)
+
+    val unionQuery = q1 union q2
+    // compiles to SQL (simplified):
+    //   select x8."COF_NAME", x8."SUP_ID", x8."PRICE", x8."SALES", x8."TOTAL"
+    //     from "COFFEES" x8
+    //     where x8."PRICE" < 8.0
+    //   union select x9."COF_NAME", x9."SUP_ID", x9."PRICE", x9."SALES", x9."TOTAL"
+    //     from "COFFEES" x9
+    //     where x9."PRICE" > 9.0
+
+    val unionAllQuery = q1 ++ q2
+    // compiles to SQL (simplified):
+    //   select x8."COF_NAME", x8."SUP_ID", x8."PRICE", x8."SALES", x8."TOTAL"
+    //     from "COFFEES" x8
+    //     where x8."PRICE" < 8.0
+    //   union all select x9."COF_NAME", x9."SUP_ID", x9."PRICE", x9."SALES", x9."TOTAL"
+    //     from "COFFEES" x9
+    //     where x9."PRICE" > 9.0
+    //#union
+    println(unionQuery.result.statements.head)
+    println(unionAllQuery.result.statements.head)
   }
-  val suppliers = TableQuery[Suppliers]
-
-  class Coffees(tag: Tag) extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
-    def name = column[String]("COF_NAME", O.PrimaryKey)
-    def supID = column[Int]("SUP_ID")
-    def price = column[Double]("PRICE")
-    def sales = column[Int]("SALES")
-    def total = column[Int]("TOTAL")
-    def * = (name, supID, price, sales, total)
-    def supplier = foreignKey("SUP_FK", supID, suppliers)(_.id)
-  }
-  val coffees = TableQuery[Coffees]
-
-  //#implicitCross
-  val monadicCrossJoin = for {
-    c <- coffees
-    s <- suppliers
-  } yield (c.name, s.name)
-  // compiles to SQL:
-  //   select x2."COF_NAME", x3."SUP_NAME"
-  //     from "COFFEES" x2, "SUPPLIERS" x3
-  //#implicitCross
-  println(monadicCrossJoin.result.statements.head)
-
-  //#implicitInner
-  val monadicInnerJoin = for {
-    c <- coffees
-    s <- suppliers if c.supID === s.id
-  } yield (c.name, s.name)
-  // compiles to SQL:
-  //   select x2."COF_NAME", x3."SUP_NAME"
-  //     from "COFFEES" x2, "SUPPLIERS" x3
-  //     where x2."SUP_ID" = x3."SUP_ID"
-  //#implicitInner
-  println(monadicInnerJoin.result.statements.head)
-
-  //#explicit
-  val crossJoin = for {
-    (c, s) <- coffees join suppliers
-  } yield (c.name, s.name)
-  // compiles to SQL (simplified):
-  //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
-  //     inner join "SUPPLIERS" x3
-
-  val innerJoin = for {
-    (c, s) <- coffees join suppliers on (_.supID === _.id)
-  } yield (c.name, s.name)
-  // compiles to SQL (simplified):
-  //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
-  //     inner join "SUPPLIERS" x3
-  //     on x2."SUP_ID" = x3."SUP_ID"
-
-  val leftOuterJoin = for {
-    (c, s) <- coffees joinLeft suppliers on (_.supID === _.id)
-  } yield (c.name, s.map(_.name))
-  // compiles to SQL (simplified):
-  //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
-  //     left outer join "SUPPLIERS" x3
-  //     on x2."SUP_ID" = x3."SUP_ID"
-
-  val rightOuterJoin = for {
-    (c, s) <- coffees joinRight suppliers on (_.supID === _.id)
-  } yield (c.map(_.name), s.name)
-  // compiles to SQL (simplified):
-  //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
-  //     right outer join "SUPPLIERS" x3
-  //     on x2."SUP_ID" = x3."SUP_ID"
-
-  val fullOuterJoin = for {
-    (c, s) <- coffees joinFull suppliers on (_.supID === _.id)
-  } yield (c.map(_.name), s.map(_.name))
-  // compiles to SQL (simplified):
-  //   select x2."COF_NAME", x3."SUP_NAME" from "COFFEES" x2
-  //     full outer join "SUPPLIERS" x3
-  //     on x2."SUP_ID" = x3."SUP_ID"
-  //#explicit
-  println(crossJoin.result.statements.head)
-  println(innerJoin.result.statements.head)
-  println(leftOuterJoin.result.statements.head)
-  println(rightOuterJoin.result.statements.head)
-  println(fullOuterJoin.result.statements.head)
-
-  //#zip
-  val zipJoinQuery = for {
-    (c, s) <- coffees zip suppliers
-  } yield (c.name, s.name)
-
-  val zipWithJoin = for {
-    res <- coffees.zipWith(suppliers, (c: Coffees, s: Suppliers) => (c.name, s.name))
-  } yield res
-  //#zip
-  //println(zipJoinQuery.result.statements.head)
-  //println(zipWithJoin.result.statements.head)
-
-  //#zipWithIndex
-  val zipWithIndexJoin = for {
-    (c, idx) <- coffees.zipWithIndex
-  } yield (c.name, idx)
-  //#zipWithIndex
-  //println(zipWithIndexJoin.result.statements.head)
-
-  //#union
-  val q1 = coffees.filter(_.price < 8.0)
-  val q2 = coffees.filter(_.price > 9.0)
-
-  val unionQuery = q1 union q2
-  // compiles to SQL (simplified):
-  //   select x8."COF_NAME", x8."SUP_ID", x8."PRICE", x8."SALES", x8."TOTAL"
-  //     from "COFFEES" x8
-  //     where x8."PRICE" < 8.0
-  //   union select x9."COF_NAME", x9."SUP_ID", x9."PRICE", x9."SALES", x9."TOTAL"
-  //     from "COFFEES" x9
-  //     where x9."PRICE" > 9.0
-
-  val unionAllQuery = q1 ++ q2
-  // compiles to SQL (simplified):
-  //   select x8."COF_NAME", x8."SUP_ID", x8."PRICE", x8."SALES", x8."TOTAL"
-  //     from "COFFEES" x8
-  //     where x8."PRICE" < 8.0
-  //   union all select x9."COF_NAME", x9."SUP_ID", x9."PRICE", x9."SALES", x9."TOTAL"
-  //     from "COFFEES" x9
-  //     where x9."PRICE" > 9.0
-  //#union
-  println(unionQuery.result.statements.head)
-  println(unionAllQuery.result.statements.head)
 }

--- a/doc/code/OrmToSlick.scala
+++ b/doc/code/OrmToSlick.scala
@@ -4,225 +4,227 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import slick.jdbc.H2Profile.api._
 
-object OrmToSlick extends App {
-  import SqlToSlick.Tables._
+object OrmToSlick {
+  def main(args: Array[String]): Unit = {
+    import SqlToSlick.Tables._
 
-  // fake ORM
-  object PeopleFinder{
-    def getByIds(ids: Seq[Int]): Seq[Person] = Seq()
-    def getById(id: Int): Person = null
-  }
-  implicit class OrmPersonAddress(person: Person){
-    def address: Address = null
-  }
-  implicit class OrmPrefetch(people: Seq[Person]){
-    def prefetch(f: Person => Address) = people
-  }
-  object session{
-    def createQuery(hql: String) = new HqlQuery
-    def createCriteria(cls: java.lang.Class[_]) = new Criteria
-    def save = ()
-  }
-  class Criteria{
-    def add(r: Restriction) = this
-  }
-  type Restriction = Criteria
-  class HqlQuery{
-    def setParameterList(column: String, values: Array[_]): Unit = ()
-  }
-  object Property{
-    def forName(s:String) = new Property
-  }
-  class Property{
-    def in(array: Array[_]): Restriction = new Restriction
-    def lt(i: Int) = new Restriction
-    def gt(i: Int) = new Restriction
-  }
-  object Restrictions{
-    def disjunction = new Criteria
-  }
-
-  val db = Database.forConfig("h2mem1")
-  try {
-    val setup = DBIO.seq(
-      addresses.schema.create,
-      people.schema.create,
-      sql"ALTER TABLE PERSON ALTER COLUMN NAME VARCHAR(255) DEFAULT('')".as[Int],
-      sql"ALTER TABLE PERSON ALTER COLUMN AGE INT DEFAULT(-1)".as[Int],
-      sql"ALTER TABLE PERSON ALTER COLUMN ADDRESS_ID INT DEFAULT(1)".as[Int],
-      SqlToSlick.inserts
-    )
-    Await.result(db.run(setup), Duration.Inf)
-
-    ;{
-      //#ormObjectNavigation
-      val people: Seq[Person] = PeopleFinder.getByIds(Seq(2,99,17,234))
-      val addresses: Seq[Address] = people.map(_.address)
-      //#ormObjectNavigation
-    };{
-      //#ormPrefetch
-                                // tell the ORM to load all related addresses at once
-      val people: Seq[Person] = PeopleFinder.getByIds(Seq(2,99,17,234)).prefetch(_.address)
-      val addresses: Seq[Address] = people.map(_.address)
-      //#ormPrefetch
+    // fake ORM
+    object PeopleFinder{
+      def getByIds(ids: Seq[Int]): Seq[Person] = Seq()
+      def getById(id: Int): Person = null
+    }
+    implicit class OrmPersonAddress(person: Person){
+      def address: Address = null
+    }
+    implicit class OrmPrefetch(people: Seq[Person]){
+      def prefetch(f: Person => Address) = people
+    }
+    object session{
+      def createQuery(hql: String) = new HqlQuery
+      def createCriteria(cls: java.lang.Class[_]) = new Criteria
+      def save = ()
+    }
+    class Criteria{
+      def add(r: Restriction) = this
+    }
+    type Restriction = Criteria
+    class HqlQuery{
+      def setParameterList(column: String, values: Array[_]): Unit = ()
+    }
+    object Property{
+      def forName(s:String) = new Property
+    }
+    class Property{
+      def in(array: Array[_]): Restriction = new Restriction
+      def lt(i: Int) = new Restriction
+      def gt(i: Int) = new Restriction
+    }
+    object Restrictions{
+      def disjunction = new Criteria
     }
 
-    ;{
-      //#slickNavigation
-      val peopleQuery: Query[People,Person,Seq] = people.filter(_.id inSet(Set(2,99,17,234)))
-      val addressesQuery: Query[Addresses,Address,Seq] = peopleQuery.flatMap(_.address)
-      //#slickNavigation
-      //#slickExecution
-      val addressesAction: DBIO[Seq[Address]] = addressesQuery.result
-      val addresses: Future[Seq[Address]] = db.run(addressesAction)
-      //#slickExecution
-      Await.result(addresses, Duration.Inf)
-    };{
-      type Query = HqlQuery
-      //#hqlQuery
-      val hql: String = "FROM Person p WHERE p.id in (:ids)"
-      val q: Query = session.createQuery(hql)
-      q.setParameterList("ids", Array(2,99,17,234))
-      //#hqlQuery
-    };{
-      //#criteriaQuery
-      val id = Property.forName("id")
-      val q = session.createCriteria(classOf[Person])
-                     .add( id in Array(2,99,17,234) )
-      //#criteriaQuery
-      //#criteriaQueryComposition
-      def byIds(c: Criteria, ids: Array[Int]) = c.add( id in ids )
+    val db = Database.forConfig("h2mem1")
+    try {
+      val setup = DBIO.seq(
+        addresses.schema.create,
+        people.schema.create,
+        sql"ALTER TABLE PERSON ALTER COLUMN NAME VARCHAR(255) DEFAULT('')".as[Int],
+        sql"ALTER TABLE PERSON ALTER COLUMN AGE INT DEFAULT(-1)".as[Int],
+        sql"ALTER TABLE PERSON ALTER COLUMN ADDRESS_ID INT DEFAULT(1)".as[Int],
+        SqlToSlick.inserts
+      )
+      Await.result(db.run(setup), Duration.Inf)
 
-      val c = byIds(
-        session.createCriteria(classOf[Person]),
-        Array(2,99,17,234)
-      )      
-      //#criteriaQueryComposition
-    };{
-      //#criteriaComposition
-      val age = Property.forName("age")
-      val q = session.createCriteria(classOf[Person])
-                     .add(
-                       Restrictions.disjunction
-                         .add(age lt 5)
-                         .add(age gt 65)
-                     )
-      //#criteriaComposition
-    };{
-      //#slickQuery
-      val q = people.filter(p => p.age < 5 || p.age > 65)
-      //#slickQuery
-    };{
-      //#slickQueryWithTypes
-      val q = (people: Query[People, Person, Seq]).filter(
-        (p: People) => 
+      ;{
+        //#ormObjectNavigation
+        val people: Seq[Person] = PeopleFinder.getByIds(Seq(2,99,17,234))
+        val addresses: Seq[Address] = people.map(_.address)
+        //#ormObjectNavigation
+      };{
+        //#ormPrefetch
+        // tell the ORM to load all related addresses at once
+        val people: Seq[Person] = PeopleFinder.getByIds(Seq(2,99,17,234)).prefetch(_.address)
+        val addresses: Seq[Address] = people.map(_.address)
+        //#ormPrefetch
+      }
+
+      ;{
+        //#slickNavigation
+        val peopleQuery: Query[People,Person,Seq] = people.filter(_.id inSet(Set(2,99,17,234)))
+        val addressesQuery: Query[Addresses,Address,Seq] = peopleQuery.flatMap(_.address)
+        //#slickNavigation
+        //#slickExecution
+        val addressesAction: DBIO[Seq[Address]] = addressesQuery.result
+        val addresses: Future[Seq[Address]] = db.run(addressesAction)
+        //#slickExecution
+        Await.result(addresses, Duration.Inf)
+      };{
+        type Query = HqlQuery
+        //#hqlQuery
+        val hql: String = "FROM Person p WHERE p.id in (:ids)"
+        val q: Query = session.createQuery(hql)
+        q.setParameterList("ids", Array(2,99,17,234))
+        //#hqlQuery
+      };{
+        //#criteriaQuery
+        val id = Property.forName("id")
+        val q = session.createCriteria(classOf[Person])
+          .add( id in Array(2,99,17,234) )
+        //#criteriaQuery
+        //#criteriaQueryComposition
+        def byIds(c: Criteria, ids: Array[Int]) = c.add( id in ids )
+
+        val c = byIds(
+          session.createCriteria(classOf[Person]),
+          Array(2,99,17,234)
+        )
+        //#criteriaQueryComposition
+      };{
+        //#criteriaComposition
+        val age = Property.forName("age")
+        val q = session.createCriteria(classOf[Person])
+          .add(
+            Restrictions.disjunction
+              .add(age lt 5)
+              .add(age gt 65)
+          )
+        //#criteriaComposition
+      };{
+        //#slickQuery
+        val q = people.filter(p => p.age < 5 || p.age > 65)
+        //#slickQuery
+      };{
+        //#slickQueryWithTypes
+        val q = (people: Query[People, Person, Seq]).filter(
+          (p: People) =>
           (
             ((p.age: Rep[Int]) < 5 || p.age > 65)
-            : Rep[Boolean]
+                : Rep[Boolean]
           )
-      )
-      //#slickQueryWithTypes
-    };{
-      //#slickForComprehension
-      for( p <- people if p.age < 5 || p.age > 65 ) yield p
-      //#slickForComprehension
-    };{
-      //#slickOrderBy
-      ( for( p <- people if p.age < 5 || p.age > 65 ) yield p ).sortBy(_.name)
-      //#slickOrderBy
-    };{
-      //#slickMap
-      people.map(p => (p.name, p.age))
-      //#slickMap
-    };{
-      //#ormGetById
-      PeopleFinder.getById(5)
-      //#ormGetById
-    };{
-      Await.result(
-        //#slickRun
-        db.run(people.filter(_.id === 5).result)
-        //#slickRun
-      , Duration.Inf)
-    };{
-      //#ormWriteCaching
-      val person = PeopleFinder.getById(5)
-      //#ormWriteCaching
-    };{
-      object person {
-        var name: String = ""
-        var age: Int = 0
-      }
-      //#ormWriteCaching
-      person.name = "C. Vogt"
-      person.age = 12345
-      session.save
-      //#ormWriteCaching
-    };{
-      //#slickUpdate
-      val personQuery = people.filter(_.id === 5)
-      personQuery.map(p => (p.name,p.age)).update("C. Vogt", 12345)
-      //#slickUpdate
-
-      //#slickDelete
-      personQuery.delete // deletes person with id 5
-      //#slickDelete
-    };{
-      //#slickInsert
-      people.map(p => (p.name,p.age)) += ("S. Zeiger", 54321)
-      //#slickInsert
-    };{
-      //#slickRelationships
-      implicit class PersonExtensions[C[_]](q: Query[People, Person, C]) {
-        // specify mapping of relationship to address
-        def withAddress = q.join(addresses).on(_.addressId === _.id)
-      }
-      //#slickRelationships
-      ;{
-      //#slickRelationships
-      
-      val chrisQuery = people.filter(_.id === 2)
-      val stefanQuery = people.filter(_.id === 3)
-
-      val chrisWithAddress: Future[(Person, Address)] =
-        db.run(chrisQuery.withAddress.result.head)
-      val stefanWithAddress: Future[(Person, Address)] =
-        db.run(stefanQuery.withAddress.result.head)
-      //#slickRelationships
-      Await.result(chrisWithAddress, Duration.Inf)
-      Await.result(stefanWithAddress, Duration.Inf)
-      }
-      {
-        //#relationshipNavigation
-        val chris: Person = PeopleFinder.getById(2)
-        val address: Address = chris.address
-        //#relationshipNavigation
-      }
-
-      /*
-      //#relationshipNavigation2
-      case class Address( … )
-      case class Person( …, address: Address )
-      //#relationshipNavigation2
-      */
-
-      {
-        //#slickRelationships2
-        val chrisQuery: Query[People,Person,Seq] = people.filter(_.id === 2)
-        val addressQuery: Query[Addresses,Address,Seq] = chrisQuery.withAddress.map(_._2)
-        val address = db.run(addressQuery.result.head)
-        //#slickRelationships2
-        Await.result(address, Duration.Inf)
+        )
+        //#slickQueryWithTypes
       };{
-        import scala.concurrent.ExecutionContext.Implicits.global
-        //#associationTuple
-        val tupledJoin: Query[(People,Addresses),(Person,Address), Seq]
-              = people join addresses on (_.addressId === _.id)
+        //#slickForComprehension
+        for( p <- people if p.age < 5 || p.age > 65 ) yield p
+        //#slickForComprehension
+      };{
+        //#slickOrderBy
+        ( for( p <- people if p.age < 5 || p.age > 65 ) yield p ).sortBy(_.name)
+        //#slickOrderBy
+      };{
+        //#slickMap
+        people.map(p => (p.name, p.age))
+        //#slickMap
+      };{
+        //#ormGetById
+        PeopleFinder.getById(5)
+        //#ormGetById
+      };{
+        Await.result(
+          //#slickRun
+          db.run(people.filter(_.id === 5).result)
+            //#slickRun
+            , Duration.Inf)
+      };{
+        //#ormWriteCaching
+        val person = PeopleFinder.getById(5)
+        //#ormWriteCaching
+      };{
+        object person {
+          var name: String = ""
+          var age: Int = 0
+        }
+        //#ormWriteCaching
+        person.name = "C. Vogt"
+        person.age = 12345
+        session.save
+        //#ormWriteCaching
+      };{
+        //#slickUpdate
+        val personQuery = people.filter(_.id === 5)
+        personQuery.map(p => (p.name,p.age)).update("C. Vogt", 12345)
+        //#slickUpdate
 
-        case class PersonWithAddress(person: Person, address: Address)
-        val caseClassJoinResults = db.run(tupledJoin.result).map(_.map((PersonWithAddress.apply _).tupled))
-        //#associationTuple
+        //#slickDelete
+        personQuery.delete // deletes person with id 5
+                           //#slickDelete
+      };{
+        //#slickInsert
+        people.map(p => (p.name,p.age)) += ("S. Zeiger", 54321)
+        //#slickInsert
+      };{
+        //#slickRelationships
+        implicit class PersonExtensions[C[_]](q: Query[People, Person, C]) {
+          // specify mapping of relationship to address
+          def withAddress = q.join(addresses).on(_.addressId === _.id)
+        }
+        //#slickRelationships
+        ;{
+          //#slickRelationships
+          
+          val chrisQuery = people.filter(_.id === 2)
+          val stefanQuery = people.filter(_.id === 3)
+
+          val chrisWithAddress: Future[(Person, Address)] =
+            db.run(chrisQuery.withAddress.result.head)
+          val stefanWithAddress: Future[(Person, Address)] =
+            db.run(stefanQuery.withAddress.result.head)
+          //#slickRelationships
+          Await.result(chrisWithAddress, Duration.Inf)
+          Await.result(stefanWithAddress, Duration.Inf)
+        }
+        {
+          //#relationshipNavigation
+          val chris: Person = PeopleFinder.getById(2)
+          val address: Address = chris.address
+          //#relationshipNavigation
+        }
+
+        /*
+         //#relationshipNavigation2
+         case class Address( … )
+         case class Person( …, address: Address )
+         //#relationshipNavigation2
+         */
+
+        {
+          //#slickRelationships2
+          val chrisQuery: Query[People,Person,Seq] = people.filter(_.id === 2)
+          val addressQuery: Query[Addresses,Address,Seq] = chrisQuery.withAddress.map(_._2)
+          val address = db.run(addressQuery.result.head)
+          //#slickRelationships2
+          Await.result(address, Duration.Inf)
+        };{
+          import scala.concurrent.ExecutionContext.Implicits.global
+          //#associationTuple
+          val tupledJoin: Query[(People,Addresses),(Person,Address), Seq]
+          = people join addresses on (_.addressId === _.id)
+
+          case class PersonWithAddress(person: Person, address: Address)
+          val caseClassJoinResults = db.run(tupledJoin.result).map(_.map((PersonWithAddress.apply _).tupled))
+          //#associationTuple
+        }
       }
-    }
-  } finally db.close
+    } finally db.close
+  }
 }

--- a/doc/code/SqlToSlick.scala
+++ b/doc/code/SqlToSlick.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.Duration
 import slick.jdbc.H2Profile.api._
 
 
-object SqlToSlick extends App {
+object SqlToSlick {
 
   object Tables{
     //#tableClasses
@@ -40,290 +40,291 @@ object SqlToSlick extends App {
     people += (0,"J. Doe",18,2)
   )
 
-  val db = Database.forConfig("h2mem1")
-  try {
+  def main(args: Array[String]): Unit = {
+    val db = Database.forConfig("h2mem1")
+    try {
 
-    Await.result(db.run(DBIO.seq(
-      addresses.schema.create,
-      people.schema.create,
-      inserts
-    )), Duration.Inf)
+      Await.result(db.run(DBIO.seq(
+                            addresses.schema.create,
+                            people.schema.create,
+                            inserts
+                          )), Duration.Inf)
 
-    def _jdbc = {
-      //#jdbc
-      import java.sql._
+      def _jdbc = {
+        //#jdbc
+        import java.sql._
 
-      Class.forName("org.h2.Driver")
-      val conn = DriverManager.getConnection("jdbc:h2:mem:test1")
-      val people = new scala.collection.mutable.ListBuffer[(Int,String,Int)]()
-      try{
-        val stmt = conn.createStatement()
+        Class.forName("org.h2.Driver")
+        val conn = DriverManager.getConnection("jdbc:h2:mem:test1")
+        val people = new scala.collection.mutable.ListBuffer[(Int,String,Int)]()
         try{
-
-          val rs = stmt.executeQuery("select ID, NAME, AGE from PERSON")
+          val stmt = conn.createStatement()
           try{
-            while(rs.next()){
-              people += ((rs.getInt(1), rs.getString(2), rs.getInt(3)))
+
+            val rs = stmt.executeQuery("select ID, NAME, AGE from PERSON")
+            try{
+              while(rs.next()){
+                people += ((rs.getInt(1), rs.getString(2), rs.getInt(3)))
+              }
+            }finally{
+              rs.close()
             }
+
           }finally{
-            rs.close()
+            stmt.close()
           }
-
         }finally{
-          stmt.close()
+          conn.close()
         }
-      }finally{
-        conn.close()
+        //#jdbc
+        people
       }
-      //#jdbc
-      people
-    }
-    val slickPlainSql = {
-      //#SlickPlainSQL
-      import slick.jdbc.H2Profile.api._
+      val slickPlainSql = {
+        //#SlickPlainSQL
+        import slick.jdbc.H2Profile.api._
 
-      //#SlickPlainSQL
-      /*
-      //#SlickPlainSQL
-      val db = Database.forConfig("h2mem1")
-      //#SlickPlainSQL
-      */
-      //#SlickPlainSQL
+        //#SlickPlainSQL
+        /*
+         //#SlickPlainSQL
+         val db = Database.forConfig("h2mem1")
+         //#SlickPlainSQL
+         */
+        //#SlickPlainSQL
 
-      val action = sql"select ID, NAME, AGE from PERSON".as[(Int,String,Int)]
-      db.run(action)
-      //#SlickPlainSQL
-    }
-    val slickTypesafeQuery = {
-      //#SlickTypesafeQuery
-      import slick.jdbc.H2Profile.api._
-
-      //#SlickTypesafeQuery
-      /*
-      //#SlickTypesafeQuery
-      val db = Database.forConfig("h2mem1")
-      //#SlickTypesafeQuery
-      */
-      //#SlickTypesafeQuery
-
-      val query = people.map(p => (p.id,p.name,p.age))
-      db.run(query.result)
-      //#SlickTypesafeQuery
-    }
-    val tRes = Await.result(slickTypesafeQuery, Duration.Inf)
-    val pRes = Await.result(slickPlainSql, Duration.Inf)
-    assert(tRes == pRes)
-    assert(pRes.size > 0)
-
-    ;{
-      import slick.jdbc.H2Profile.api._
-
-      //#slickFunction
-      implicit class MyStringColumnExtensions(i: Rep[Int]){
-        def squared = i * i
+        val action = sql"select ID, NAME, AGE from PERSON".as[(Int,String,Int)]
+        db.run(action)
+        //#SlickPlainSQL
       }
-      //#slickFunction
-      val squared =
-      //#slickFunction
+      val slickTypesafeQuery = {
+        //#SlickTypesafeQuery
+        import slick.jdbc.H2Profile.api._
 
-      // usage:
-      people.map(p => p.age.squared)
-      //#slickFunction
-      //#dbFunction
-      val power = SimpleFunction.binary[Int,Int,Int]("POWER")
-      //#dbFunction
-      val pow =
-      //#dbFunction
+        //#SlickTypesafeQuery
+        /*
+         //#SlickTypesafeQuery
+         val db = Database.forConfig("h2mem1")
+         //#SlickTypesafeQuery
+         */
+        //#SlickTypesafeQuery
 
-      // usage:
-      people.map(p => power(p.age,2))
-      //#dbFunction
-
-      val (sRes, pRes) = Await.result(db.run(squared.to[Set].result.zip(pow.to[Set].result)), Duration.Inf)
-      assert(sRes == pRes)
-      assert(Set(998001,1002001) subsetOf pRes)
-    }
-    ;{
-      //#overrideSql
-      people.map(p => (p.id,p.name,p.age))
-            .result
-            // inject hand-written SQL, see https://gist.github.com/cvogt/d9049c63fc395654c4b4
-      //#overrideSql
-      /*
-      //#overrideSql
-            .overrideSql("SELECT id, name, age FROM Person")
-      //#overrideSql
-      */
+        val query = people.map(p => (p.id,p.name,p.age))
+        db.run(query.result)
+        //#SlickTypesafeQuery
+      }
+      val tRes = Await.result(slickTypesafeQuery, Duration.Inf)
+      val pRes = Await.result(slickPlainSql, Duration.Inf)
+      assert(tRes == pRes)
+      assert(pRes.size > 0)
 
       ;{
-        val sql =
-          //#sqlQueryProjectionWildcard
-          sql"select * from PERSON".as[Person]
-          //#sqlQueryProjectionWildcard
-        val slick =
-          //#slickQueryProjectionWildcard
-          people.result
-          //#slickQueryProjectionWildcard
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
-          //#sqlQueryProjection
-          sql"""
+        import slick.jdbc.H2Profile.api._
+
+        //#slickFunction
+        implicit class MyStringColumnExtensions(i: Rep[Int]){
+          def squared = i * i
+        }
+        //#slickFunction
+        val squared =
+          //#slickFunction
+
+        // usage:
+        people.map(p => p.age.squared)
+        //#slickFunction
+        //#dbFunction
+        val power = SimpleFunction.binary[Int,Int,Int]("POWER")
+        //#dbFunction
+        val pow =
+          //#dbFunction
+
+        // usage:
+        people.map(p => power(p.age,2))
+        //#dbFunction
+
+        val (sRes, pRes) = Await.result(db.run(squared.to[Set].result.zip(pow.to[Set].result)), Duration.Inf)
+        assert(sRes == pRes)
+        assert(Set(998001,1002001) subsetOf pRes)
+      }
+      ;{
+        //#overrideSql
+        people.map(p => (p.id,p.name,p.age))
+          .result
+        // inject hand-written SQL, see https://gist.github.com/cvogt/d9049c63fc395654c4b4
+        //#overrideSql
+        /*
+         //#overrideSql
+         .overrideSql("SELECT id, name, age FROM Person")
+         //#overrideSql
+         */
+
+        ;{
+            val sql =
+              //#sqlQueryProjectionWildcard
+              sql"select * from PERSON".as[Person]
+            //#sqlQueryProjectionWildcard
+            val slick =
+              //#slickQueryProjectionWildcard
+              people.result
+            //#slickQueryProjectionWildcard
+            val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+            assert(sqlRes == slickRes)
+            assert(sqlRes.size > 0)
+          };{
+          val sql =
+            //#sqlQueryProjection
+            sql"""
             select AGE, concat(concat(concat(NAME,' ('),ID),')')
             from PERSON
           """.as[(Int,String)]
           //#sqlQueryProjection
-        val slick =
+          val slick =
+            //#slickQueryProjection
+            people.map(p => (p.age, p.name ++ " (" ++ p.id.asColumnOf[String] ++ ")")).result
           //#slickQueryProjection
-          people.map(p => (p.age, p.name ++ " (" ++ p.id.asColumnOf[String] ++ ")")).result
-          //#slickQueryProjection
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryFilter
+            sql"select * from PERSON where AGE >= 18 AND NAME = 'C. Vogt'".as[Person]
           //#sqlQueryFilter
-          sql"select * from PERSON where AGE >= 18 AND NAME = 'C. Vogt'".as[Person]
-          //#sqlQueryFilter
-        val slick =
+          val slick =
+            //#slickQueryFilter
+            people.filter(p => p.age >= 18 && p.name === "C. Vogt").result
           //#slickQueryFilter
-          people.filter(p => p.age >= 18 && p.name === "C. Vogt").result
-          //#slickQueryFilter
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryOrderBy
+            sql"select * from PERSON order by AGE asc, NAME".as[Person]
           //#sqlQueryOrderBy
-          sql"select * from PERSON order by AGE asc, NAME".as[Person]
-          //#sqlQueryOrderBy
-        val slick =
+          val slick =
+            //#slickQueryOrderBy
+            people.sortBy(p => (p.age.asc, p.name)).result
           //#slickQueryOrderBy
-          people.sortBy(p => (p.age.asc, p.name)).result
-          //#slickQueryOrderBy
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryAggregate
+            sql"select max(AGE) from PERSON".as[Option[Int]].head
           //#sqlQueryAggregate
-          sql"select max(AGE) from PERSON".as[Option[Int]].head
-          //#sqlQueryAggregate
-        val slick =
+          val slick =
+            //#slickQueryAggregate
+            people.map(_.age).max.result
           //#slickQueryAggregate
-          people.map(_.age).max.result
-          //#slickQueryAggregate
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-      };{
-        val sql =
-          //#sqlQueryGroupBy
-          sql"""
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+        };{
+          val sql =
+            //#sqlQueryGroupBy
+            sql"""
             select ADDRESS_ID, AVG(AGE)
             from PERSON
             group by ADDRESS_ID
           """.as[(Int,Option[Double])]
           //#sqlQueryGroupBy
-        val slick =
+          val slick =
+            //#slickQueryGroupBy
+            people.groupBy(p => p.addressId)
+              .map{ case (addressId, group) => (addressId, group.map(_.age).avg) }
+              .result
           //#slickQueryGroupBy
-          people.groupBy(p => p.addressId)
-                 .map{ case (addressId, group) => (addressId, group.map(_.age).avg) }
-                 .result
-          //#slickQueryGroupBy
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-        assert(sqlRes.exists(_._2 == Some(1000.0)))
-      };{
-        val sql =
-          //#sqlQueryHaving
-          sql"""
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+          assert(sqlRes.exists(_._2 == Some(1000.0)))
+        };{
+          val sql =
+            //#sqlQueryHaving
+            sql"""
             select ADDRESS_ID
             from PERSON
             group by ADDRESS_ID
             having avg(AGE) > 50
           """.as[Int]
           //#sqlQueryHaving
-        val slick =
+          val slick =
+            //#slickQueryHaving
+            people.groupBy(p => p.addressId)
+              .map{ case (addressId, group) => (addressId, group.map(_.age).avg) }
+              .filter{ case (addressId, avgAge) => avgAge > 50.0 }
+              .map(_._1)
+              .result
           //#slickQueryHaving
-          people.groupBy(p => p.addressId)
-                 .map{ case (addressId, group) => (addressId, group.map(_.age).avg) }
-                 .filter{ case (addressId, avgAge) => avgAge > 50.0 }
-                 .map(_._1)
-                 .result
-          //#slickQueryHaving
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
-          //#sqlQueryImplicitJoin
-          sql"""
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryImplicitJoin
+            sql"""
             select P.NAME, A.CITY
             from PERSON P, ADDRESS A
             where P.ADDRESS_ID = a.id
           """.as[(String,String)]
           //#sqlQueryImplicitJoin
-        val slick =
-          //#slickQueryImplicitJoin
-          people.flatMap(p =>
-            addresses.filter(a => p.addressId === a.id)
-                     .map(a => (p.name, a.city))
-          ).result
+          val slick =
+            //#slickQueryImplicitJoin
+            people.flatMap(p =>
+              addresses.filter(a => p.addressId === a.id)
+                .map(a => (p.name, a.city))
+            ).result
 
           //#slickQueryImplicitJoin
-        val slick2 =
+          val slick2 =
+            //#slickQueryImplicitJoin
+            // or equivalent for-expression:
+            (for(p <- people;
+                 a <- addresses if p.addressId === a.id
+             ) yield (p.name, a.city)
+            ).result
           //#slickQueryImplicitJoin
-          // or equivalent for-expression:
-          (for(p <- people;
-               a <- addresses if p.addressId === a.id
-           ) yield (p.name, a.city)
-          ).result
-          //#slickQueryImplicitJoin
-        val ((sqlRes, slickRes), slick2Res) = Await.result(db.run(sql zip slick zip slick2), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(slickRes == slick2Res)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
-          //#sqlQueryExplicitJoin
-          sql"""
+          val ((sqlRes, slickRes), slick2Res) = Await.result(db.run(sql zip slick zip slick2), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(slickRes == slick2Res)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryExplicitJoin
+            sql"""
             select P.NAME, A.CITY
             from PERSON P
             join ADDRESS A on P.ADDRESS_ID = a.id
           """.as[(String,String)]
           //#sqlQueryExplicitJoin
-        val slick =
+          val slick =
+            //#slickQueryExplicitJoin
+            (people join addresses on (_.addressId === _.id))
+              .map{ case (p, a) => (p.name, a.city) }.result
           //#slickQueryExplicitJoin
-          (people join addresses on (_.addressId === _.id))
-            .map{ case (p, a) => (p.name, a.city) }.result
-          //#slickQueryExplicitJoin
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
-          //#sqlQueryLeftJoin
-          sql"""
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryLeftJoin
+            sql"""
             select P.NAME,A.CITY
             from ADDRESS A
             left join PERSON P on P.ADDRESS_ID = a.id
           """.as[(Option[String],String)]
           //#sqlQueryLeftJoin
-        val slick =
+          val slick =
+            //#slickQueryLeftJoin
+            (addresses joinLeft people on (_.id === _.addressId))
+              .map{ case (a, p) => (p.map(_.name), a.city) }.result
           //#slickQueryLeftJoin
-          (addresses joinLeft people on (_.id === _.addressId))
-            .map{ case (a, p) => (p.map(_.name), a.city) }.result
-          //#slickQueryLeftJoin
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
-          //#sqlQueryCollectionSubQuery
-          sql"""
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQueryCollectionSubQuery
+            sql"""
             select *
             from PERSON P
             where P.ID in (select ID
@@ -331,39 +332,39 @@ object SqlToSlick extends App {
                            where CITY = 'New York City')
           """.as[Person]
           //#sqlQueryCollectionSubQuery
-        val slick = {
-          //#slickQueryCollectionSubQuery
-          val address_ids = addresses.filter(_.city === "New York City").map(_.id)
-          people.filter(_.id in address_ids).result // <- run as one query
-          //#slickQueryCollectionSubQuery
-        }
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql = {
-          //#sqlQueryInSet
-          val (i1,i2) = (1,2)
-          sql"""
+          val slick = {
+            //#slickQueryCollectionSubQuery
+            val address_ids = addresses.filter(_.city === "New York City").map(_.id)
+            people.filter(_.id in address_ids).result // <- run as one query
+                                                      //#slickQueryCollectionSubQuery
+          }
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql = {
+            //#sqlQueryInSet
+            val (i1,i2) = (1,2)
+            sql"""
             select *
             from PERSON P
             where P.ID in ($i1,$i2)
           """.as[Person]
-          //#sqlQueryInSet
-        }
-        val slick = {
-          //#slickQueryInSet
-          people.filter(_.id inSet Set(1,2))
-                 .result
-          //#slickQueryInSet
-        }
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
-        assert(sqlRes.size > 0)
-      };{
-        val sql =
-          //#sqlQuerySemiRandomChoose
-          sql"""
+            //#sqlQueryInSet
+          }
+          val slick = {
+            //#slickQueryInSet
+            people.filter(_.id inSet Set(1,2))
+              .result
+            //#slickQueryInSet
+          }
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+          assert(sqlRes.size > 0)
+        };{
+          val sql =
+            //#sqlQuerySemiRandomChoose
+            sql"""
             select * from PERSON P,
                                (select rand() * MAX(ID) as ID from PERSON) RAND_ID
             where P.ID >= RAND_ID.ID
@@ -371,67 +372,67 @@ object SqlToSlick extends App {
             limit 1
           """.as[Person].head
           //#sqlQuerySemiRandomChoose
-        val slick = {
-          //#slickQuerySemiRandomChoose
-          val rand = SimpleFunction.nullary[Double]("RAND")
+          val slick = {
+            //#slickQuerySemiRandomChoose
+            val rand = SimpleFunction.nullary[Double]("RAND")
 
-          val rndId = (people.map(_.id).max.asColumnOf[Double] * rand).asColumnOf[Int]
+            val rndId = (people.map(_.id).max.asColumnOf[Double] * rand).asColumnOf[Int]
 
-          people.filter(_.id >= rndId)
-                 .sortBy(_.id)
-                 .result.head
-          //#slickQuerySemiRandomChoose
-        }
-      };{
-        val sqlInsert =
-          //#sqlQueryInsert
-          sqlu"""
+            people.filter(_.id >= rndId)
+              .sortBy(_.id)
+              .result.head
+            //#slickQuerySemiRandomChoose
+          }
+        };{
+          val sqlInsert =
+            //#sqlQueryInsert
+            sqlu"""
             insert into PERSON (NAME, AGE, ADDRESS_ID) values ('M Odersky', 12345, 1)
           """
           //#sqlQueryInsert
-        val sqlUpdate =
-          //#sqlQueryUpdate
-          sqlu"""
+          val sqlUpdate =
+            //#sqlQueryUpdate
+            sqlu"""
             update PERSON set NAME='M. Odersky', AGE=54321 where NAME='M Odersky'
           """
           //#sqlQueryUpdate
-        val sqlDelete =
-          //#sqlQueryDelete
-          sqlu"""
+          val sqlDelete =
+            //#sqlQueryDelete
+            sqlu"""
             delete PERSON where NAME='M. Odersky'
           """
           //#sqlQueryDelete
 
-        val slickInsert = {
-          //#slickQueryInsert
-          people.map(p => (p.name, p.age, p.addressId)) += ("M Odersky",12345,1)
-          //#slickQueryInsert
-        }
-        val slickUpdate = {
-          //#slickQueryUpdate
-          people.filter(_.name === "M Odersky")
-                 .map(p => (p.name,p.age))
-                 .update(("M. Odersky",54321))
-          //#slickQueryUpdate
-        }
-        val slickDelete = {
-          //#slickQueryDelete
-          people.filter(p => p.name === "M. Odersky")
-                 .delete
-          //#slickQueryDelete
-        }
-        val (sqlInsertRes, slickInsertRes) = Await.result(db.run(sqlInsert zip slickInsert), Duration.Inf)
-        assert(sqlInsertRes == slickInsertRes)
-        val (sqlUpdateRes, slickUpdateRes) = Await.result(db.run(sqlUpdate zip slickUpdate), Duration.Inf)
-        assert(sqlUpdateRes == 2)
-        assert(slickUpdateRes == 0)
-        val (sqlDeleteRes, slickDeleteRes) = Await.result(db.run(sqlDelete zip slickDelete), Duration.Inf)
-        assert(sqlDeleteRes == 2)
-        assert(slickDeleteRes == 0)
-      };{
-        val sql =
-          //#sqlCase
-          sql"""
+          val slickInsert = {
+            //#slickQueryInsert
+            people.map(p => (p.name, p.age, p.addressId)) += ("M Odersky",12345,1)
+            //#slickQueryInsert
+          }
+          val slickUpdate = {
+            //#slickQueryUpdate
+            people.filter(_.name === "M Odersky")
+              .map(p => (p.name,p.age))
+              .update(("M. Odersky",54321))
+            //#slickQueryUpdate
+          }
+          val slickDelete = {
+            //#slickQueryDelete
+            people.filter(p => p.name === "M. Odersky")
+              .delete
+            //#slickQueryDelete
+          }
+          val (sqlInsertRes, slickInsertRes) = Await.result(db.run(sqlInsert zip slickInsert), Duration.Inf)
+          assert(sqlInsertRes == slickInsertRes)
+          val (sqlUpdateRes, slickUpdateRes) = Await.result(db.run(sqlUpdate zip slickUpdate), Duration.Inf)
+          assert(sqlUpdateRes == 2)
+          assert(slickUpdateRes == 0)
+          val (sqlDeleteRes, slickDeleteRes) = Await.result(db.run(sqlDelete zip slickDelete), Duration.Inf)
+          assert(sqlDeleteRes == 2)
+          assert(slickDeleteRes == 0)
+        };{
+          val sql =
+            //#sqlCase
+            sql"""
             select
               case
                 when ADDRESS_ID = 1 then 'A'
@@ -440,17 +441,18 @@ object SqlToSlick extends App {
             from PERSON P
           """.as[Option[String]]
           //#sqlCase
-        val slick =
+          val slick =
+            //#slickCase
+            people.map(p =>
+              Case
+                  If(p.addressId === 1) Then "A"
+                  If(p.addressId === 2) Then "B"
+            ).result
           //#slickCase
-          people.map(p =>
-            Case
-              If(p.addressId === 1) Then "A"
-              If(p.addressId === 2) Then "B"
-          ).result
-          //#slickCase
-        val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
-        assert(sqlRes == slickRes)
+          val (sqlRes, slickRes) = Await.result(db.run(sql zip slick), Duration.Inf)
+          assert(sqlRes == slickRes)
+        }
       }
-    }
-  } finally db.close
+    } finally db.close
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt.Keys.scalaVersion
 object Dependencies {
   val scala212 = "2.12.21"
   val scala213 = "2.13.18"
-  val scala3 = "3.3.7"
+  val scala3 = "3.8.3"
 
   val scalaVersions = Seq(scala212, scala213, scala3) // When updating these also update ci.yml and .mergify.yml
 

--- a/project/ReusableSbtChecker.scala
+++ b/project/ReusableSbtChecker.scala
@@ -29,8 +29,6 @@ class ReusableSbtChecker(val scaladocDir: String,
     if (!new File(scaladocDir).exists())
       throw new MessageOnlyException("sdlcDocDir '" + scaladocDir + "' does not exist")
 
-    detect212()
-
     buildModel()
     scanPages()
 

--- a/slick-compat-collections/src/main/scala-2.12/slick/compat/collection/package.scala
+++ b/slick-compat-collections/src/main/scala-2.12/slick/compat/collection/package.scala
@@ -21,6 +21,9 @@ import scala.runtime.Tuple2Zipped
 package object collection {
   import CompatImpl.*
 
+  private[slick] def numericSign[T](numeric: Numeric[T], value: T): Int =
+    numeric.signum(value)
+
   /**
    * A factory that builds a collection of type `C` with elements of type `A`.
    *

--- a/slick-compat-collections/src/main/scala-2.13+/slick/compat/collection/collection.scala
+++ b/slick-compat-collections/src/main/scala-2.13+/slick/compat/collection/collection.scala
@@ -8,6 +8,9 @@ package object collection {
   private[slick] type Factory[-A, +C] = scala.collection.Factory[A, C]
   private[slick] val Factory = scala.collection.Factory
 
+  private[slick] def numericSign[T](numeric: Numeric[T], value: T): Int =
+    numeric.toInt(numeric.sign(value))
+
   private[slick] type LazyList[+T] = scala.collection.immutable.LazyList[T]
   private[slick] val LazyList = scala.collection.immutable.LazyList
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -337,19 +337,19 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
   def testProductClassShape = {
     def columnShape[T](implicit s: Shape[FlatShapeLevel, Rep[T], T, Rep[T]]) = s
     class C(val a: Int, val b: Option[String]) extends Product{
-      def canEqual(that: Any): Boolean = that.isInstanceOf[C]
+      def canEqual(that: Any): Boolean = (that: @unchecked).isInstanceOf[C]
       def productArity: Int = 2
       def productElement(n: Int): Any = Seq(a, b)(n)
-      override def equals(a: Any) = a match {
+      override def equals(a: Any) = (a: @unchecked) match {
         case that: C => this.a == that.a && this.b == that.b
         case _ => false
       }
     }
     class LiftedC(val a: Rep[Int], val b: Rep[Option[String]]) extends Product{
-      def canEqual(that: Any): Boolean = that.isInstanceOf[LiftedC]
+      def canEqual(that: Any): Boolean = (that: @unchecked).isInstanceOf[LiftedC]
       def productArity: Int = 2
       def productElement(n: Int): Any = Seq(a, b)(n)
-      override def equals(a: Any) = a match {
+      override def equals(a: Any) = (a: @unchecked) match {
         case that: LiftedC => this.a == that.a && this.b == that.b
         case _ => false
       }

--- a/slick-testkit/src/test/scala/slick/benchmark/MemBarrierBench.scala
+++ b/slick-testkit/src/test/scala/slick/benchmark/MemBarrierBench.scala
@@ -2,7 +2,7 @@ package slick.benchmark
 
 import java.util.concurrent.atomic.AtomicLong
 
-object MemBarrierBench extends App {
+object MemBarrierBench {
 
   trait Subscr[T] {
     def onNext(v: T): Unit

--- a/slick-testkit/src/test/scala/slick/benchmark/StreamsStressTest.scala
+++ b/slick-testkit/src/test/scala/slick/benchmark/StreamsStressTest.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.reactivestreams.tck.TestEnvironment
 
-object StreamsStressTest extends App {
+object StreamsStressTest {
   /*import slick.jdbc.DerbyProfile.api._
   val url = "jdbc:derby:memory:StreamsStressTest;create=true"
   val driver = "org.apache.derby.jdbc.EmbeddedDriver"*/
@@ -17,40 +17,42 @@ object StreamsStressTest extends App {
 
   val env = new TestEnvironment(30000)
   val entityNum = new AtomicInteger()
-  val db = Database.forURL(url, driver = driver, keepAliveConnection = true)
-  try {
-    val threads = 1.to(numThreads).toVector.map { i =>
-      new Thread(new Runnable {
-        def run(): Unit = {
-          try {
-            for(j <- 1 to repeats) {
-              run1
-              if(j % 100 == 0) println(s"Thread $i: Stream $j successful")
-            }
-          } catch { case t: Throwable => env.flop(t, t.toString) }
-        }
-      })
-    }
-    threads.foreach(_.start())
-    threads.foreach(_.join())
-    println("All threads finished")
-    env.verifyNoAsyncErrors()
-  } finally db.close
+  def main(args: Array[String]): Unit = {
+    val db = Database.forURL(url, driver = driver, keepAliveConnection = true)
+    try {
+      val threads = 1.to(numThreads).toVector.map { i =>
+        new Thread(new Runnable {
+                     def run(): Unit = {
+                       try {
+                         for(j <- 1 to repeats) {
+                           run1
+                           if(j % 100 == 0) println(s"Thread $i: Stream $j successful")
+                         }
+                       } catch { case t: Throwable => env.flop(t, t.toString) }
+                     }
+                   })
+      }
+      threads.foreach(_.start())
+      threads.foreach(_.join())
+      println("All threads finished")
+      env.verifyNoAsyncErrors()
+    } finally db.close
 
-  def run1: Unit = {
-    val sub = env.newManualSubscriber(createPublisher(1L))
-    sub.requestNextElementOrEndOfStream("Timeout while waiting for next element from Publisher")
-    sub.requestEndOfStream()
-  }
-
-  def createPublisher(elements: Long) = {
-    val tableName = "data_" + elements + "_" + entityNum.incrementAndGet()
-    class Data(tag: Tag) extends Table[Int](tag, tableName) {
-      def id = column[Int]("id")
-      def * = id
+    def run1: Unit = {
+      val sub = env.newManualSubscriber(createPublisher(1L))
+      sub.requestNextElementOrEndOfStream("Timeout while waiting for next element from Publisher")
+      sub.requestEndOfStream()
     }
-    val data = TableQuery[Data]
-    val a = data.schema.create >> (data ++= Range.apply(0, elements.toInt)) >> data.sortBy(_.id).map(_.id).result
-    db.stream(a.withPinnedSession)
+
+    def createPublisher(elements: Long) = {
+      val tableName = "data_" + elements + "_" + entityNum.incrementAndGet()
+      class Data(tag: Tag) extends Table[Int](tag, tableName) {
+        def id = column[Int]("id")
+        def * = id
+      }
+      val data = TableQuery[Data]
+      val a = data.schema.create >> (data ++= Range.apply(0, elements.toInt)) >> data.sortBy(_.id).map(_.id).result
+      db.stream(a.withPinnedSession)
+    }
   }
 }

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -6,8 +6,8 @@ import scala.language.implicitConversions
 import scala.reflect.{ClassTag, classTag as mkClassTag}
 
 import slick.SlickException
-import slick.util.{ConstArray, Dumpable, DumpInfo, TupleSupport}
 import slick.compat.collection.*
+import slick.util.{ConstArray, Dumpable, DumpInfo, TupleSupport}
 
 /** Super-trait for all types */
 trait Type extends Dumpable {

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -8,9 +8,9 @@ import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 import slick.SlickException
+import slick.compat.collection.*
 import slick.dbio.*
 import slick.util.*
-import slick.compat.collection.*
 import slick.util.AsyncExecutor.{Continuation, Fresh, Priority, WithConnection}
 
 import com.typesafe.config.Config

--- a/slick/src/main/scala/slick/dbio/DBIOAction.scala
+++ b/slick/src/main/scala/slick/dbio/DBIOAction.scala
@@ -8,8 +8,8 @@ import scala.util.control.NonFatal
 
 import slick.SlickException
 import slick.basic.BasicBackend
-import slick.util.{ignoreFollowOnError, Dumpable, DumpInfo}
 import slick.compat.collection.*
+import slick.util.{ignoreFollowOnError, Dumpable, DumpInfo}
 
 import org.reactivestreams.Subscription
 

--- a/slick/src/main/scala/slick/jdbc/Invoker.scala
+++ b/slick/src/main/scala/slick/jdbc/Invoker.scala
@@ -2,8 +2,8 @@ package slick.jdbc
 
 import scala.annotation.unchecked.uncheckedVariance
 
-import slick.util.CloseableIterator
 import slick.compat.collection.*
+import slick.util.CloseableIterator
 
 /** Base trait for all statement invokers of result element type R. */
 trait Invoker[+R] { self =>

--- a/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcActionComponent.scala
@@ -5,6 +5,7 @@ import java.sql.{PreparedStatement, ResultSet, Statement}
 import scala.collection.mutable.Builder
 import scala.language.existentials
 import scala.util.control.NonFatal
+
 import slick.SlickException
 import slick.ast.*
 import slick.ast.ColumnOption.PrimaryKey
@@ -14,8 +15,8 @@ import slick.dbio.*
 import slick.lifted.{CompiledStreamingExecutable, FlatShapeLevel, Query, Shape}
 import slick.relational.{CompiledMapping, ResultConverter}
 import slick.sql.{FixedSqlAction, FixedSqlStreamingAction, SqlActionComponent}
-import slick.util.{ignoreFollowOnError, DumpInfo, SQLBuilder}
 import slick.compat.collection.*
+import slick.util.{ignoreFollowOnError, DumpInfo, SQLBuilder}
 
 
 trait JdbcActionComponent extends SqlActionComponent { self: JdbcProfile =>

--- a/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcModelBuilder.scala
@@ -217,7 +217,7 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
     def default: Option[Option[Any]] = rawDefault.map { v =>
       if(v == "NULL") None else {
         // NOTE: When extending this list, please also extend the code generator accordingly
-        Some((v,tpe) match {
+        Some(((v,tpe): @unchecked) match {
           case (v,"Byte")   => v.toByte
           case (v,"Short")  => v.toShort
           case (v,"Int")    => v.toInt
@@ -234,6 +234,8 @@ class JdbcModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)(imp
           case (StringPattern(str),"String") => str
           case ("TRUE","Boolean")  => true
           case ("FALSE","Boolean") => false
+          // Intentionally non-exhaustive: unrecognised (value, type) pairs throw MatchError,
+          // which is caught and logged when ignoreInvalidDefaults = true.
         })
       }
     }

--- a/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
+++ b/slick/src/main/scala/slick/jdbc/LoggingStatement.scala
@@ -8,8 +8,8 @@ import java.util.Calendar
 
 import scala.collection.mutable.ArrayBuffer
 
-import slick.jdbc.JdbcBackend.{benchmarkLogger, parameterLogger, statementAndParameterLogger, statementLogger}
 import slick.compat.collection.*
+import slick.jdbc.JdbcBackend.{benchmarkLogger, parameterLogger, statementAndParameterLogger, statementLogger}
 import slick.util.TableDump
 
 /** A wrapper for `java.sql.Statement` that logs statements and benchmark results

--- a/slick/src/main/scala/slick/jdbc/StaticQuery.scala
+++ b/slick/src/main/scala/slick/jdbc/StaticQuery.scala
@@ -5,9 +5,9 @@ import java.sql.PreparedStatement
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
+import slick.compat.collection.*
 import slick.dbio.Effect
 import slick.sql.SqlStreamingAction
-import slick.compat.collection.*
 
 class ActionBasedSQLInterpolation(val s: StringContext) extends AnyVal {
   /** Build a SQLActionBuilder via string interpolation */

--- a/slick/src/main/scala/slick/lifted/AbstractTable.scala
+++ b/slick/src/main/scala/slick/lifted/AbstractTable.scala
@@ -95,7 +95,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     m <- getClass.getMethods.iterator
     if m.getParameterTypes.length == 0 && classOf[Constraint].isAssignableFrom(m.getReturnType)
     q = {
-      if(!m.isAccessible) m.setAccessible(true) // Dotty makes classes nested within in methods private
+      m.trySetAccessible() // Dotty makes classes nested within in methods private
       m.invoke(this).asInstanceOf[Constraint]
     }
   } yield q
@@ -114,7 +114,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
     m <- getClass.getMethods.iterator
     if m.getReturnType == classOf[Index] && m.getParameterTypes.length == 0
   } yield {
-    if(!m.isAccessible) m.setAccessible(true) // Dotty makes classes nested within in methods private
+    m.trySetAccessible() // Dotty makes classes nested within in methods private
     m.invoke(this).asInstanceOf[Index]
   }).toIndexedSeq.sortBy(_.name)
 }

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -6,8 +6,8 @@ import scala.util.{Failure, Try}
 
 import slick.SlickException
 import slick.basic.BasicBackend
-import slick.relational.RelationalBackend
 import slick.compat.collection.*
+import slick.relational.RelationalBackend
 import slick.util.Logging
 
 import com.typesafe.config.Config

--- a/slick/src/main/scala/slick/memory/DistributedProfile.scala
+++ b/slick/src/main/scala/slick/memory/DistributedProfile.scala
@@ -7,10 +7,10 @@ import slick.SlickException
 import slick.ast.*
 import slick.ast.TypeUtil.*
 import slick.basic.{FixedBasicAction, FixedBasicStreamingAction}
+import slick.compat.collection.*
 import slick.compiler.*
 import slick.dbio.*
 import slick.relational.{CompiledMapping, RelationalProfile, ResultConverter}
-import slick.compat.collection.*
 import slick.util.{??, DumpInfo, RefId}
 
 /** A profile for distributed queries. */

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -7,9 +7,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import slick.SlickException
 import slick.ast.*
+import slick.compat.collection.*
 import slick.lifted.{Constraint, Index, PrimaryKey}
 import slick.relational.{RelationalBackend, RelationalProfile}
-import slick.compat.collection.*
 import slick.util.Logging
 
 import com.typesafe.config.Config

--- a/slick/src/main/scala/slick/memory/MemoryProfile.scala
+++ b/slick/src/main/scala/slick/memory/MemoryProfile.scala
@@ -8,10 +8,10 @@ import scala.reflect.ClassTag
 import slick.ast.*
 import slick.ast.TypeUtil.*
 import slick.basic.{FixedBasicAction, FixedBasicStreamingAction}
+import slick.compat.collection.*
 import slick.compiler.*
 import slick.dbio.*
 import slick.relational.{CompiledMapping, RelationalProfile, ResultConverter, ResultConverterCompiler}
-import slick.compat.collection.*
 import slick.util.{??, DumpInfo}
 
 /** A profile for interpreted queries on top of the in-memory database. */

--- a/slick/src/main/scala/slick/memory/QueryInterpreter.scala
+++ b/slick/src/main/scala/slick/memory/QueryInterpreter.scala
@@ -241,6 +241,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         (ch.nodeType, n.nodeType) match {
           case (OptionType(tpe), tpe2) if tpe == tpe2 => chV.asInstanceOf[Option[Any]].get
           case (tpe, OptionType(tpe2)) if tpe == tpe2 => Option(chV)
+          case _ => chV // same type or unrecognised cast — return value unchanged
         }
       case Library.Exists(coll) =>
         run(coll).asInstanceOf[Coll].nonEmpty
@@ -368,6 +369,7 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
         case (_, ScalaBaseType.doubleType) => v.toString.toDouble
         case (_, ScalaBaseType.floatType) => v.toString.toFloat
         case (_, ScalaBaseType.bigDecimalType) => BigDecimal(v.toString)
+        case (from, to) => throw new slick.SlickException(s"Unsupported cast from $from to $to")
       }
     case Library.Ceiling =>
       val t = args(0)._1.asInstanceOf[ScalaNumericType[Any]]
@@ -418,7 +420,8 @@ class QueryInterpreter(db: HeapBackend#Database, params: Any) extends Logging {
       var len = s.length
       while(len > 0 && s.charAt(len-1) == ' ') len -= 1
       if(len == s.length) s else s.substring(0, len)
-    case Library.Sign => args(0)._1.asInstanceOf[ScalaNumericType[Any]].numeric.signum(args(0)._2)
+    case Library.Sign =>
+      numericSign(args(0)._1.asInstanceOf[ScalaNumericType[Any]].numeric, args(0)._2)
     case Library.Trim => args(0)._2.asInstanceOf[String].trim
     case Library.UCase => args(0)._2.asInstanceOf[String].toUpperCase
     case Library.User => ""

--- a/slick/src/main/scala/slick/util/AsyncExecutor.scala
+++ b/slick/src/main/scala/slick/util/AsyncExecutor.scala
@@ -227,7 +227,7 @@ object AsyncExecutor extends Logging {
                                             keepAliveTime: Duration,
                                             registerMbeans: Boolean) extends AsyncExecutor {
 
-    @volatile private[this] lazy val mBeanName = new ObjectName(s"slick:type=AsyncExecutor,name=$name")
+    private[this] lazy val mBeanName = new ObjectName(s"slick:type=AsyncExecutor,name=$name")
 
     // Before init: 0, during init: 1, after init: 2, during/after shutdown: 3
     private[this] val state = new AtomicInteger(0)
@@ -336,6 +336,7 @@ object AsyncExecutor extends Logging {
   }
 
   private class DaemonThreadFactory(namePrefix: String) extends ThreadFactory {
+    @annotation.nowarn
     private[this] val group =
       Option(System.getSecurityManager).fold(Thread.currentThread.getThreadGroup)(_.getThreadGroup)
     private[this] val threadNumber = new AtomicInteger(1)

--- a/slick/src/main/scala/slick/util/ConstArray.scala
+++ b/slick/src/main/scala/slick/util/ConstArray.scala
@@ -5,8 +5,9 @@ import java.util.Arrays
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.reflect.ClassTag
-import slick.compat.collection.*
 import scala.util.hashing.MurmurHash3
+
+import slick.compat.collection.*
 
 /** An efficient immutable array implementation which is used in the AST. Semantics are generally
   * the same as for Scala collections but for performance reasons it does not implement any
@@ -368,7 +369,7 @@ final class ConstArray[+T] private[util] (a: Array[Any], val length: Int) extend
   override def hashCode = {
     if(_hashCode != 0) _hashCode
     else {
-      val h = MurmurHash3.productHash(this)
+      val h = MurmurHash3.orderedHash(iterator, MurmurHash3.productSeed)
       _hashCode = h
       h
     }


### PR DESCRIPTION
- removed slick-compat-collections (used by for 2.12)
- fixed new compiler warnings
- fixed use of deprecated APIs (murmur hash, signum)
- refactored use of the `App` trait to a normal `main` method