### PR TITLE
Add Postgres DDL test: Double maps to DOUBLE PRECISION

### DIFF
--- a/slick-testkit/src/test/scala/slick/test/lifted/PostgresDDLTest.scala
+++ b/slick-testkit/src/test/scala/slick/test/lifted/PostgresDDLTest.scala
@@ -1,0 +1,38 @@
+package slick.test.lifted
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Regression test for issue #1323: PostgresProfile must generate
+  * `DOUBLE PRECISION` (a valid PostgreSQL type) rather than a bare `DOUBLE`
+  * for a `column[Double]` in its createStatements DDL.
+  */
+class PostgresDDLTest {
+
+  import slick.jdbc.PostgresProfile.api._
+
+  @Test
+  def testDoublePrecisionType: Unit = {
+    class Coffees1323(tag: Tag) extends Table[(String, Double)](tag, "COFFEES_1323") {
+      def name = column[String]("NAME")
+      def price = column[Double]("PRICE")
+
+      def * = (name, price)
+    }
+    val coffees = TableQuery[Coffees1323]
+
+    val createStatements = coffees.schema.createStatements.toList
+    assertTrue("DDL (create) must contain SQL statement(s)", createStatements.nonEmpty)
+
+    val ddl = createStatements.mkString("\n")
+    assertTrue(
+      "Double column must render as DOUBLE PRECISION: " + ddl,
+      ddl.contains("DOUBLE PRECISION")
+    )
+    assertTrue(
+      "Double column must not render as a bare DOUBLE: " + ddl,
+      !ddl.contains("DOUBLE NOT NULL") && !ddl.contains("DOUBLE,") && !ddl.contains("DOUBLE)")
+    )
+  }
+
+}


### PR DESCRIPTION
Forward-looking regression test for #1323: a PostgreSQL `column[Double]` must be generated as `DOUBLE PRECISION` (a valid PostgreSQL type), not as a bare `DOUBLE`.

This test guards the behavior **going forward**. It does **not** close the issue: I could not reproduce the reported bare-`DOUBLE` output on any released version — 3.0.0, 3.0.3, 3.1.1 and 2.1.0 all emit `DOUBLE PRECISION` for a plain `column[Double]`. The original defect may have required a condition this plain-column scenario doesn't capture, so the test stays green everywhere and I can't prove it would have caught it.

Runs as `slick.test.lifted.PostgresDDLTest.testDoublePrecisionType` (JUnit, DDL-only — no PostgreSQL server needed).

References #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)