### PR TITLE
CI: run sbt with --server everywhere; make Versioning.bump exhaustive

### DIFF
--- a/.github/workflows/check-scaladoc-links.yml
+++ b/.github/workflows/check-scaladoc-links.yml
@@ -35,4 +35,5 @@ jobs:
     - name: Setup SBT
       uses: sbt/setup-sbt@v1
 
-    - run: sbt checkScaladocLinks
+    # --server runs sbt in the foreground; the default background server plus thin client can fail to connect on startup
+    - run: sbt --server checkScaladocLinks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,11 @@ jobs:
 
       - name: Build and test
         run: |
-          # The sbt 2 runner joins all arguments into one command line, so separate commands with ';'
-          sbt "++${{ matrix.scala }}; coverage; testAll; coverageReport"
+          # The sbt 2 runner joins all arguments into one command line, so separate commands with ';'.
+          # Without --server the runner starts the sbt server in the background and connects a thin client to it. The
+          # client sometimes reads project/target/active.json before the server has finished writing it and gives up
+          # with "failed to connect to server". --server runs sbt in the foreground instead.
+          sbt --server "++${{ matrix.scala }}; coverage; testAll; coverageReport"
         env:
           SLICK_TESTKIT_CONFIG: test-dbs/testkit.github-actions.conf
           TZ: Asia/Kamchatka
@@ -170,7 +173,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Publish docs to website
-        run: GIT_SSH_COMMAND="ssh -i $(pwd)/deploy-key" sbt site/deployDocs
+        run: GIT_SSH_COMMAND="ssh -i $(pwd)/deploy-key" sbt --server site/deployDocs
 
   publish:
     name: Release
@@ -202,4 +205,4 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt ci-release
+        run: sbt --server ci-release

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,6 +54,7 @@ jobs:
         run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mysql --disable-log-bin
       
       - name: Compile project and download dependencies
-        run: sbt compile
+        # --server runs sbt in the foreground; the default background server plus thin client can fail to connect on startup
+        run: sbt --server compile
         env:
           SLICK_TESTKIT_CONFIG: test-dbs/testkit-databases.conf

--- a/.github/workflows/version-policy-check.yml
+++ b/.github/workflows/version-policy-check.yml
@@ -40,4 +40,5 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check version policy
-        run: sbt "++${{ matrix.scala }}; versionPolicyCheck"
+        # --server runs sbt in the foreground; the default background server plus thin client can fail to connect on startup
+        run: sbt --server "++${{ matrix.scala }}; versionPolicyCheck"

--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -13,9 +13,11 @@ import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport.{Compatibility, versio
 
 
 object Versioning extends AutoPlugin {
+  // The compatibility intention decides how the next version is derived from the last stable tag: a fully
+  // compatible change bumps the last number, anything else bumps the middle one. The first number is not
+  // derived from compatibility; set developmentMajorVersion to work towards a new one.
   val BumpMinor = Compatibility.BinaryAndSourceCompatible
   val BumpMajor = Compatibility.None
-  val BumpEpoch = Compatibility.None
 
   object autoImport {
     val developmentMajorVersion =
@@ -45,11 +47,10 @@ object Versioning extends AutoPlugin {
         case class Stable(x: Version.Numeric, y: Version.Numeric, z: Version.Numeric) extends Tag {
           def bumpMinor = copy(z = z.next)
           def bumpMajor = copy(y = y.next, z = Version.Number(0))
-          def bumpEpoch = copy(x = x.next, y = Version.Number(0), z = Version.Number(0))
           def bump(compat: Compatibility) = compat match {
-            case BumpMinor => bumpMinor
-            case BumpMajor => bumpMajor
-            case BumpEpoch => bumpEpoch
+            case Compatibility.BinaryAndSourceCompatible             => bumpMinor
+            // A release that breaks source compatibility bumps the middle number even when it stays binary compatible
+            case Compatibility.BinaryCompatible | Compatibility.None => bumpMajor
           }
         }
       }


### PR DESCRIPTION
Two unrelated build annoyances seen in the CI log of #3709.

1. The "Build and Test" job failed before running anything with

     sbt connection file .../project/target/active.json is corrupt or unreadable:
     IncompleteParseException: exhausted input; starting a new server
     [error] failed to connect to server

   Without --server the sbt 2 runner starts the server in the background and connects a thin client to it. The client can read active.json before the server has finished writing it, then tries to start a second server and gives up. --server runs sbt in the foreground, as the PR compat report workflow already does since 33151457. Apply it to every sbt invocation in the workflows so no job depends on the thin client.

2. The meta-build compile warned in project/Versioning.scala:

     [E029] match may not be exhaustive. It would fail on pattern case: BinaryCompatible
     [E030] Unreachable case: BumpEpoch

   Since 6debffe4 BumpMajor and BumpEpoch are both Compatibility.None, so the BumpEpoch case could never match, and Compatibility.BinaryCompatible was not handled at all. Match on the Compatibility values directly: a fully compatible change bumps the last number, anything else bumps the middle one. Bumping the first number is driven by developmentMajorVersion, not by the compatibility intention, so drop the dead BumpEpoch alias and bumpEpoch.