### PR TITLE
Add regression test for distinct on Option projection

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/AggregateTest.scala
@@ -523,4 +523,27 @@ class AggregateTest extends AsyncTest[RelationalTestDB] {
     )
   }
 
+  def testDistinctOptionProjection = {
+    // Regression test for issue #1689: `.distinct` on a table whose `*` projection
+    // maps an Option column (via `id.?`) used to shuffle the order of the generated
+    // SQL columns, causing a column-mapping crash (e.g. trying to read a String as a Long).
+    case class User1689(id: Option[Int], name: String, age: Long)
+    class Users1689(tag: Tag) extends Table[User1689](tag, "users_1689") {
+      def id = column[Int]("id", O.PrimaryKey)
+      def name = column[String]("name")
+      def age = column[Long]("age")
+      def * = (id.?, name, age).mapTo[User1689]
+    }
+    val users = TableQuery[Users1689]
+
+    val rows = Seq(
+      User1689(Some(1), "John", 30L),
+      User1689(Some(2), "Jane", 25L)
+    )
+
+    users.schema.create >>
+      (users ++= rows) >>
+      users.distinct.result.map(_.toSet shouldBe rows.toSet)
+  }
+
 }


### PR DESCRIPTION
Regression test for #1689: `.distinct` on a table whose `*` projection maps an Option column (via `id.?`) shuffled the order of the generated SQL columns, dropping a column and corrupting deserialization.

**Verified red→green:** on Slick 3.2.1 (Scala 2.11) `users.distinct.result` emits `select min("id"), "name", "id" from ... group by "id","name","age"` — the `age` column is dropped and `id` projected twice, so the `age: Long` field reads the id value. It passes on current `main`, so this test guards the fix.

Runs as `AggregateTest.testDistinctOptionProjection[h2mem]`.

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)