### PR TITLE
Add regression test for ProvenShape in abstract keyed table

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -550,4 +550,37 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
       kvs.result.head.map(_ shouldBe KV(stableKey, "newval", initial, newDate))
     )
   }
+
+  def testProvenShapeInKeyedTable738 = {
+    // Regression test for issue #738: an abstract table parameterized over U with an
+    // implicit `Shape[_ <: FlatShapeLevel, U, U, _]` bound, whose `*` projection combines a
+    // concrete `Rep` with an abstract `ProvenShape[U]` mapping, must compile and round-trip.
+    import slick.lifted.{FlatShapeLevel, ProvenShape, Shape}
+
+    type KeyedEntity[U] = (Long, U)
+
+    abstract class KeyedTable[U](tag: Tag, name: String)(
+      implicit sh: Shape[_ <: FlatShapeLevel, U, U, _]
+    ) extends Table[KeyedEntity[U]](tag, name) {
+      val id: Rep[Long] = column[Long]("ID", O.AutoInc, O.PrimaryKey)
+      def mapping: ProvenShape[U]
+      def * = (id, mapping)
+    }
+
+    class People(tag: Tag) extends KeyedTable[(String, Int)](tag, "people738") {
+      def name = column[String]("NAME")
+      def age = column[Int]("AGE")
+      def mapping: ProvenShape[(String, Int)] = (name, age)
+    }
+    val people = TableQuery[People]
+
+    for {
+      _ <- people.schema.create
+      _ <- people.map(_.mapping) ++= Seq(("Alice", 30), ("Bob", 40))
+      _ <- people.sortBy(_.id).result.map { rows =>
+        rows.map(_._2).toSet shouldBe Set(("Alice", 30), ("Bob", 40))
+        rows.map(_._1).toSet.size shouldBe 2
+      }
+    } yield ()
+  }
 }


### PR DESCRIPTION
Forward-looking regression test for #738: an abstract `KeyedTable[U]` with an implicit `Shape[_ <: FlatShapeLevel, U, U, _]` bound, whose `*` projection combines a concrete `Rep` with an abstract `ProvenShape[U]` mapping, must compile and round-trip.

This test guards the behavior **going forward**. It does **not** close the issue: the failure reported in #738 existed only on an unreleased master snapshot (the issue references the in-development branch `tmp/provenshape-shape`) and was fixed before any release. The scenario compiles cleanly on every released version I tried (2.0.0, 2.1.0, 3.0.0, 3.1.0, 3.2.3), so the test never goes red on a release — I can't prove it guards the original defect, only that the behavior is correct now and stays correct.

Runs as `JdbcMapperTest.testProvenShapeInKeyedTable738[h2mem]`.

References #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)