### PR TITLE
Fix MySQL expression defaults being marked AutoInc

### DIFF
--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ModelBuilderTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/ModelBuilderTest.scala
@@ -112,6 +112,47 @@ class ModelBuilderTest extends AsyncTest[JdbcTestDB] {
   }
   val typeTest = TableQuery[TypeTest]
 
+  def testMySQLExpressionDefaults = if(tdb.confName.contains("mysql")) {
+    val timestamp = java.sql.Timestamp.valueOf("2001-02-03 04:05:06")
+    (for {
+      _ <- sqlu"""create table expression_defaults (
+        id integer not null auto_increment primary key,
+        created_at datetime not null default current_timestamp,
+        updated_at datetime not null default current_timestamp on update current_timestamp,
+        value integer not null default 7,
+        expression_value integer not null default (1 + 2),
+        virtual_value integer generated always as (value * 2) virtual,
+        stored_value integer generated always as (value * 3) stored
+      )"""
+      model <- tdb.profile.createModel()
+      columns = model.tables.find(_.name.table == "expression_defaults").get.columns.map(c => c.name -> c).toMap
+      rows = {
+        def options(name: String) = columns(name).options.collect { case ColumnOption.AutoInc => ColumnOption.AutoInc }.toSeq
+        class Rows(tag: Tag) extends Table[(Int, java.sql.Timestamp, java.sql.Timestamp, Int, Int, Int)](tag, "expression_defaults") {
+          def id = column[Int]("id", options("id")*)
+          def createdAt = column[java.sql.Timestamp]("created_at", options("created_at")*)
+          def updatedAt = column[java.sql.Timestamp]("updated_at", options("updated_at")*)
+          def value = column[Int]("value", options("value")*)
+          def virtualValue = column[Int]("virtual_value", options("virtual_value")*)
+          def storedValue = column[Int]("stored_value", options("stored_value")*)
+          def * = (id, createdAt, updatedAt, value, virtualValue, storedValue)
+        }
+        TableQuery[Rows]
+      }
+      _ <- rows += ((0, timestamp, timestamp, 7, 0, 0))
+      row <- rows.result.head
+      _ = {
+        assertEquals(timestamp, row._2)
+        assertEquals(timestamp, row._3)
+        assertEquals(14, row._5)
+        assertEquals(21, row._6)
+        assertEquals(Set("id", "virtual_value", "stored_value"),
+          columns.values.filter(_.options.contains(ColumnOption.AutoInc)).map(_.name).toSet)
+        assertTrue(columns("value").options.contains(RelationalProfile.ColumnOption.Default(7)))
+      }
+    } yield ()).andFinally(sqlu"drop table if exists expression_defaults")
+  } else DBIO.successful(())
+
   def test = ifCap(jcap.createModel) {
     def createModel(tables: Option[Seq[MTable]] = None, ignoreInvalidDefaults: Boolean = true) =
       tdb.profile.createModel(tables.map(DBIO.successful), ignoreInvalidDefaults)

--- a/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
+++ b/slick/src/main/scala/slick/jdbc/MySQLProfile.scala
@@ -78,6 +78,27 @@ trait MySQLProfile extends JdbcProfile with JdbcActionComponent.MultipleRowsPerS
 
   class MySQLModelBuilder(mTables: Seq[MTable], ignoreInvalidDefaults: Boolean)
     extends JdbcModelBuilder(mTables, ignoreInvalidDefaults) {
+    override def readColumns(t: MTable): DBIO[Vector[MColumn]] = {
+      import profile.api.actionBasedSQLInterpolation
+
+      for {
+        columns <- super.readColumns(t)
+        extra <- if(columns.exists(_.isGenerated.contains(true))) {
+          val schema = t.name.catalog.orElse(t.name.schema)
+          sql"""select COLUMN_NAME, EXTRA from information_schema.COLUMNS
+                where TABLE_SCHEMA = coalesce($schema, database()) and TABLE_NAME = ${t.name.name}"""
+            .as[(String, Option[String])]
+        } else DBIO.successful(Vector.empty[(String, Option[String])])
+      } yield {
+        val extras = extra.collect { case (name, Some(value)) => name -> value }.toMap
+        columns.map { column =>
+          extras.get(column.name).fold(column) { value =>
+            column.copy(isGenerated = Some(value.contains("VIRTUAL GENERATED") || value.contains("STORED GENERATED")))
+          }
+        }
+      }
+    }
+
     override def createPrimaryKeyBuilder(tableBuilder: TableBuilder, meta: Seq[MPrimaryKey]): PrimaryKeyBuilder =
       new MySQLPrimaryKeyBuilder(tableBuilder, meta)
     override def createColumnBuilder(tableBuilder: TableBuilder, meta: MColumn): ColumnBuilder =


### PR DESCRIPTION
Fixes #3718.

MySQL expression defaults such as `DEFAULT CURRENT_TIMESTAMP` are reported by Connector/J as generated columns. Slick then gives them `AutoInc`, so ordinary inserts silently omit explicit timestamps. This change corrects the column metadata before model construction, retaining `AutoInc` for actual identity and computed columns.

When JDBC reports a generated column, `MySQLModelBuilder.readColumns` reads `information_schema.COLUMNS.EXTRA` once for that table. Only `VIRTUAL GENERATED` and `STORED GENERATED` identify computed columns; `DEFAULT_GENERATED` remains writable. Schema/table names are bound parameters. Tables without a reported generated column need no extra query; missing/null supplemental metadata preserves the original JDBC metadata. This follows the [MySQL COLUMNS documentation](https://dev.mysql.com/doc/refman/8.0/en/information-schema-columns-table.html).

The regression builds a table mapping from the introspected `AutoInc` options and performs a real insert. It covers explicit creation/update timestamps, an integer expression default, a literal default, an auto-increment key, and virtual/stored computed columns. The fixture is removed even if assertions fail.

Validation on macOS arm64, Java 21, Scala 2.13.18, Connector/J 26.7.0 and a local MySQL 8.4.11 server:

- With upstream `MySQLProfile.scala`, the new regression fails: the explicit `2001-02-03 04:05:06` timestamp is replaced by the server clock. It passes with this fix.
- `testkit/testOnly slick.test.profile.MySQLTest slick.test.profile.H2MemTest -- -z com.typesafe.slick.testkit.tests.ModelBuilderTest.*`: four reported passes (the MySQL-specific method is a no-op on H2).
- Both MySQL model tests pass with `useInformationSchema=true` and separately with `useInformationSchema=false`.
- `git diff --check` passes. Full suite, full generated-source round trip, Scala 2.12/3 and other MySQL versions were not run. The new expression-default fixture requires MySQL 8.0.13 or later.

This implementation, explanation and local testing were performed by OpenAI Codex with the account owner's authorization; no human review is claimed. No CLA signature or personal attestation was made by the assistant.

If a maintainer or sponsor considers this eligible for an optional US$25 contribution reward, PayPal would be appreciated via a private payment channel. No reward is currently funded or assumed, and this contribution has no payment condition. No payment details are posted here.
