### PR TITLE
fix localtime jdbc serialization to always include seconds

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcTypeTest.scala
@@ -303,6 +303,17 @@ class JdbcTypeTest extends AsyncTest[JdbcTestDB] {
       () => randomLocalDateTime().toLocalTime
     )
 
+  def testLocalTimeFormatCompatibility =
+    roundTrip[LocalTime](
+      List(
+        LocalTime.of(12, 34),
+        LocalTime.of(12, 34, 56),
+        LocalTime.of(12, 34, 56, 123000000)
+      ),
+      () => LocalTime.of(12, 34),
+      tableNameSuffix = "_format_compat"
+    )
+
   def testInstant =
     roundTrip[Instant](
       List(LocalDateTime.parse("2018-03-25T01:37:40", formatter).toInstant(ZoneOffset.UTC),

--- a/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala
+++ b/slick/src/main/scala/slick/jdbc/JdbcTypesComponent.scala
@@ -2,6 +2,8 @@ package slick.jdbc
 
 import java.sql.{Array as _, *}
 import java.time.*
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 import java.util.UUID
 
 import scala.reflect.ClassTag
@@ -216,7 +218,7 @@ trait JdbcTypesComponent extends RelationalTypesComponent { self: JdbcProfile =>
         java.sql.Types.VARCHAR
       }
       override def setValue(v: LocalTime, p: PreparedStatement, idx: Int) : Unit = {
-        p.setString(idx, v.toString)
+        p.setString(idx, localTimeFormatter.format(v))
       }
       override def getValue(r: ResultSet, idx: Int) : LocalTime = {
         r.getString(idx) match {
@@ -225,12 +227,20 @@ trait JdbcTypesComponent extends RelationalTypesComponent { self: JdbcProfile =>
         }
       }
       override def updateValue(v: LocalTime, r: ResultSet, idx: Int) = {
-        r.updateString(idx, v.toString)
+        r.updateString(idx, localTimeFormatter.format(v))
       }
 
       override def valueToSQLLiteral(value: LocalTime) = {
-        s"'${value.toString}'"
+        s"'${localTimeFormatter.format(value)}'"
       }
+
+      private[this] val localTimeFormatter =
+        new DateTimeFormatterBuilder()
+          .appendPattern("HH:mm:ss")
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .optionalEnd()
+          .toFormatter()
     }
 
     class LocalDateTimeJdbcType extends DriverJdbcType[LocalDateTime] {


### PR DESCRIPTION
Use a DateTimeFormatterBuilder in LocalTimeJdbcType so persisted LocalTime values are formatted as HH:mm:ss with optional fractional seconds, avoiding HH:mm strings that fail on HSQLDB TIME(3). Add JdbcTypeTest.testLocalTimeFormatCompatibility to verify round-trip behavior for minute-only, second, and fractional-second LocalTime values across profiles.