### PR TITLE
Add plain-SQL test: UPDATE without WHERE reports affected rows

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/PlainSQLTest.scala
@@ -168,4 +168,24 @@ class PlainSQLTest extends AsyncTest[JdbcTestDB] {
 
     seq(create, selectMaxFromEmptyFails)
   }
+
+  def testUpdateWithoutWhereAffectedRows = ifCap(tcap.plainSql) {
+    val create =
+      sqlu"""create table USERS_878(ID int not null primary key, NAME varchar(255))""".map(_ shouldBe 0)
+
+    val populate =
+      DBIO.fold(
+        (for {
+          (id, name) <- List((1, "Stefan"), (2, "Jan Christopher"))
+        } yield sqlu"insert into USERS_878 values ($id, $name)"),
+        0
+      )(_ + _).map(_ shouldBe 2)
+
+    // Bug #878: an UPDATE without a WHERE clause must report the real number of
+    // affected rows (2 here), not always 1.
+    val updateAll =
+      sqlu"update USERS_878 set NAME = 'Unicorn'".map(_ shouldBe 2)
+
+    seq(create, populate, updateAll)
+  }
 }


### PR DESCRIPTION
Forward-looking regression test for #878: a plain `sqlu` UPDATE without a WHERE clause must return the real number of affected rows (2 here), not always 1.

This test guards the behavior **going forward** on H2. It does **not** close the issue: the original report was specific to SQL Server via the jTDS driver, which H2 can't exercise, so this test doesn't run the code path where the bug actually lived. It does confirm H2 reports the affected-row count correctly and guards against regressions there.

Runs as `PlainSQLTest.testUpdateWithoutWhereAffectedRows[h2mem]` (gated on `tcap.plainSql`).

References #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)