### PR TITLE
Slick4 tracing

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/ce/ActionListenerTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/ce/ActionListenerTest.scala
@@ -1,0 +1,171 @@
+package slick.test.ce
+
+import cats.effect.IO
+import cats.effect.kernel.Outcome
+import munit.CatsEffectSuite
+
+import slick.basic.ActionListener
+import slick.cats.Database
+import slick.jdbc.DatabaseConfig
+import slick.jdbc.H2Profile
+import slick.jdbc.H2Profile.api.*
+import slick.sql.SqlAction
+
+class ActionListenerTest extends CatsEffectSuite {
+
+  class Items(tag: Tag) extends Table[Int](tag, "TRACE_ITEMS") {
+    def v = column[Int]("V")
+    def * = v
+  }
+  val items = TableQuery[Items]
+
+  private def resourceWithListener(listener: ActionListener[IO]) =
+    cats.effect.Resource.make(
+      IO.blocking {
+        val dc = DatabaseConfig.forConfig[H2Profile](
+          "mydb",
+          com.typesafe.config.ConfigFactory.parseString(
+            """
+              |mydb {
+              |  profile = "slick.jdbc.H2Profile$"
+              |  db {
+              |    connectionPool = disabled
+              |    driver = "org.h2.Driver"
+              |    url = "jdbc:h2:mem:actionlistener;DB_CLOSE_DELAY=-1"
+              |  }
+              |}
+              |""".stripMargin
+          )
+        )
+        Database.fromCore(dc.profile.backend.makeDatabase[IO](dc, listener).unsafeRunSync())
+      }
+    )(db => IO.blocking(db.close()).attempt.void)
+
+  test("SqlAction exposes SQL statements to listener") {
+    for {
+      seen <- IO.ref(Vector.empty[String])
+      listener = new ActionListener[IO] {
+        override def around[R, H](action: slick.dbio.DBIOAction[R, _, _], exec: IO[H]): IO[H] = {
+          val sqls = action match {
+            case s: SqlAction[?, ?, ?] => s.statements.toVector
+            case _ => Vector.empty
+          }
+          seen.update(_ ++ sqls) >> exec
+        }
+      }
+      out <- resourceWithListener(listener).use { db =>
+        db.run(sql"select 1".as[Int].head)
+      }
+      sqls <- seen.get
+      _ = assertEquals(out, 1)
+      _ = assert(sqls.exists(_.toLowerCase.contains("select 1")))
+    } yield ()
+  }
+
+  test("NamedAction name is visible to listener") {
+    for {
+      names <- IO.ref(Vector.empty[String])
+      listener = new ActionListener[IO] {
+        override def around[R, H](action: slick.dbio.DBIOAction[R, _, _], exec: IO[H]): IO[H] =
+          action match {
+            case slick.dbio.NamedAction(_, n) => names.update(_ :+ n) >> exec
+            case _ => exec
+          }
+      }
+      _ <- resourceWithListener(listener).use { db =>
+        db.run(DBIO.successful(1).named("named-node")).void
+      }
+      seen <- names.get
+      _ = assert(seen.contains("named-node"))
+    } yield ()
+  }
+
+  test("flatMap composition sees both nodes") {
+    for {
+      count <- IO.ref(0)
+      listener = new ActionListener[IO] {
+        override def around[R, H](action: slick.dbio.DBIOAction[R, _, _], exec: IO[H]): IO[H] =
+          action match {
+            case slick.dbio.NamedAction(_, "left") | slick.dbio.NamedAction(_, "right") =>
+              count.update(_ + 1) >> exec
+            case _ => exec
+          }
+      }
+      _ <- resourceWithListener(listener).use { db =>
+        val a = DBIO.successful(1).named("left")
+        val b = (_: Int) => DBIO.successful(2).named("right")
+        db.run(a.flatMap(b)).void
+      }
+      n <- count.get
+      _ = assertEquals(n, 2)
+    } yield ()
+  }
+
+  test("streaming actions are intercepted") {
+    for {
+      hits <- IO.ref(0)
+      listener = new ActionListener[IO] {
+        override def around[R, H](action: slick.dbio.DBIOAction[R, _, _], exec: IO[H]): IO[H] =
+          action match {
+            case _: SqlAction[?, ?, ?] => hits.update(_ + 1) >> exec
+            case _ => exec
+          }
+      }
+      _ <- resourceWithListener(listener).use { db =>
+        for {
+          _ <- db.run(items.schema.create)
+          _ <- db.run(DBIO.sequence((1 to 3).map(items += _)))
+          _ <- db.stream(items.result).compile.toVector
+          _ <- db.run(items.schema.drop)
+        } yield ()
+      }
+      n <- hits.get
+      _ = assert(n > 0)
+    } yield ()
+  }
+
+  test("around wraps execution with before/after") {
+    for {
+      events <- IO.ref(Vector.empty[String])
+      listener = new ActionListener[IO] {
+        override def around[R, H](action: slick.dbio.DBIOAction[R, _, _], exec: IO[H]): IO[H] =
+          events.update(_ :+ "before") >>
+            exec.guaranteeCase {
+              case Outcome.Succeeded(_) => events.update(_ :+ "after")
+              case _ => events.update(_ :+ "after")
+            }
+      }
+      _ <- resourceWithListener(listener).use { db =>
+        db.run(DBIO.successful(1)).void
+      }
+      ev <- events.get
+      _ = assert(ev.contains("before"))
+      _ = assert(ev.contains("after"))
+      _ = assert(ev.indexOf("before") < ev.indexOf("after"))
+    } yield ()
+  }
+
+  test("noop listener works transparently") {
+    resourceWithListener(ActionListener.noop[IO]).use { db =>
+      db.run(DBIO.successful(42)).map(v => assertEquals(v, 42))
+    }
+  }
+
+  test("transactionally exposes TransactionalAction") {
+    for {
+      seen <- IO.ref(false)
+      listener = new ActionListener[IO] {
+        override def around[R, H](action: slick.dbio.DBIOAction[R, _, _], exec: IO[H]): IO[H] =
+          action match {
+            case _: slick.dbio.TransactionalAction[?, ?, ?] => seen.set(true) >> exec
+            case _ => exec
+          }
+      }
+      _ <- resourceWithListener(listener).use { db =>
+        db.run(DBIO.successful(()).transactionally).void
+      }
+      ok <- seen.get
+      _ = assert(ok)
+    } yield ()
+  }
+}

--- a/slick/src/main/scala/slick/basic/ActionListener.scala
+++ b/slick/src/main/scala/slick/basic/ActionListener.scala
@@ -1,0 +1,26 @@
+package slick.basic
+
+import slick.dbio.DBIOAction
+
+/** Listener hook for tracing and instrumentation around DBIO node execution.
+  *
+  * The `exec` effect represents the original execution of `action`. Implementations can run
+  * effectful logic before/after `exec` (for example start/finish spans, timing, logging), but
+  * they cannot inspect or alter the `H` value itself.
+  */
+trait ActionListener[F[_]] {
+  /** Wrap execution of a single DBIO node.
+    *
+    * `H` is intentionally opaque: listeners can only sequence instrumentation around `exec`.
+    * They cannot construct a replacement result based on `H`.
+    */
+  def around[R, H](action: DBIOAction[R, _, _], exec: F[H]): F[H]
+}
+
+object ActionListener {
+  /** Listener that performs no wrapping. */
+  def noop[F[_]]: ActionListener[F] =
+    new ActionListener[F] {
+      override def around[R, H](action: DBIOAction[R, _, _], exec: F[H]): F[H] = exec
+    }
+}

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory
    * types for `Database` and `Session`. */
 trait BasicBackend { self =>
   protected lazy val actionLogger = new SlickLogger(LoggerFactory.getLogger(classOf[BasicBackend].getName+".action"))
-  protected lazy val streamLogger = new SlickLogger(LoggerFactory.getLogger(classOf[BasicBackend].getName+".stream"))
 
   protected[this] def logAction(a: DBIOAction[?, NoStream, Nothing]): Unit = {
     if (actionLogger.isDebugEnabled && a.isLogged) {

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -24,6 +24,32 @@ trait BasicBackend { self =>
   protected lazy val actionLogger = new SlickLogger(LoggerFactory.getLogger(classOf[BasicBackend].getName+".action"))
   protected lazy val streamLogger = new SlickLogger(LoggerFactory.getLogger(classOf[BasicBackend].getName+".stream"))
 
+  protected[this] def logAction(a: DBIOAction[?, NoStream, Nothing]): Unit = {
+    if (actionLogger.isDebugEnabled && a.isLogged) {
+      val logA = a.nonFusedEquivalentAction
+      val aPrefix = if (a eq logA) "" else "[fused] "
+      val dump = new TreePrinter(prefix = "    ", firstPrefix = aPrefix, narrow = {
+        case a: DBIOAction[?, ?, ?] => a.nonFusedEquivalentAction
+        case o                      => o
+      }).get(logA)
+      val msg = DumpInfo.highlight(dump.substring(0, dump.length - 1))
+      actionLogger.debug(msg)
+    }
+  }
+
+  private[this] type AnyK[A] = Any
+
+  private[this] lazy val defaultActionLoggerAny: ActionListener[AnyK] =
+    new ActionListener[AnyK] {
+      override def around[R, H](a: DBIOAction[R, _, _], exec: Any): Any = {
+        logAction(a.asInstanceOf[DBIOAction[?, NoStream, Nothing]])
+        exec
+      }
+    }
+
+  protected final def defaultActionLogger[F[_]]: ActionListener[F] =
+    defaultActionLoggerAny.asInstanceOf[ActionListener[F]]
+
   /** Non-parameterized marker trait for any database instance, regardless of effect type.
     * Use this type when you need to refer to "any database" without knowing the effect type. */
   trait AnyDatabaseDef extends Closeable {
@@ -41,7 +67,7 @@ trait BasicBackend { self =>
   /** Create a Database instance from a [[slick.basic.BasicDatabaseConfig]]. */
   def makeDatabase[F[_]: Async](
     config: BasicDatabaseConfig[?],
-    actionListener: ActionListener[F] = ActionListener.noop[F]
+    actionListener: ActionListener[F] = defaultActionLogger[F]
   ): F[Database[F]]
   // -----------------------------------------------------------------------
   // Execution state
@@ -565,7 +591,6 @@ trait BasicBackend { self =>
       ctx: Ref[F, ExecState]
     ): F[R] = {
       val F = asyncF
-      logAction(a)
       // Wrap in F.defer so that recursive calls to interpret do not consume Scala stack
       // frames. Without this, deeply nested FlatMapAction / AndThenAction structures
       // (e.g. 10,000+ levels) would cause a StackOverflowError.  CE3's defer pushes the
@@ -709,18 +734,6 @@ trait BasicBackend { self =>
     // Logging
     // ------------------------------------------------------------------
 
-    protected[this] def logAction(a: DBIOAction[?, NoStream, Nothing]): Unit = {
-      if (actionLogger.isDebugEnabled && a.isLogged) {
-        val logA = a.nonFusedEquivalentAction
-        val aPrefix = if (a eq logA) "" else "[fused] "
-        val dump = new TreePrinter(prefix = "    ", firstPrefix = aPrefix, narrow = {
-          case a: DBIOAction[?, ?, ?] => a.nonFusedEquivalentAction
-          case o                      => o
-        }).get(logA)
-        val msg = DumpInfo.highlight(dump.substring(0, dump.length - 1))
-        actionLogger.debug(msg)
-      }
-    }
   }
 
   // -----------------------------------------------------------------------

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -39,7 +39,10 @@ trait BasicBackend { self =>
   type Context >: Null <: BasicActionContext
 
   /** Create a Database instance from a [[slick.basic.BasicDatabaseConfig]]. */
-  def makeDatabase[F[_]: Async](config: BasicDatabaseConfig[?]): F[Database[F]]
+  def makeDatabase[F[_]: Async](
+    config: BasicDatabaseConfig[?],
+    actionListener: ActionListener[F] = ActionListener.noop[F]
+  ): F[Database[F]]
   // -----------------------------------------------------------------------
   // Execution state
   // -----------------------------------------------------------------------
@@ -98,6 +101,7 @@ trait BasicBackend { self =>
 
     /** Concurrency controls for admission and connection-slot arbitration. */
     val controls: Controls[F]
+    val actionListener: ActionListener[F]
 
     protected final def admissionControl: AdmissionControl[F] = controls.admissionControl
     protected final def connectionArbiter: ConnectionArbiter[F] = controls.connectionArbiter
@@ -434,7 +438,7 @@ trait BasicBackend { self =>
       def noCleanup(it: CloseableIterator[T]): (CloseableIterator[T], Option[Throwable] => F[Unit]) =
         (it, _ => F.unit)
 
-      a match {
+      val streamExec: F[(CloseableIterator[T], Option[Throwable] => F[Unit])] = a match {
         case sa: SynchronousDatabaseAction[?, ?, ?, ?] if sa.supportsStreaming =>
           ensureSession(ctx).flatMap { case (session, state) =>
             F.blocking {
@@ -533,6 +537,7 @@ trait BasicBackend { self =>
           interpret[Seq[T]](other.asInstanceOf[DBIOAction[Seq[T], NoStream, Nothing]], ctx)
             .map(seq => noCleanup(CloseableIterator.wrap(seq.iterator)))
       }
+      actionListener.around(a, streamExec)
     }
 
     /** Set up a transaction on a freshly-acquired connection.
@@ -566,132 +571,134 @@ trait BasicBackend { self =>
       // (e.g. 10,000+ levels) would cause a StackOverflowError.  CE3's defer pushes the
       // continuation onto the run-loop instead of building Scala frames.
       F.defer {
-      a match {
-        case SuccessAction(v) =>
-          F.pure(v)
+        val exec: F[R] = a match {
+          case SuccessAction(v) =>
+            F.pure(v)
 
-        case FailureAction(t) =>
-          F.raiseError(t)
+          case FailureAction(t) =>
+            F.raiseError(t)
 
-        case LiftFAction(fa) =>
-          // fa is already an F[R]; type safety guaranteed by DBIO.liftF
-          fa.asInstanceOf[F[R]]
+          case LiftFAction(fa) =>
+            // fa is already an F[R]; type safety guaranteed by DBIO.liftF
+            fa.asInstanceOf[F[R]]
 
-        case FlatMapAction(base, f) =>
-          interpret[Any](base.asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
-            .flatMap { v =>
-              val next = f.asInstanceOf[Any => DBIOAction[R, NoStream, Nothing]](v)
-              interpret[R](next, ctx)
-            }
-
-        case AndThenAction(actions) =>
-          val last = actions.length - 1
-          def run(pos: Int): F[Any] = {
-            val fi = interpret[Any](actions(pos).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
-            if (pos == last) fi
-            else fi.flatMap(_ => run(pos + 1))
-          }
-          run(0).asInstanceOf[F[R]]
-
-        case sa @ SequenceAction(actions) =>
-          val len = actions.length
-          def run(pos: Int, acc: Vector[Any]): F[Vector[Any]] = {
-            if (pos == len) F.pure(acc)
-            else
-              interpret[Any](actions(pos).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
-                .flatMap(v => run(pos + 1, acc :+ v))
-          }
-          run(0, Vector.empty).map { results =>
-            val b = sa.cbf.asInstanceOf[Factory[Any, R]].newBuilder
-            results.foreach(b += _)
-            b.result()
-          }
-
-        case CleanUpAction(base, f, keepFailure) =>
-          // Use uncancelable+poll so that:
-          //   - the base action runs cancelably (via poll),
-          //   - the cleanup action f(...) always runs, even on cancellation,
-          //   - after cleanup, the original outcome is restored.
-          // On cancellation, f receives Some(CancellationException) so user code can
-          // distinguish cancel from normal errors.
-          F.uncancelable { poll =>
-            poll(interpret[R](base.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx))
-              .guaranteeCase {
-                case Outcome.Succeeded(_) =>
-                  interpret[Any](f(None).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx).void
-                case Outcome.Errored(err) =>
-                  // Run cleanup with the error. Re-raise original unless keepFailure=false
-                  // and cleanup itself also fails (cleanup error takes precedence).
-                  interpret[Any](f(Some(err)).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx).void
-                    .recoverWith { case cleanupErr if !keepFailure => F.raiseError(cleanupErr) }
-                case Outcome.Canceled() =>
-                  // Run cleanup with a CancellationException so user code can react to cancel.
-                  // Errors from cleanup are swallowed so as not to mask the cancellation.
-                  interpret[Any](
-                    f(Some(new java.util.concurrent.CancellationException("DBIO action canceled")))
-                      .asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx).attempt.void
+          case FlatMapAction(base, f) =>
+            interpret[Any](base.asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
+              .flatMap { v =>
+                val next = f.asInstanceOf[Any => DBIOAction[R, NoStream, Nothing]](v)
+                interpret[R](next, ctx)
               }
-          }
 
-        case FailedAction(inner) =>
-          interpret[Any](inner.asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
-            .attempt
-            .flatMap {
-              case Left(t)  => F.pure(t.asInstanceOf[R])
-              case Right(_) => F.raiseError(new NoSuchElementException("Action.failed did not fail"))
+          case AndThenAction(actions) =>
+            val last = actions.length - 1
+            def run(pos: Int): F[Any] = {
+              val fi = interpret[Any](actions(pos).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
+              if (pos == last) fi
+              else fi.flatMap(_ => run(pos + 1))
+            }
+            run(0).asInstanceOf[F[R]]
+
+          case sa @ SequenceAction(actions) =>
+            val len = actions.length
+            def run(pos: Int, acc: Vector[Any]): F[Vector[Any]] = {
+              if (pos == len) F.pure(acc)
+              else
+                interpret[Any](actions(pos).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
+                  .flatMap(v => run(pos + 1, acc :+ v))
+            }
+            run(0, Vector.empty).map { results =>
+              val b = sa.cbf.asInstanceOf[Factory[Any, R]].newBuilder
+              results.foreach(b += _)
+              b.result()
             }
 
-        case AsTryAction(inner) =>
-          interpret[Any](inner.asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
-            .attempt
-            .map {
-              case Right(v) => scala.util.Success(v).asInstanceOf[R]
-              case Left(t)  => scala.util.Failure(t).asInstanceOf[R]
-            }
-
-        case NamedAction(inner, _) =>
-          interpret[R](inner.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx)
-
-        case TransactionalAction(inner, isolationLevel) =>
-          // uncancelable ensures enterTransactionScope and guaranteeCase registration are
-          // atomic: a cancellation between them would leave transactionDepth incremented
-          // with no finalizer to decrement it.  The inner action runs cancelably via poll.
-          asyncF.uncancelable { poll =>
-            enterTransactionScope(ctx, isolationLevel) >>
-            poll(interpret[R](inner.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx))
-              .guaranteeCase { outcome =>
-                exitTransactionScope(ctx, succeeded = outcome.isSuccess)
-              }
-          }
-
-        case PinnedSessionAction(inner) =>
-          // uncancelable pairs the increment and the guarantee registration atomically,
-          // mirroring the TransactionalAction pattern.  Without this, cancellation between
-          // the increment and the guarantee could leave pinnedDepth permanently > 0,
-          // preventing releaseSession from ever running.  Inner action runs cancelably via poll.
-          asyncF.uncancelable { poll =>
-            ctx.update(s => s.copy(pinnedDepth = s.pinnedDepth + 1)) >>
-            poll(interpret[R](inner.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx))
-              .guarantee {
-                ctx.update(s => s.copy(pinnedDepth = s.pinnedDepth - 1)) >>
-                ctx.get.flatMap { s =>
-                  // Only release the connection if there are no more pins or transactions
-                  if (!s.pinned) releaseSession(ctx) else asyncF.unit
+          case CleanUpAction(base, f, keepFailure) =>
+            // Use uncancelable+poll so that:
+            //   - the base action runs cancelably (via poll),
+            //   - the cleanup action f(...) always runs, even on cancellation,
+            //   - after cleanup, the original outcome is restored.
+            // On cancellation, f receives Some(CancellationException) so user code can
+            // distinguish cancel from normal errors.
+            F.uncancelable { poll =>
+              poll(interpret[R](base.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx))
+                .guaranteeCase {
+                  case Outcome.Succeeded(_) =>
+                    interpret[Any](f(None).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx).void
+                  case Outcome.Errored(err) =>
+                    // Run cleanup with the error. Re-raise original unless keepFailure=false
+                    // and cleanup itself also fails (cleanup error takes precedence).
+                    interpret[Any](f(Some(err)).asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx).void
+                      .recoverWith { case cleanupErr if !keepFailure => F.raiseError(cleanupErr) }
+                  case Outcome.Canceled() =>
+                    // Run cleanup with a CancellationException so user code can react to cancel.
+                    // Errors from cleanup are swallowed so as not to mask the cancellation.
+                    interpret[Any](
+                      f(Some(new java.util.concurrent.CancellationException("DBIO action canceled")))
+                        .asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx).attempt.void
                 }
-              }
-          }
-
-        case a: SynchronousDatabaseAction[?, ?, ?, ?] =>
-          withSession[R](ctx) { (session, state) =>
-            F.blocking {
-              a.asInstanceOf[SynchronousDatabaseAction[R, NoStream, Context, Nothing]]
-               .run(sessionAsContext(session, state))
             }
-          }
 
-        case a: DBIOAction[?, ?, ?] =>
-          F.raiseError(new SlickException(s"Unsupported database action $a for $this"))
-      }
+          case FailedAction(inner) =>
+            interpret[Any](inner.asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
+              .attempt
+              .flatMap {
+                case Left(t)  => F.pure(t.asInstanceOf[R])
+                case Right(_) => F.raiseError(new NoSuchElementException("Action.failed did not fail"))
+              }
+
+          case AsTryAction(inner) =>
+            interpret[Any](inner.asInstanceOf[DBIOAction[Any, NoStream, Nothing]], ctx)
+              .attempt
+              .map {
+                case Right(v) => scala.util.Success(v).asInstanceOf[R]
+                case Left(t)  => scala.util.Failure(t).asInstanceOf[R]
+              }
+
+          case NamedAction(inner, _) =>
+            interpret[R](inner.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx)
+
+          case TransactionalAction(inner, isolationLevel) =>
+            // uncancelable ensures enterTransactionScope and guaranteeCase registration are
+            // atomic: a cancellation between them would leave transactionDepth incremented
+            // with no finalizer to decrement it.  The inner action runs cancelably via poll.
+            asyncF.uncancelable { poll =>
+              enterTransactionScope(ctx, isolationLevel) >>
+              poll(interpret[R](inner.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx))
+                .guaranteeCase { outcome =>
+                  exitTransactionScope(ctx, succeeded = outcome.isSuccess)
+                }
+            }
+
+          case PinnedSessionAction(inner) =>
+            // uncancelable pairs the increment and the guarantee registration atomically,
+            // mirroring the TransactionalAction pattern.  Without this, cancellation between
+            // the increment and the guarantee could leave pinnedDepth permanently > 0,
+            // preventing releaseSession from ever running.  Inner action runs cancelably via poll.
+            asyncF.uncancelable { poll =>
+              ctx.update(s => s.copy(pinnedDepth = s.pinnedDepth + 1)) >>
+              poll(interpret[R](inner.asInstanceOf[DBIOAction[R, NoStream, Nothing]], ctx))
+                .guarantee {
+                  ctx.update(s => s.copy(pinnedDepth = s.pinnedDepth - 1)) >>
+                  ctx.get.flatMap { s =>
+                    // Only release the connection if there are no more pins or transactions
+                    if (!s.pinned) releaseSession(ctx) else asyncF.unit
+                  }
+                }
+            }
+
+          case a: SynchronousDatabaseAction[?, ?, ?, ?] =>
+            withSession[R](ctx) { (session, state) =>
+              F.blocking {
+                a.asInstanceOf[SynchronousDatabaseAction[R, NoStream, Context, Nothing]]
+                  .run(sessionAsContext(session, state))
+              }
+            }
+
+          case a: DBIOAction[?, ?, ?] =>
+            F.raiseError(new SlickException(s"Unsupported database action $a for $this"))
+        }
+
+        actionListener.around(a, exec)
       } // end F.defer
     }
 
@@ -744,5 +751,4 @@ trait BasicBackend { self =>
     /** Whether the session is currently pinned (from ExecState.pinned). */
     def isPinned: Boolean
   }
-
 }

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -24,7 +24,7 @@ trait JdbcBackend extends RelationalBackend {
 
   override def makeDatabase[F[_]: Async](
     config: slick.basic.BasicDatabaseConfig[?],
-    actionListener: ActionListener[F] = ActionListener.noop[F]
+    actionListener: ActionListener[F] = defaultActionLogger[F]
   ): F[Database[F]] = {
     // If the config has a "db" sub-section use it (the {profile=..., db={...}} format),
     // otherwise use the config directly (flat format where datasource keys are at the top level).

--- a/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcBackend.scala
@@ -7,6 +7,7 @@ import java.sql.{Array => _, *}
 import cats.effect.Async
 
 import slick.relational.RelationalBackend
+import slick.basic.ActionListener
 import slick.basic.ConcurrencyControl.*
 import slick.util.*
 import slick.util.ConfigExtensionMethods.*
@@ -21,32 +22,42 @@ trait JdbcBackend extends RelationalBackend {
 
   val backend: JdbcBackend = this
 
-  override def makeDatabase[F[_]: Async](config: slick.basic.BasicDatabaseConfig[?]): F[Database[F]] = {
+  override def makeDatabase[F[_]: Async](
+    config: slick.basic.BasicDatabaseConfig[?],
+    actionListener: ActionListener[F] = ActionListener.noop[F]
+  ): F[Database[F]] = {
     // If the config has a "db" sub-section use it (the {profile=..., db={...}} format),
     // otherwise use the config directly (flat format where datasource keys are at the top level).
     val dbConfig = config.config.getConfigOr("db", config.config)
     val source = JdbcDataSource.forConfig(dbConfig, null, config.path, config.classLoader)
     val cc = config.controls
     val n  = source.maxConnections.getOrElse(cc.maxConnections)
-    makeDatabaseWithSource[F](source, cc.copy(maxConnections = n))
+    makeDatabaseWithSource[F](source, cc.copy(maxConnections = n), actionListener)
   }
 
-  def makeDatabase[F[_]: Async](config: JdbcDatabaseConfig[?]): F[Database[F]] = {
+  def makeDatabase[F[_]: Async](
+    config: JdbcDatabaseConfig[?],
+    actionListener: ActionListener[F]
+  ): F[Database[F]] = {
     val cc = config.controls
     val n  = config.source.maxConnections.getOrElse(cc.maxConnections)
-    makeDatabaseWithSource[F](config.source, cc.copy(maxConnections = n))
+    makeDatabaseWithSource[F](config.source, cc.copy(maxConnections = n), actionListener)
   }
+
+  def makeDatabase[F[_]: Async](config: JdbcDatabaseConfig[?]): F[Database[F]] =
+    makeDatabase(config, ActionListener.noop[F])
 
   /** Construct a [[Database]] from a [[JdbcDataSource]] and open the keepalive connection if
     * configured.  This is the primitive used by both [[makeDatabase]] overloads.  The caller is
     * responsible for calling [[JdbcDatabaseDef.close]] when done. */
   private def makeDatabaseWithSource[F[_]: Async](
     source: JdbcDataSource,
-    controls: slick.ControlsConfig
+    controls: slick.ControlsConfig,
+    listener: ActionListener[F]
   ): F[Database[F]] = {
     Async[F].flatMap(Controls.create[F](controls)) { c =>
       val ag = Async[F]
-      val db = new JdbcDatabaseDef[F](source, c)(ag) {}
+      val db = new JdbcDatabaseDef[F](source, c, listener)(ag) {}
       val keepAlive: F[Unit] = source match {
         case ds: DataSourceJdbcDataSource if ds.keepAliveConnection =>
           Async[F].blocking(ds.openKeepAlive())
@@ -65,7 +76,8 @@ trait JdbcBackend extends RelationalBackend {
     */
   abstract class JdbcDatabaseDef[F[_]](
     val source: JdbcDataSource,
-    override val controls: Controls[F]
+    override val controls: Controls[F],
+    override val actionListener: ActionListener[F]
   )(
     override implicit val asyncF: Async[F]
   ) extends BasicDatabaseDef[F] {

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -28,7 +28,7 @@ trait DistributedBackend extends RelationalBackend with Logging {
 
   override def makeDatabase[F[_]: Async](
     config: slick.basic.BasicDatabaseConfig[?],
-    actionListener: ActionListener[F] = ActionListener.noop[F]
+    actionListener: ActionListener[F] = defaultActionLogger[F]
   ): F[Database[F]] =
     Async[F].raiseError(new SlickException("DistributedBackend cannot be configured with an external config file"))
 

--- a/slick/src/main/scala/slick/memory/DistributedBackend.scala
+++ b/slick/src/main/scala/slick/memory/DistributedBackend.scala
@@ -6,6 +6,7 @@ import scala.util.{Failure, Try}
 import cats.effect.{Async, IO, Ref, Resource}
 
 import slick.SlickException
+import slick.basic.ActionListener
 import slick.basic.BasicBackend
 import slick.compat.collection.*
 import slick.dbio.{DBIOAction, Streaming}
@@ -25,10 +26,17 @@ trait DistributedBackend extends RelationalBackend with Logging {
   val Database = new DistributedDatabaseFactoryDef
   val backend: DistributedBackend = this
 
-  override def makeDatabase[F[_]: Async](config: slick.basic.BasicDatabaseConfig[?]): F[Database[F]] =
+  override def makeDatabase[F[_]: Async](
+    config: slick.basic.BasicDatabaseConfig[?],
+    actionListener: ActionListener[F] = ActionListener.noop[F]
+  ): F[Database[F]] =
     Async[F].raiseError(new SlickException("DistributedBackend cannot be configured with an external config file"))
 
-  class DistributedDatabaseDef[F[_]](val dbs: Vector[BasicBackend#AnyDatabaseDef], override val controls: Controls[F])(implicit override val asyncF: cats.effect.Async[F])
+  class DistributedDatabaseDef[F[_]](
+    val dbs: Vector[BasicBackend#AnyDatabaseDef],
+    override val controls: Controls[F],
+    override val actionListener: ActionListener[F] = ActionListener.noop[F]
+  )(implicit override val asyncF: cats.effect.Async[F])
     extends BasicDatabaseDef[F] {
 
     /** DistributedBackend always uses cats.effect.IO as its effect type. */

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -8,6 +8,7 @@ import cats.effect.{Async, IO, Resource}
 
 import slick.SlickException
 import slick.ast.*
+import slick.basic.ActionListener
 import slick.basic.ConcurrencyControl.Controls
 import slick.compat.collection.*
 import slick.lifted.{Constraint, Index, PrimaryKey}
@@ -26,7 +27,10 @@ trait HeapBackend extends RelationalBackend with Logging {
   val Database = new HeapDatabaseFactoryDef
   val backend: HeapBackend = this
 
-  override def makeDatabase[F[_]: Async](config: slick.basic.BasicDatabaseConfig[?]): F[Database[F]] =
+  override def makeDatabase[F[_]: Async](
+    config: slick.basic.BasicDatabaseConfig[?],
+    actionListener: ActionListener[F] = ActionListener.noop[F]
+  ): F[Database[F]] =
     Async[F].flatMap(Controls.create[F](ControlsConfig.unbounded))(c => Async[F].pure(new HeapDatabaseDef[F](c)))
 
   /** Non-parameterized base for HeapDatabaseDef, providing table management operations
@@ -43,7 +47,10 @@ trait HeapBackend extends RelationalBackend with Logging {
     def getTables: IndexedSeq[HeapTable]
   }
 
-  class HeapDatabaseDef[F[_]](override val controls: Controls[F])(implicit override val asyncF: cats.effect.Async[F]) extends BasicDatabaseDef[F] with AnyHeapDatabaseDef {
+  class HeapDatabaseDef[F[_]](
+    override val controls: Controls[F],
+    override val actionListener: ActionListener[F] = ActionListener.noop[F]
+  )(implicit override val asyncF: cats.effect.Async[F]) extends BasicDatabaseDef[F] with AnyHeapDatabaseDef {
 
     override protected def sessionAsContext(session: Session, state: ExecState): Context = {
       val s = session

--- a/slick/src/main/scala/slick/memory/HeapBackend.scala
+++ b/slick/src/main/scala/slick/memory/HeapBackend.scala
@@ -29,7 +29,7 @@ trait HeapBackend extends RelationalBackend with Logging {
 
   override def makeDatabase[F[_]: Async](
     config: slick.basic.BasicDatabaseConfig[?],
-    actionListener: ActionListener[F] = ActionListener.noop[F]
+    actionListener: ActionListener[F] = defaultActionLogger[F]
   ): F[Database[F]] =
     Async[F].flatMap(Controls.create[F](ControlsConfig.unbounded))(c => Async[F].pure(new HeapDatabaseDef[F](c)))
 


### PR DESCRIPTION
This PR introduces `ActionListener[F[_]]`, a new advanced hook for instrumenting individual `DBIOAction` node execution in Slick and moves actionLogigng to a new `logger: ActionListener[Any]`.

It wraps both regular and streaming interpreter execution, so listeners can observe SQL actions, named actions, transactional wrappers, and other DBIO nodes consistently. 

Listener wiring is intentionally backend-level and opt-in, keeping high-level facades unchanged.

## Example: using an ActionListener

```scala
## Example: ActionListener with otel4s
```scala
def otelListener(tracer: Tracer[IO]): ActionListener[IO] =
  new ActionListener[IO] {
    override def around[R, H](action: DBIOAction[R, _, _], exec: IO[H]): IO[H] = {
      val maybeName = action match {
        case sql: SqlAction[?, ?, ?] => Option(sql.getDumpInfo.mainInfo).filter(_.nonEmpty)
        case NamedAction(_, name)    => Some(name)
        case _                       => None
      }
      maybeName match {
        case Some(name) =>
          tracer.spanBuilder("slick.dbio")
            .addAttribute("action", name)
            .build
            .surround(exec)
        case None =>
          exec
      }
    }
  }
  
val dc = DatabaseConfig.forConfig[H2Profile]("mydb")

// Advanced opening path: create core DB with listener, then wrap with facade
def openDb(tracer: Tracer[IO]): Database =
  Database.fromCore(dc.profile.backend.makeDatabase[IO](dc, otelListener(tracer)).unsafeRunSync())``` 

This enables low-friction tracing/metrics instrumentation around DBIO execution while preserving existing APIs for users who don’t need instrumentation.