### PR TITLE
Add regression test for multi-column update with mapped Date

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/JdbcMapperTest.scala
@@ -516,4 +516,38 @@ class JdbcMapperTest extends AsyncTest[JdbcTestDB] {
       ts.map(_.auto).to[Set].result.map(_ shouldBe Set(Data(7, 8), Data(9, 10), Data(5, 6)))
     )
   }
+
+  def testMultiColumnUpdateWithMappedDate = {
+    import java.util.Date
+
+    implicit val dateColumnType: BaseColumnType[Date] =
+      MappedColumnType.base[Date, Long](_.getTime, new Date(_))
+
+    case class KV(key: String, value: String, createdAt: Date, modifiedAt: Date)
+
+    class KVTable(tag: Tag) extends Table[KV](tag, "config_1159") {
+      def key = column[String]("key", O.PrimaryKey)
+      def value = column[String]("value")
+      def createdAt = column[Date]("created_at")
+      def modifiedAt = column[Date]("modified_at")
+      def * = (key, value, createdAt, modifiedAt).mapTo[KV]
+    }
+    val kvs = TableQuery[KVTable]
+
+    val stableKey = "software.revision.stable"
+    val initial = new Date(0L)
+    val newDate = new Date(5000000L)
+
+    // The bug: a multi-column update that includes a mapped Date/time column produced
+    // an incorrect row. Updating only a single column worked. Here we update both the
+    // value and the mapped modifiedAt column and assert the row reflects both new values.
+    val updateStableQ = kvs.filter(_.key === stableKey).map(c => (c.value, c.modifiedAt))
+
+    seq(
+      kvs.schema.create,
+      kvs += KV(stableKey, "oldval", initial, initial),
+      updateStableQ.update(("newval", newDate)),
+      kvs.result.head.map(_ shouldBe KV(stableKey, "newval", initial, newDate))
+    )
+  }
 }


### PR DESCRIPTION
Forward-looking regression test for #1159: a multi-column `.update(...)` that includes a column with a `MappedColumnType.base[Date, Long]` mapping updates all targeted columns correctly.

This test guards the behavior **going forward**. It does **not** close the issue: the reported silent no-op was tied to a Date-mapping/scope condition, and the issue's own resolution was "bring the implicit Date mapper into scope." This test necessarily has the mapper in scope (without it the code does not compile), so it exercises the *working* configuration — it stays green even on Slick 3.0.0 (verified on H2 and on a real PostgreSQL 11), so I can't prove it would have caught the original defect.

Runs as `JdbcMapperTest.testMultiColumnUpdateWithMappedDate[h2mem]`.

References #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)